### PR TITLE
Docker-machining

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language: node
 services:
   - docker
 
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
 script:
   - docker-compose build
   - docker-compose run api ./test.sh

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,8 @@
 FROM golang
+
 RUN mkdir -p /go/src/github.com/truetandem/e-QIP-prototype/
 COPY api /go/src/github.com/truetandem/e-QIP-prototype/api
+
 RUN curl https://glide.sh/get | sh
+
 WORKDIR /go/src/github.com/truetandem/e-QIP-prototype/api

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,2 +1,5 @@
 FROM golang
+RUN mkdir -p /go/src/github.com/truetandem/e-QIP-prototype/
+COPY api /go/src/github.com/truetandem/e-QIP-prototype/api
 RUN curl https://glide.sh/get | sh
+WORKDIR /go/src/github.com/truetandem/e-QIP-prototype/api

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,2 @@
+FROM postgres
+COPY db docker-entrypoint-initdb.d

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,5 +1,7 @@
 FROM node
 
+RUN mkdir /usr/src/app
+COPY . /usr/src/app
 WORKDIR /usr/src/app
-ADD package.json /usr/src/app/package.json
 RUN npm install --silent
+VOLUME /usr/src/app/dist

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -1,5 +1,4 @@
 #! /bin/sh
 npm install --silent
 npm run build
-# ln -s dist/* /srv/
 npm run watch

--- a/build-frontend.sh
+++ b/build-frontend.sh
@@ -1,3 +1,5 @@
 #! /bin/sh
 npm install --silent
+npm run build
+# ln -s dist/* /srv/
 npm run watch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ frontend:
   env_file:
     - .env
   command: ./build-frontend.sh
+  volumes:
+    - dist:/usr/src/app/dist
 api:
   build: .
   dockerfile: Dockerfile.api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ db:
     - ./db:/docker-entrypoint-initdb.d
 web:
   image: abiosoft/caddy
-  volumes:
-    - ./dist:/srv
   ports:
     - "8080:2015"
   links:
@@ -16,24 +14,22 @@ web:
     DATABASE_USER: postgres
     DATABASE_NAME: postgres
     DATABASE_HOST: db
+  volumes:
+      - dist:/srv
+  volumes_from:
+      - frontend:ro
 frontend:
   build: .
   dockerfile: Dockerfile.frontend
   env_file:
     - .env
-  volumes:
-    - .:/usr/src/app
-    - /usr/src/app/node_modules
   command: ./build-frontend.sh
 api:
   build: .
   dockerfile: Dockerfile.api
   env_file:
     - .env
-  working_dir: /go/src/github.com/truetandem/e-QIP-prototype/api
   command: ./run.sh
-  volumes:
-    - .:/go/src/github.com/truetandem/e-QIP-prototype
   ports:
     - "3000:3000"
   links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,50 @@
-db:
-  expose:
-    - "5432"
-  image: postgres
-  volumes:
-    - ./db:/docker-entrypoint-initdb.d
-web:
-  image: abiosoft/caddy
-  ports:
-    - "8080:2015"
-  links:
-    - db
-  environment:
-    DATABASE_USER: postgres
-    DATABASE_NAME: postgres
-    DATABASE_HOST: db
-  volumes:
-      - dist:/srv
-  volumes_from:
-      - frontend:ro
-frontend:
-  build: .
-  dockerfile: Dockerfile.frontend
-  env_file:
-    - .env
-  command: ./build-frontend.sh
-  volumes:
-    - dist:/usr/src/app/dist
-api:
-  build: .
-  dockerfile: Dockerfile.api
-  env_file:
-    - .env
-  command: ./run.sh
-  ports:
-    - "3000:3000"
-  links:
-    - db
-  environment:
-    DATABASE_USER: postgres
-    DATABASE_NAME: postgres
-    DATABASE_HOST: db:5432
+version: '2'
+services:
+    db:
+      restart: always
+      expose:
+        - "5432"
+      build:
+        context: .
+        dockerfile: Dockerfile.db
+    web:
+      image: abiosoft/caddy
+      ports:
+        - "8080:2015"
+      links:
+        - db
+      environment:
+        DATABASE_USER: postgres
+        DATABASE_NAME: postgres
+        DATABASE_HOST: db
+      volumes:
+          - dist:/srv
+      volumes_from:
+          - frontend:ro
+    frontend:
+      build:
+        context: .
+        dockerfile: Dockerfile.frontend
+      env_file:
+        - .env
+      command: ./build-frontend.sh
+      volumes:
+        - dist:/usr/src/app/dist
+    api:
+      build:
+        context: .
+        dockerfile: Dockerfile.api
+      depends_on:
+        - db
+      env_file:
+        - .env
+      command: ./run.sh
+      ports:
+        - "3000:3000"
+      environment:
+        DATABASE_USER: postgres
+        DATABASE_NAME: postgres
+        DATABASE_HOST: db:5432
+volumes:
+  dist:
+    external: false


### PR DESCRIPTION
I tend to use `docker-machine` to offload the computing power onto a remote container. The problem is that the local filesystem does not automatically get to the remote container. Accordingly, I needed to copy the files in the Dockerfile.frontend and Dockerfile.api and then do the builds there. Furthermore, because the `web` container needs to access the build from the `frontend` container, I needed to use a named volume that is accessed from the `web` container.

This PR allows for a clean: `docker-compose up`, even when using docker-machine on a remote server.