### PR TITLE
Backend mock entities

### DIFF
--- a/api/design/validate.md
+++ b/api/design/validate.md
@@ -19,7 +19,28 @@ FORMAT: 1A
 
     + Body
 
-        application/json
+      {
+        "Errors": [
+          {
+            "Fieldname": "SSN",
+            "Errors": [
+              {
+                "Fieldname": "First",
+                "Error": "First is a required field"
+              },
+              {
+                "Fieldname": "Middle",
+                "Error": "Middle is a required field"
+              },
+              {
+                "Fieldname": "Last",
+                "Error": "Last is a required field"
+              }
+            ]
+          }
+        ]
+      }
+
 
 + Response 500
 
@@ -40,7 +61,14 @@ FORMAT: 1A
 
     + Body
 
-        application/json
+      {
+        "Errors": [
+          {
+            "Fieldname": "Passport",
+            "Error": ""
+          }
+        ]
+      }
 
 + Response 500
 
@@ -61,7 +89,39 @@ FORMAT: 1A
 
     + Body
 
-        application/json
+      {
+        "Errors": [
+          {
+            "Fieldname": "Address",
+            "Error": ""
+          },
+          {
+            "Fieldname": "Street",
+            "Error": ""
+          },
+          {
+            "Fieldname": "City",
+            "Error": ""
+          },
+          {
+            "Fieldname": "State",
+            "Error": ""
+          },
+          {
+            "Fieldname": "Zipcode",
+            "Error": ""
+          },
+          {
+            "Fieldname": "County",
+            "Error": ""
+          },
+          {
+            "Fieldname": "Country",
+            "Error": "",
+            "Suggestions": []
+          }
+        ]
+      }
 
 + Response 500
 
@@ -81,8 +141,14 @@ FORMAT: 1A
         X-Eqip-Media-Type: eqip.v1
 
     + Body
-
-        application/json
+      {
+        "Errors": [
+          {
+            "Fieldname": "City",
+            "Error": ""
+          }
+        ]
+      }
 
 + Response 500
 
@@ -103,7 +169,15 @@ FORMAT: 1A
 
     + Body
 
-        application/json
+    {
+      "Errors": [
+        {
+          "Fieldname": "Zipcode",
+          "Error": ""
+        }
+      ]
+    }
+
 
 + Response 500
 
@@ -124,6 +198,13 @@ FORMAT: 1A
 
     + Body
 
-        application/json
+    {
+      "Errors": [
+        {
+          "Fieldname": "State",
+          "Error": ""
+        }
+      ]
+    }
 
 + Response 500

--- a/api/handlers/json.go
+++ b/api/handlers/json.go
@@ -6,6 +6,15 @@ import (
 	"net/http"
 )
 
+func EncodeErrJSON(w http.ResponseWriter, errors interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(struct {
+		Errors interface{}
+	}{
+		Errors: errors,
+	})
+}
+
 // EncodeJSON encodes any object and writes it to a response writer
 func EncodeJSON(w http.ResponseWriter, data interface{}) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/api/main.go
+++ b/api/main.go
@@ -34,13 +34,13 @@ func main() {
 
 	// Validation
 	v := r.PathPrefix("/validate").Subrouter()
-	v.HandleFunc("/ssn/{ssn}", handlers.ValidateSSN).Methods("GET")
-	v.HandleFunc("/passport/{passport}", handlers.ValidatePassport).Get("GET")
+	v.HandleFunc("/ssn/{ssn}", handlers.ValidateSSN)
+	v.HandleFunc("/passport/{passport}", handlers.ValidatePassport)
 
 	// Address Validation
-	v.HandleFunc("/address/city/{city}", handlers.ValidateCity).Methods("GET")
-	v.HandleFunc("/address/zipcode/{zipcode}", handlers.ValidateZipcode).Methods("GET")
-	v.HandleFunc("/address/state/{state}", handlers.ValidateState).Methods("GET")
+	v.HandleFunc("/address/city/{city}", handlers.ValidateCity)
+	v.HandleFunc("/address/zipcode/{zipcode}", handlers.ValidateZipcode)
+	v.HandleFunc("/address/state/{state}", handlers.ValidateState)
 	v.HandleFunc("/address", handlers.ValidateAddress).Methods("POST")
 
 	log.Println("Starting API mock server")

--- a/api/model/form/complex_fields.go
+++ b/api/model/form/complex_fields.go
@@ -1,0 +1,86 @@
+package form
+
+// AddressField contains complete address information for an entity
+type AddressField struct {
+	Address1 TextField
+	Address2 TextField
+	Street   TextField
+	City     TextField
+	State    StateField
+	Zipcode  ZipcodeField
+	County   TextField
+	Country  CountryField
+}
+
+func (a AddressField) Valid() (bool, error) {
+	return true, nil
+}
+
+// BirthAddress contains the birth location for a person. This contains a
+// subset of the Address information
+type BirthAddressField struct {
+	City    TextField
+	State   StateField
+	County  CountryField
+	Country CountryField
+}
+
+// Valid validates information for a person Birth Address
+func (f BirthAddressField) Valid() (bool, error) {
+	var stack ErrorStack
+	stack.Append("City", ErrFieldRequired{"Field is required"})
+	stack.Append("State", ErrFieldRequired{"State is required"})
+
+	// TODO Demonstration
+	err := ErrInvalidLocation{
+		Message:     "Invalid Country",
+		Suggestions: []string{"United States", "United Kingdom"},
+	}
+	stack.Append("Country", err)
+	return !stack.HasErrors(), stack
+}
+
+// PersonField stores information for a particular person
+type PersonField struct {
+	Firstname  FirstnameField
+	Lastname   TextField
+	Middlename MiddlenameField
+	Suffix     Suffix
+}
+
+func (f PersonField) Valid() (bool, error) {
+	var stack ErrorStack
+
+	if ok, err := f.Firstname.Valid(); !ok {
+		stack.Append("Firstname", err)
+	}
+
+	if ok, err := f.Lastname.Valid(); !ok {
+		stack.Append("Lastname", err)
+	}
+
+	if ok, err := f.Middlename.Valid(); !ok {
+		stack.Append("Middlename", err)
+	}
+	return !stack.HasErrors(), stack
+}
+
+// DateRangeField contains from and to dates and ensures they are within a valid range
+type DateRangeField struct {
+	From DateField
+	To   DateField
+}
+
+func (d DateRangeField) Valid() (bool, error) {
+	return true, nil
+}
+
+// EmployerActivity stores when a person has worked during a specific period of time for a particular
+// position and supervisor
+type EmployerActivity struct {
+	PositionTitle     TextField
+	Supervisor        TextField
+	DatesOfEmployment DateRangeField
+}
+
+type EmployerActivities []EmployerActivity

--- a/api/model/form/complex_fields.go
+++ b/api/model/form/complex_fields.go
@@ -4,13 +4,14 @@ package form
 type AddressField struct {
 	Address TextField
 	Street  TextField
-	City    TextField
+	City    CityField
 	State   StateField
 	Zipcode ZipcodeField
 	County  TextField
 	Country CountryField
 }
 
+// Valid validates the location fields for an address
 func (a AddressField) Valid() (bool, error) {
 
 	var stack ErrorStack

--- a/api/model/form/complex_fields.go
+++ b/api/model/form/complex_fields.go
@@ -49,17 +49,30 @@ func (a AddressField) Valid() (bool, error) {
 // BirthAddress contains the birth location for a person. This contains a
 // subset of the Address information
 type BirthAddressField struct {
-	City    TextField
+	City    CityField
 	State   StateField
-	County  CountryField
+	County  TextField
 	Country CountryField
 }
 
 // Valid validates information for a person Birth Address
 func (f BirthAddressField) Valid() (bool, error) {
 	var stack ErrorStack
-	stack.Append("City", ErrFieldRequired{"Field is required"})
-	stack.Append("State", ErrFieldRequired{"State is required"})
+	if ok, err := f.City.Valid(); !ok {
+		stack.Append("City", err)
+	}
+
+	if ok, err := f.State.Valid(); !ok {
+		stack.Append("State", err)
+	}
+
+	if ok, err := f.County.Valid(); !ok {
+		stack.Append("County", err)
+	}
+
+	if ok, err := f.Country.Valid(); !ok {
+		stack.Append("Country", err)
+	}
 
 	return !stack.HasErrors(), stack
 }
@@ -86,6 +99,10 @@ func (f PersonField) Valid() (bool, error) {
 	if ok, err := f.Middlename.Valid(); !ok {
 		stack.Append("Middlename", err)
 	}
+
+	if ok, err := f.Suffix.Valid(); !ok {
+		stack.Append("Middlename", err)
+	}
 	return !stack.HasErrors(), stack
 }
 
@@ -95,16 +112,15 @@ type DateRangeField struct {
 	To   DateField
 }
 
-func (d DateRangeField) Valid() (bool, error) {
-	return true, nil
-}
+func (f DateRangeField) Valid() (bool, error) {
+	var stack ErrorStack
 
-// EmployerActivity stores when a person has worked during a specific period of time for a particular
-// position and supervisor
-type EmployerActivity struct {
-	PositionTitle     TextField
-	Supervisor        TextField
-	DatesOfEmployment DateRangeField
-}
+	if ok, err := f.From.Valid(); !ok {
+		stack.Append("From", err)
+	}
 
-type EmployerActivities []EmployerActivity
+	if ok, err := f.To.Valid(); !ok {
+		stack.Append("From", err)
+	}
+	return !stack.HasErrors(), stack
+}

--- a/api/model/form/complex_fields.go
+++ b/api/model/form/complex_fields.go
@@ -2,18 +2,48 @@ package form
 
 // AddressField contains complete address information for an entity
 type AddressField struct {
-	Address1 TextField
-	Address2 TextField
-	Street   TextField
-	City     TextField
-	State    StateField
-	Zipcode  ZipcodeField
-	County   TextField
-	Country  CountryField
+	Address TextField
+	Street  TextField
+	City    TextField
+	State   StateField
+	Zipcode ZipcodeField
+	County  TextField
+	Country CountryField
 }
 
 func (a AddressField) Valid() (bool, error) {
-	return true, nil
+
+	var stack ErrorStack
+
+	if ok, err := a.Address.Valid(); !ok {
+		stack.Append("Address", err)
+	}
+
+	if ok, err := a.Street.Valid(); !ok {
+		stack.Append("Street", err)
+	}
+
+	if ok, err := a.City.Valid(); !ok {
+		stack.Append("City", err)
+	}
+
+	if ok, err := a.State.Valid(); !ok {
+		stack.Append("State", err)
+	}
+
+	if ok, err := a.Zipcode.Valid(); !ok {
+		stack.Append("Zipcode", err)
+	}
+
+	if ok, err := a.County.Valid(); !ok {
+		stack.Append("County", err)
+	}
+
+	if ok, err := a.Country.Valid(); !ok {
+		stack.Append("Country", err)
+	}
+
+	return !stack.HasErrors(), stack
 }
 
 // BirthAddress contains the birth location for a person. This contains a
@@ -31,12 +61,6 @@ func (f BirthAddressField) Valid() (bool, error) {
 	stack.Append("City", ErrFieldRequired{"Field is required"})
 	stack.Append("State", ErrFieldRequired{"State is required"})
 
-	// TODO Demonstration
-	err := ErrInvalidLocation{
-		Message:     "Invalid Country",
-		Suggestions: []string{"United States", "United Kingdom"},
-	}
-	stack.Append("Country", err)
 	return !stack.HasErrors(), stack
 }
 

--- a/api/model/form/complex_fields_test.go
+++ b/api/model/form/complex_fields_test.go
@@ -1,0 +1,66 @@
+package form
+
+import "testing"
+
+func TestAddressField(t *testing.T) {
+
+	tests := []struct {
+		Field    AddressField
+		Expected bool
+	}{
+		{
+			AddressField{
+				Address: "12345",
+				Street:  "Some rd",
+				City:    "Arlington",
+				State:   "VA",
+				Zipcode: "22202",
+				County:  "Arlington",
+				Country: "United States",
+			},
+			true,
+		},
+		{
+			AddressField{
+				Address: "",
+				Street:  "",
+				City:    "",
+				State:   "",
+				Zipcode: "",
+				County:  "",
+				Country: "",
+			},
+			false,
+		},
+		{
+			AddressField{
+				Address: "Some Address",
+				Street:  "",
+				City:    "",
+				State:   "",
+				Zipcode: "",
+				County:  "",
+				Country: "",
+			},
+			false,
+		},
+		{
+			AddressField{
+				Address: "Some Address",
+				Street:  "1234",
+				City:    "",
+				State:   "",
+				Zipcode: "",
+				County:  "",
+				Country: "",
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] to be [%v]\n", ok, test.Expected)
+		}
+	}
+}

--- a/api/model/form/errors.go
+++ b/api/model/form/errors.go
@@ -1,0 +1,59 @@
+package form
+
+import "fmt"
+
+// Validator is an interface to be used by components that require validation
+type Validator interface {
+	Valid() (bool, error)
+}
+
+// ValidationError stores error information for a particular field name
+type ValidationError struct {
+	Name  string
+	Error error
+}
+
+// ErrorStack contains a list of Validation errors that have been captured
+type ErrorStack []ValidationError
+
+// HasErrors checks if any errors exist
+func (stack ErrorStack) HasErrors() bool {
+	return len(stack) > 0
+}
+
+func (stack ErrorStack) Error() string {
+	return fmt.Sprintf("%d Errors \n", len(stack))
+}
+
+// Append adds an error to the list of errors
+func (stack *ErrorStack) Append(name string, err error) {
+	*stack = append(*stack, ValidationError{name, err})
+}
+
+// ErrFieldInvalid represents an error for a field with an invalid value
+type ErrFieldInvalid struct {
+	Message string
+}
+
+func (e ErrFieldInvalid) Error() string {
+	return e.Message
+}
+
+// ErrFieldRequired represents an error for a field that requires data
+type ErrFieldRequired struct {
+	Message string
+}
+
+func (e ErrFieldRequired) Error() string {
+	return e.Message
+}
+
+// TODO Just for demonstration purposes
+type ErrInvalidLocation struct {
+	Message     string
+	Suggestions []string
+}
+
+func (e ErrInvalidLocation) Error() string {
+	return e.Message
+}

--- a/api/model/form/errors.go
+++ b/api/model/form/errors.go
@@ -7,27 +7,77 @@ type Validator interface {
 	Valid() (bool, error)
 }
 
-// ValidationError stores error information for a particular field name
-type ValidationError struct {
-	Name  string
-	Error error
-}
+// ErrorStackResults contains a collection of validation results
+type ErrorStackResults interface{}
 
-// ErrorStack contains a list of Validation errors that have been captured
-type ErrorStack []ValidationError
+// ErrorStack contains a list of ErrorStackResults that have been captured
+type ErrorStack []ErrorStackResults
 
 // HasErrors checks if any errors exist
 func (stack ErrorStack) HasErrors() bool {
 	return len(stack) > 0
 }
 
+// Error is string representation of an ErrorStack and displays
+// the total number of errors
 func (stack ErrorStack) Error() string {
 	return fmt.Sprintf("%d Errors \n", len(stack))
 }
 
-// Append adds an error to the list of errors
+// Append adds an error to the list of errors. A different validation result
+// type is used based on the number of errors contained within the results.
 func (stack *ErrorStack) Append(name string, err error) {
-	*stack = append(*stack, ValidationError{name, err})
+	if err == nil {
+		return
+	}
+	switch errType := err.(type) {
+	// If we have an error that contains many errors, use ValidationResults (note plural s)
+	case ErrorStack:
+		*stack = append(*stack, ValidationResults{
+			Fieldname: name,
+			Errors:    errType,
+		})
+	// If we have an error dealing with locations, use the LocationValidationResult
+	case ErrInvalidLocation:
+		*stack = append(*stack, LocationValidationResult{
+			Fieldname:   name,
+			Error:       err.Error(),
+			Suggestions: errType.Suggestions,
+		})
+	// For all other errors, simply grab string representation of the error
+	default:
+		*stack = append(*stack, ValidationResult{
+			Fieldname: name,
+			Error:     err.Error(),
+		})
+	}
+}
+
+// NewErrorStack creates a new stack of errors for a particular field
+func NewErrorStack(fieldname string, err error) ErrorStack {
+	var stack ErrorStack
+	stack.Append(fieldname, err)
+	return stack
+}
+
+// ValidationResult returns one error for a particular field
+type ValidationResult struct {
+	Fieldname string
+	Error     string
+}
+
+// ValidationResults returns one or more errors for a particular field. This result
+// contains a slice of additional errors
+type ValidationResults struct {
+	Fieldname string
+	Errors    ErrorStack
+}
+
+// ValidationResults returns an error and possible suggestions for a particular field
+type LocationValidationResult struct {
+	Fieldname   string
+	Error       string
+	Suggestions []string
 }
 
 // ErrFieldInvalid represents an error for a field with an invalid value
@@ -44,6 +94,7 @@ type ErrFieldRequired struct {
 	Message string
 }
 
+// Error is a basic represenation of a Require Field error
 func (e ErrFieldRequired) Error() string {
 	return e.Message
 }

--- a/api/model/form/fields.go
+++ b/api/model/form/fields.go
@@ -1,0 +1,292 @@
+package form
+
+import (
+	"fmt"
+	"net/mail"
+	"strings"
+	"time"
+)
+
+// TextField is a generic container for required text
+type TextField string
+
+// Valid validates a TextField
+func (t TextField) Valid() (bool, error) {
+	if strings.TrimSpace(string(t)) == "" {
+		return false, ErrFieldRequired{"TextField is required"}
+	}
+	return true, nil
+}
+
+// EmailField contains a properly formatted email
+type EmailField string
+
+func (e EmailField) Valid() (bool, error) {
+	if _, err := mail.ParseAddress(string(e)); err != nil {
+		return false, ErrFieldInvalid{"Invalid email"}
+	}
+	return true, nil
+}
+
+// URLField contains a properly formatted URL
+type URLField string
+
+func (e URLField) Valid() (bool, error) {
+	return true, nil
+}
+
+// DateField stores date information by month, day and year. It also
+// contains a flag to indicate if the date is estimated
+type DateField struct {
+	Month     int64
+	Day       int64
+	Year      int64
+	Estimated bool
+}
+
+// Valid determines if field is valid
+// TODO Figure out exactly how estimated affects overall validation
+func (d DateField) Valid() (bool, error) {
+	var stack ErrorStack
+
+	if d.Month < 1 || d.Month > 12 {
+		stack.Append("Month", ErrFieldInvalid{fmt.Sprintf("`%v` is an invalid month", d.Month)})
+	}
+
+	if d.Day < 1 || d.Day > 31 {
+		stack.Append("Day", ErrFieldInvalid{fmt.Sprintf("`%v` is an invalid day", d.Month)})
+	}
+
+	if d.Year < 1900 {
+		stack.Append("Year", ErrFieldInvalid{fmt.Sprintf("`%v` is an invalid year", d.Month)})
+	}
+
+	return !stack.HasErrors(), stack
+}
+
+type MonthYearField struct {
+	Month     int64
+	Year      int64
+	Estimated bool
+}
+
+func (d MonthYearField) Valid() (bool, error) {
+	return true, nil
+}
+
+// Time creates a time.Time based off of the values entered
+// TODO this will be affected by how estimated is calculated
+func (d DateField) Time() (time.Time, error) {
+	if ok, err := d.Valid(); !ok {
+		return time.Time{}, err
+	}
+
+	formatted := fmt.Sprintf("%v/%v/%v", d.Month, d.Day, d.Year)
+	return time.Parse("1/2/2006", formatted)
+}
+
+// SSN stores a person social security number
+// https://www.ssa.gov/employer/randomization.html
+type SSNField struct {
+	First         string
+	Middle        string
+	Last          string
+	NotApplicable bool
+}
+
+func (s SSNField) Valid() (bool, error) {
+	if s.NotApplicable {
+		return true, nil
+	}
+
+	var stack ErrorStack
+	if s.First == "" {
+		stack.Append("First", ErrFieldRequired{"First is a required field"})
+	}
+
+	if s.Middle == "" {
+		stack.Append("Middle", ErrFieldRequired{"Middle is a required field"})
+	}
+
+	if s.Last == "" {
+		stack.Append("Last", ErrFieldRequired{"Last is a required field"})
+	}
+	return !stack.HasErrors(), stack
+}
+
+// Represents a person suffix if applicable
+type Suffix string
+
+func (s Suffix) Valid() (bool, error) {
+	options := []string{"Jr", "Sr", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "Other"}
+	for _, option := range options {
+		if string(s) == option {
+			return true, nil
+		}
+	}
+	return false, ErrFieldInvalid{fmt.Sprintf("Suffix `%v` is not a valid value", s)}
+}
+
+// PhoneNumberField contains the contents for a Phone Number
+// TimeToCall = {Day, Night, Both}
+// DSN = Check box if International or DSN phone number
+type PhoneNumberField struct {
+	Number     string
+	Extension  string
+	TimeToCall string
+	DSN        bool
+}
+
+func (p PhoneNumberField) Valid() (bool, error) {
+	return true, nil
+}
+
+// EmploymentStatusField contains a person employement status.
+// {Full-time, Part-time}
+type EmploymentStatusField string
+
+func (e EmploymentStatusField) Valid() (bool, error) {
+	return true, nil
+}
+
+// FirstnameField contains a persons first name. Also contains a flag to indicate
+// if the person has entered an initial.
+type FirstnameField struct {
+	Name        string
+	InitialOnly bool
+}
+
+func (f FirstnameField) Valid() (bool, error) {
+	if f.Name == "" {
+		return false, ErrFieldRequired{"Firstname is required"}
+	}
+	return true, nil
+}
+
+// MiddlenameField stores and validates a persons Middle Name
+type MiddlenameField struct {
+	Name string
+	// Initial Only || No Middle Name
+	Type string
+}
+
+func (m MiddlenameField) Valid() (bool, error) {
+	var stack ErrorStack
+
+	if m.Type == "" && m.Name == "" {
+		stack.Append("Name", ErrFieldRequired{"Middlename is required"})
+	}
+
+	if m.Type != "Initial Only" || m.Type != "No Middle Name" {
+		stack.Append("Type", ErrFieldInvalid{fmt.Sprintf("%v is not a valid Middlename Type", m.Type)})
+	}
+	return !stack.HasErrors(), stack
+}
+
+// HairColorField stores the persons hair color
+type HairColorField string
+
+func (f HairColorField) Valid() (bool, error) {
+	// Check if from enum of hair color
+	return true, nil
+}
+
+// EyeColorField stores the persons eye color
+type EyeColorField string
+
+func (f EyeColorField) Valid() (bool, error) {
+	// Check if from enum of hair color
+	return true, nil
+}
+
+// SexField stores a person sex
+type SexField string
+
+func (f SexField) Valid() (bool, error) {
+	switch strings.ToLower(string(f)) {
+	case "male":
+		return true, nil
+	case "female":
+		return true, nil
+	default:
+		return false, fmt.Errorf("Invalid sex field")
+	}
+}
+
+// HeightField stores a persons height
+type HeightField struct {
+	Feet   int64
+	Inches int64
+}
+
+func (f HeightField) Valid() (bool, error) {
+	if f.Feet < 1 || f.Feet > 9 {
+		return false, fmt.Errorf("Invalid Feet")
+	}
+
+	if f.Inches < 0 || f.Inches > 11 {
+		return false, fmt.Errorf("Invalid Inches")
+	}
+
+	return true, nil
+}
+
+// WeightField stores a persons weight
+type WeightField int64
+
+func (f WeightField) Valid() (bool, error) {
+	if f < 0 || f > 2000 {
+		return false, fmt.Errorf("Invalid weight")
+	}
+
+	return true, nil
+}
+
+// ZipcodeField stores a properly formatted zipcode
+type ZipcodeField string
+
+func (f ZipcodeField) Valid() (bool, error) {
+	return true, nil
+}
+
+// StateField stores a state location
+type StateField string
+
+func (f StateField) Valid() (bool, error) {
+	return true, nil
+}
+
+// CountryField stores a country location
+type CountryField string
+
+func (f CountryField) Valid() (bool, error) {
+	return true, nil
+}
+
+// MaritalStatusField stores the persons marital status
+// {Never Married, Married (Including Common Law, Separated, Annulled, Divorced, Widowed}
+type MaritalStatusField string
+
+func (f MaritalStatusField) Valid() (bool, error) {
+	return true, nil
+}
+
+// RelativeTypeField represents different types of relatives.
+// Mother Father Stepmother Stepfather FosterParent Child Stepchild Brother
+// Sister Stepbrother Stepsister HalfBrother HalfSister FatherInLaw MotherInLaw
+// Guardian
+type RelativeTypeField string
+
+func (f RelativeTypeField) Valid() (bool, error) {
+	return true, nil
+}
+
+// CurrencyField stores US Currency alues
+type CurrencyField struct {
+	Amount    string
+	Estimated bool
+}
+
+func (f CurrencyField) Valid() (bool, error) {
+	return true, nil
+}

--- a/api/model/form/fields.go
+++ b/api/model/form/fields.go
@@ -65,6 +65,7 @@ func (d DateField) Valid() (bool, error) {
 	return !stack.HasErrors(), stack
 }
 
+// MonthYearField is a subset of the DateField
 type MonthYearField struct {
 	Month     int64
 	Year      int64
@@ -86,7 +87,7 @@ func (d DateField) Time() (time.Time, error) {
 	return time.Parse("1/2/2006", formatted)
 }
 
-// SSN stores a persons social security number
+// SSNField stores a persons social security number
 // https://www.ssa.gov/employer/randomization.html
 type SSNField struct {
 	First         string

--- a/api/model/form/fields_test.go
+++ b/api/model/form/fields_test.go
@@ -4,10 +4,37 @@ import "testing"
 
 func TestTextField(t *testing.T) {
 
+	tests := []struct {
+		Field    TextField
+		Expected bool
+	}{
+		{"", false},
+		{"hello", true},
+	}
+
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] to be [%v]\n", ok, test.Expected)
+		}
+	}
 }
 
 func TestEmailField(t *testing.T) {
 
+	tests := []struct {
+		Field    EmailField
+		Expected bool
+	}{
+		{"", false},
+		{"test", false},
+		{"test@local.dev", true},
+	}
+
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] to be [%v]\n", ok, test.Expected)
+		}
+	}
 }
 
 func TestURLField(t *testing.T) {
@@ -67,15 +94,55 @@ func TestWeightField(t *testing.T) {
 }
 
 func TestZipcodeField(t *testing.T) {
+	tests := []struct {
+		Field    ZipcodeField
+		Expected bool
+	}{
+		{"", false},
+		{"212", false},
+		{"22310", true},
+		{"22310-2", false},
+	}
+
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] to be [%v]\n", ok, test.Expected)
+		}
+	}
 
 }
 
 func TestStateField(t *testing.T) {
+	tests := []struct {
+		Field    StateField
+		Expected bool
+	}{
+		{"", false},
+		{"VA", true},
+		{"Virginia", true},
+	}
 
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] to be [%v]\n", ok, test.Expected)
+		}
+	}
 }
 
 func TestCountryField(t *testing.T) {
+	tests := []struct {
+		Field    CountryField
+		Expected bool
+	}{
+		{"", false},
+		{"United States", true},
+	}
 
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] to be [%v]\n", ok, test.Expected)
+		}
+	}
 }
 
 func TestMaritalStatusField(t *testing.T) {

--- a/api/model/form/fields_test.go
+++ b/api/model/form/fields_test.go
@@ -1,0 +1,91 @@
+package form
+
+import "testing"
+
+func TestTextField(t *testing.T) {
+
+}
+
+func TestEmailField(t *testing.T) {
+
+}
+
+func TestURLField(t *testing.T) {
+
+}
+
+func TestDateField(t *testing.T) {
+
+}
+
+func TestMonthYearField(t *testing.T) {
+
+}
+
+func TestSSNField(t *testing.T) {
+
+}
+
+func TestSuffixField(t *testing.T) {
+
+}
+
+func TestPhoneNumberField(t *testing.T) {
+
+}
+
+func TestEmploymentStatusField(t *testing.T) {
+
+}
+
+func TestFirstnameField(t *testing.T) {
+
+}
+
+func TestMiddlenameField(t *testing.T) {
+
+}
+
+func TestHairColorField(t *testing.T) {
+
+}
+
+func TestEyeColorField(t *testing.T) {
+
+}
+
+func TestSexField(t *testing.T) {
+
+}
+
+func TestHeightField(t *testing.T) {
+
+}
+
+func TestWeightField(t *testing.T) {
+
+}
+
+func TestZipcodeField(t *testing.T) {
+
+}
+
+func TestStateField(t *testing.T) {
+
+}
+
+func TestCountryField(t *testing.T) {
+
+}
+
+func TestMaritalStatusField(t *testing.T) {
+
+}
+
+func TestRelativeTypeField(t *testing.T) {
+
+}
+
+func TestCurrencyField(t *testing.T) {
+
+}

--- a/api/model/form/sections.go
+++ b/api/model/form/sections.go
@@ -1,7 +1,5 @@
 package form
 
-import "fmt"
-
 // IdentifyingInfoSection stores personal identifying data for a person
 type IdentifyingInfoSection struct {
 	Person          PersonField
@@ -92,6 +90,7 @@ func (s YourIdentifyingInfoSection) Valid() (bool, error) {
 	if ok, err := s.Sex.Valid(); !ok {
 		stack.Append("Sex", err)
 	}
+
 	return !stack.HasErrors(), stack
 }
 
@@ -106,16 +105,31 @@ type EmploymentActivitySection struct {
 }
 
 func (e EmploymentActivitySection) Valid() (bool, error) {
+	var stack ErrorStack
+
 	if ok, err := e.Status.Valid(); !ok {
-		// do stuff
-		fmt.Println(err)
+		stack.Append("Status", err)
 	}
 
 	if ok, err := e.EmployerName.Valid(); !ok {
-		fmt.Println(err)
+		stack.Append("EmployerName", err)
 	}
 
-	// etc etc
+	if ok, err := e.Address.Valid(); !ok {
+		stack.Append("Address", err)
+	}
 
-	return true, nil
+	if ok, err := e.Phone.Valid(); !ok {
+		stack.Append("Phone", err)
+	}
+
+	if ok, err := e.StartDate.Valid(); !ok {
+		stack.Append("StartDate", err)
+	}
+
+	if ok, err := e.EndDate.Valid(); !ok {
+		stack.Append("EndDate", err)
+	}
+
+	return !stack.HasErrors(), stack
 }

--- a/api/model/form/sections.go
+++ b/api/model/form/sections.go
@@ -5,6 +5,7 @@ import "fmt"
 // IdentifyingInfoSection stores personal identifying data for a person
 type IdentifyingInfoSection struct {
 	Person          PersonField
+	Address         AddressField
 	PlaceOfBirth    BirthAddressField
 	DateOfBirth     DateField
 	SSN             SSNField
@@ -42,6 +43,7 @@ type OtherNamesUsedSection struct {
 	OptionalComment TextField
 }
 
+// Valid validates the information for Other names used section
 func (s OtherNamesUsedSection) Valid() (bool, error) {
 	var stack ErrorStack
 	if ok, err := s.Person.Valid(); !ok {
@@ -93,6 +95,7 @@ func (s YourIdentifyingInfoSection) Valid() (bool, error) {
 	return !stack.HasErrors(), stack
 }
 
+// EmployerActivitiesSection stores a persons employement activity
 type EmploymentActivitySection struct {
 	Status       EmploymentStatusField
 	EmployerName TextField

--- a/api/model/form/sections.go
+++ b/api/model/form/sections.go
@@ -1,0 +1,118 @@
+package form
+
+import "fmt"
+
+// IdentifyingInfoSection stores personal identifying data for a person
+type IdentifyingInfoSection struct {
+	Person          PersonField
+	PlaceOfBirth    BirthAddressField
+	DateOfBirth     DateField
+	SSN             SSNField
+	OptionalComment TextField
+}
+
+// Valid checks for invalid information and returns errors
+func (s IdentifyingInfoSection) Valid() (bool, error) {
+	var stack ErrorStack
+
+	if ok, err := s.Person.Valid(); !ok {
+		stack.Append("Person", err)
+	}
+
+	if ok, err := s.DateOfBirth.Valid(); !ok {
+		stack.Append("DateOfBirth", err)
+	}
+
+	if ok, err := s.PlaceOfBirth.Valid(); !ok {
+		stack.Append("PlaceOfBirth", err)
+	}
+
+	if ok, err := s.SSN.Valid(); !ok {
+		stack.Append("SSN", err)
+	}
+
+	return !stack.HasErrors(), stack
+}
+
+// OtherNamesUsedSection stores information about a persons alternative names
+type OtherNamesUsedSection struct {
+	Person          PersonField
+	DatesUsed       DateRangeField
+	Reasons         TextField
+	OptionalComment TextField
+}
+
+func (s OtherNamesUsedSection) Valid() (bool, error) {
+	var stack ErrorStack
+	if ok, err := s.Person.Valid(); !ok {
+		stack.Append("Person", err)
+	}
+
+	if ok, err := s.DatesUsed.Valid(); !ok {
+		stack.Append("DateOfBirth", err)
+	}
+
+	if ok, err := s.Reasons.Valid(); !ok {
+		stack.Append("Reasons", err)
+	}
+
+	return !stack.HasErrors(), stack
+}
+
+// YourIdentifyingInfoSection stores personal physical attributes
+type YourIdentifyingInfoSection struct {
+	Height    HeightField
+	Weight    WeightField
+	HairColor HairColorField
+	EyeColor  EyeColorField
+	Sex       SexField
+}
+
+// Valid validates and returns errors
+func (s YourIdentifyingInfoSection) Valid() (bool, error) {
+	var stack ErrorStack
+	if ok, err := s.Height.Valid(); !ok {
+		stack.Append("Height", err)
+	}
+
+	if ok, err := s.Weight.Valid(); !ok {
+		stack.Append("Weight", err)
+	}
+
+	if ok, err := s.HairColor.Valid(); !ok {
+		stack.Append("HairColor", err)
+	}
+
+	if ok, err := s.EyeColor.Valid(); !ok {
+		stack.Append("EyeColor", err)
+	}
+
+	if ok, err := s.Sex.Valid(); !ok {
+		stack.Append("Sex", err)
+	}
+	return !stack.HasErrors(), stack
+}
+
+type EmploymentActivitySection struct {
+	Status       EmploymentStatusField
+	EmployerName TextField
+	Address      AddressField
+	Phone        PhoneNumberField
+	StartDate    DateField
+	EndDate      DateField
+}
+
+func (e EmploymentActivitySection) Valid() (bool, error) {
+	if ok, err := e.Status.Valid(); !ok {
+		// do stuff
+		fmt.Println(err)
+	}
+
+	if ok, err := e.EmployerName.Valid(); !ok {
+		fmt.Println(err)
+	}
+
+	// etc etc
+
+	return true, nil
+}

--- a/api/model/form/tag.go
+++ b/api/model/form/tag.go
@@ -1,0 +1,31 @@
+package form
+
+import "reflect"
+import "strconv"
+
+func MinLength(fieldName string, t interface{}) (int64, bool) {
+	v, ok := Extract(fieldName, "minLength", t)
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	return n, err == nil
+}
+
+func MaxLength(fieldName string, t interface{}) (int64, bool) {
+	v, ok := Extract(fieldName, "maxLength", t)
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	return n, err == nil
+}
+
+func Extract(fieldName, tag string, t interface{}) (s string, ok bool) {
+	st := reflect.TypeOf(t)
+	field, ok := st.FieldByName(fieldName)
+	if !ok {
+		return "", false
+	}
+	return field.Tag.Lookup(tag)
+}

--- a/api/model/form/tag_test.go
+++ b/api/model/form/tag_test.go
@@ -1,0 +1,19 @@
+package form
+
+import (
+	"fmt"
+	"testing"
+)
+
+type CustomTextField struct {
+	Firstname TextField `minLength:"4"`
+}
+
+func TestRule(t *testing.T) {
+
+	v, ok := MinLength("Firstname", CustomTextField{})
+	if ok {
+		fmt.Println(v)
+	}
+
+}

--- a/api/model/form/tag_test.go
+++ b/api/model/form/tag_test.go
@@ -1,19 +1,70 @@
 package form
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 type CustomTextField struct {
-	Firstname TextField `minLength:"4"`
+	Firstname   TextField `minLength:"4"`
+	Lastname    TextField `minLength:"40"`
+	Middlename  TextField `maxLength:"100"`
+	PhoneNumber string    `required:"required"`
 }
 
-func TestRule(t *testing.T) {
-
-	v, ok := MinLength("Firstname", CustomTextField{})
-	if ok {
-		fmt.Println(v)
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		Fieldname   string
+		TagName     string
+		Obj         interface{}
+		Expected    bool
+		ExpectedStr string
+	}{
+		{"Firstname", "minLength", CustomTextField{}, true, "4"},
+		{"Firstname", "", CustomTextField{}, false, ""},
+		{"", "", CustomTextField{}, false, ""},
+		{"", "minLength", CustomTextField{}, false, ""},
+		{"PhoneNumber", "required", CustomTextField{}, true, "required"},
+		{"PhoneNumber", "require", CustomTextField{}, false, "required"},
 	}
 
+	for _, test := range tests {
+		if s, ok := Extract(test.Fieldname, test.TagName, test.Obj); ok != test.Expected && s != test.ExpectedStr {
+			t.Errorf("Expected [%v] to have bool [%v] and string [%v] but got [%v] and [%v]\n",
+				test.Fieldname, test.Expected, test.ExpectedStr, ok, s)
+		}
+	}
+
+}
+func TestMinLength(t *testing.T) {
+	tests := []struct {
+		Fieldname string
+		TagName   string
+		Expected  int64
+	}{
+		{"Firstname", "minLength", 4},
+		{"Firstnames", "minLength", 0},
+		{"Lastname", "minLength", 40},
+	}
+
+	for _, test := range tests {
+		if v, _ := MinLength(test.Fieldname, CustomTextField{}); v != test.Expected {
+			t.Errorf("Expected [%v] to be [%v] but got [%v]\n", test.Fieldname, test.Expected, v)
+		}
+
+	}
+}
+
+func TestMaxLength(t *testing.T) {
+	tests := []struct {
+		Fieldname string
+		TagName   string
+		Expected  int64
+	}{
+		{"Middlename", "maxLength", 100},
+	}
+
+	for _, test := range tests {
+		if v, _ := MaxLength(test.Fieldname, CustomTextField{}); v != test.Expected {
+			t.Errorf("Expected [%v] to be [%v] but got [%v]\n", test.Fieldname, test.Expected, v)
+		}
+
+	}
 }


### PR DESCRIPTION
**Notes**
Added fields to represent entities in the eqip form. They are broken up into the following categories:
- **Basic fields** (`fields.go`)
  - These are the lowest level fields that either enhance existing types like `string`, `int64` or create very basic structs like `DateField` that contain fields for month, day, year.
- **Complex fields** (`fields_complex.go`)
  - These are composed of basic structs and represent blocks of general functionality like `AddressField` or `PersonField`
- **Sections** (`sections.go`)
  - These combine complex fields to represent entire sections in the form like `IdentifyingInfoSection`
- Updated the validation endpoints to use the new form fields to perform validation
- Updated API design docs to include sample json


These are all still WIP as validation rules will be added as we build up our requirements. For additional technical design notes and discussions, refer to issue https://github.com/truetandem/e-QIP-prototype/issues/31

Also, I may break these into separate files as another ticket.