### PR TITLE
Add continua11y back to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: node
 
 env:
   DOCKER_COMPOSE_VERSION: 1.4.2
@@ -14,12 +14,12 @@ before_install:
 
 script:
   - docker-compose build
-  - docker-compose run api ./docker-travis.sh
+  - docker-compose run api ./docker-test.sh
   - docker-compose run frontend npm test
 
-# after_script:
-#   - npm install -g pa11y-crawl
-#   - pa11y-crawl --run "docker-compose up" --ci http://localhost:8080
+after_script:
+  - npm install -g pa11y-crawl
+  - pa11y-crawl --run "docker-compose up" --ci http://localhost:8080
 
 #before_deploy:
 #  - npm run build

--- a/api/docker-build.sh
+++ b/api/docker-build.sh
@@ -4,4 +4,3 @@ go get -u -v github.com/kardianos/govendor
 /go/bin/govendor sync
 
 go build -o api
-go test $(go list ./... | grep -v /vendor/)

--- a/api/docker-run.sh
+++ b/api/docker-run.sh
@@ -1,11 +1,4 @@
 #! /bin/sh
 
-echo "--------------------------------------"
-echo "Does this file get run in travis?"
-echo "--------------------------------------"
-
-go get -u -v github.com/kardianos/govendor
-/go/bin/govendor sync
-
-go build -o api
+./docker-build.sh
 ./api 2>&1

--- a/api/docker-test.sh
+++ b/api/docker-test.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+./docker-build.sh
+go test $(go list ./... | grep -v /vendor/)

--- a/bin/before-deploy.sh
+++ b/bin/before-deploy.sh
@@ -1,0 +1,6 @@
+npm run build
+
+export PATH=$HOME:$PATH
+travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0"
+tar xzvf $HOME/cf.tgz -C $HOME
+cf install-plugin autopilot -f -r CF-Community

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,24 @@
+set -e
+
+API="https://api.cloud.gov"
+ORG="18f-acq"
+SPACE=$1
+
+if [ $# -ne 1 ]; then
+  echo "Usage: deploy <space>"
+  exit
+fi
+
+if [ $SPACE = 'production' ]; then
+  NAME="micropurchase"
+  MANIFEST="manifest.yml"
+elif [ $SPACE = 'staging' ]; then
+  NAME="micropurchase-staging"
+  MANIFEST="manifest-staging.yml"
+else
+  echo "Unknown space: $SPACE"
+  exit
+fi
+
+cf login --a $API --u $CF_USERNAME --p $CF_PASSWORD --o $ORG -s $SPACE
+cf zero-downtime-push $NAME -f $MANIFEST


### PR DESCRIPTION
After kicking the tires, it was too cumbersome to get `pa11y-crawl` running from within a Docker container. A battle for another day.

This PR:
- adds continua11y back to Travis
- removes some un-needed code comments
- refactors the go api scripts into `docker-build.sh`, `docker-run.sh`, and `docker-test.sh`