### PR TITLE
Allow the extraction of OAuth credentials from VCAP env variables

### DIFF
--- a/api/cf/env.go
+++ b/api/cf/env.go
@@ -1,0 +1,51 @@
+package cf
+
+import (
+	"fmt"
+	"os"
+
+	cfenv "github.com/cloudfoundry-community/go-cfenv"
+)
+
+func PublicAddress() string {
+	current, _ := cfenv.Current()
+	uri := getURI(current)
+	port := getPort(current)
+	return fmt.Sprintf("%s:%s", uri, port)
+}
+
+func PublicURI() string {
+	current, _ := cfenv.Current()
+	proto := getProtocol(current)
+	uri := getURI(current)
+	port := getPort(current)
+	return fmt.Sprintf("%s://%s:%s", proto, uri, port)
+}
+
+func getProtocol(current *cfenv.App) string {
+	if current != nil && len(current.ApplicationURIs) > 0 {
+		return "https"
+	}
+	return "http"
+}
+
+func getPort(current *cfenv.App) string {
+	if current != nil && current.Port != 0 {
+		return string(current.Port)
+	}
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "3000"
+	}
+
+	return port
+}
+
+func getURI(current *cfenv.App) string {
+	if current != nil && len(current.ApplicationURIs) > 0 {
+		return current.ApplicationURIs[0]
+	}
+
+	return "localhost"
+}

--- a/api/glide.lock
+++ b/api/glide.lock
@@ -1,11 +1,13 @@
-hash: fc5a939029a2dac9ed3ee3bae6008702df47c3cb960ecc8eff61c5caf1356cd7
-updated: 2016-11-30T17:11:44.538852142Z
+hash: d800bb1dfaacb29d1e3c58eeae4917c2debaec98844f5eac212e397109e4bf88
+updated: 2016-12-06T23:32:17.13670183-05:00
 imports:
 - name: cloud.google.com/go
   version: a2e776edd7c5463ed144b91a28640db71619ae3c
   subpackages:
   - compute/metadata
   - internal
+- name: github.com/cloudfoundry-community/go-cfenv
+  version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/dgryski/dgoogauth
@@ -28,6 +30,8 @@ imports:
   version: 5d7133fb578a9504f8ab549737c993422f65a000
 - name: github.com/microcosm-cc/bluemonday
   version: f77f16ffc87a6a58814e64ae72d55f9c41374e6d
+- name: github.com/mitchellh/mapstructure
+  version: 5a0325d7fafaac12dda6e7fb8bd222ec1b69875e
 - name: github.com/russross/blackfriday
   version: 0b647d0506a698cca42caca173e55559b12a69f2
 - name: github.com/shurcooL/sanitized_anchor_name

--- a/api/glide.yaml
+++ b/api/glide.yaml
@@ -24,3 +24,5 @@ import:
   - linkedin
 - package: gopkg.in/pg.v5
   version: v5.1.2
+- package: github.com/cloudfoundry-community/go-cfenv
+  version: ^1.14.0

--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2/linkedin"
 
 	"github.com/gorilla/mux"
+	"github.com/truetandem/e-QIP-prototype/api/cf"
 )
 
 var (
@@ -20,7 +21,7 @@ var (
 	redirectTo       = os.Getenv("API_REDIRECT")
 )
 
-// authServiceHandler is the initial entry point for authentication.
+// AuthServiceHandler is the initial entry point for authentication.
 func AuthServiceHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	service := vars["service"]
@@ -33,10 +34,11 @@ func AuthServiceHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, config.AuthCodeURL(oauthStateString), http.StatusTemporaryRedirect)
 }
 
-// authCallbackHandler handles responses from the authentication provider.
+// AuthCallbackHandler handles responses from the authentication provider.
 func AuthCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	service := vars["service"]
+
 	config, ok := configureAuthentication(service)
 	if !ok {
 		fmt.Printf("Could not determine service with '%s'\n", service)
@@ -62,14 +64,14 @@ func AuthCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirectToWithToken, http.StatusTemporaryRedirect)
 }
 
-// configureAuthentication takes a service name and configures the OAuth 2.0 with
+// ConfigureAuthentication takes a service name and configures the OAuth 2.0 with
 // appropriate endpoints and scopes.
 func configureAuthentication(service string) (*oauth2.Config, bool) {
 	ok := true
 	config := &oauth2.Config{
-		RedirectURL:  fmt.Sprintf("http://localhost:3000/auth/%s/callback", strings.ToLower(service)),
-		ClientID:     os.Getenv(fmt.Sprintf("%s_CLIENT_ID", strings.ToUpper(service))),
-		ClientSecret: os.Getenv(fmt.Sprintf("%s_CLIENT_SECRET", strings.ToUpper(service))),
+		RedirectURL:  fmt.Sprintf("%s/auth/%s/callback", cf.PublicURI(), strings.ToLower(service)),
+		ClientID:     cf.UserService("github-client", "id"),
+		ClientSecret: cf.UserService("github-client", "secret"),
 	}
 
 	switch service {

--- a/api/main.go
+++ b/api/main.go
@@ -4,19 +4,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
+	"github.com/truetandem/e-QIP-prototype/api/cf"
 	"github.com/truetandem/e-QIP-prototype/api/handlers"
 	middleware "github.com/truetandem/e-QIP-prototype/api/middleware"
 )
-
-func getPort() string {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "3000"
-	}
-	return port
-}
 
 func main() {
 	r := middleware.NewRouter().Inject(handlers.LoggerHandler)
@@ -44,5 +36,5 @@ func main() {
 	v.HandleFunc("/address", handlers.ValidateAddress).Methods("POST")
 
 	log.Println("Starting API mock server")
-	fmt.Println(http.ListenAndServe(":"+getPort(), handlers.CORS(r)))
+	fmt.Println(http.ListenAndServe(cf.PublicAddress(), handlers.CORS(r)))
 }


### PR DESCRIPTION
This allows the API to pull additional OAuth service information from the CloudFoundry specific VCAP environment variable.

Other changes include using the CF community library to return environment data and use it to build public addresses and URIs.