### PR TITLE
Added react-eslint plugin and rule to recognize imports that are used…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,10 @@
     },
     "plugins": [
         "standard",
-        "promise"
-    ]
+        "promise",
+        "react"
+    ],
+    "rules" : {
+      "react/jsx-uses-vars" : 1
+    }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "axios": "^0.15.2",
     "esdoc": "^0.4.8",
+    "eslint-plugin-react": "^6.7.1",
     "global": "^4.3.1",
     "history": "^4.4.0",
     "react": "^15.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@ acorn-globals@^1.0.4:
   dependencies:
     acorn "^2.1.0"
 
-acorn-jsx@^3.0.0:
+acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
@@ -1807,6 +1807,13 @@ eslint-plugin-promise@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.3.2.tgz#c1169ae6487a87cdeae44f659f4cf05131b8dc66"
 
+eslint-plugin-react@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.7.1.tgz#1af96aea545856825157d97c1b50d5a8fb64a5a7"
+  dependencies:
+    doctrine "^1.2.2"
+    jsx-ast-utils "^1.3.3"
+
 eslint-plugin-standard@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-2.0.1.tgz#3589699ff9c917f2c25f76a916687f641c369ff3"
@@ -3330,6 +3337,13 @@ jstransform@^10.1.0:
     base62 "0.1.1"
     esprima-fb "13001.1001.0-dev-harmony-fb"
     source-map "0.1.31"
+
+jsx-ast-utils@^1.3.3:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.4.tgz#0257ed1cc4b1e65b39d7d9940f9fb4f20f7ba0a9"
+  dependencies:
+    acorn-jsx "^3.0.1"
+    object-assign "^4.1.0"
 
 kind-of@^3.0.2:
   version "3.0.4"


### PR DESCRIPTION
… within components.

**Additional Notes**
- This looks like it does away with getting the not used errors for imports that are stictly used as components. For instance, the redux `Provider` or any of the `Router`, `Route` etc.
- Don't forget to do a `yarn install`  !

https://github.com/yannickcr/eslint-plugin-react
