### PR TITLE
Backend applicant ssn

### DIFF
--- a/api/design/validate.md
+++ b/api/design/validate.md
@@ -7,6 +7,9 @@ FORMAT: 1A
 ## Validates Social Security Number [GET]
 
 + Request
+    + parameters
+      + ssn: `012345678` - Social Security Number for a person
+
     + Headers
 
         Authorization: Bearer

--- a/api/design/validate.md
+++ b/api/design/validate.md
@@ -24,20 +24,7 @@ FORMAT: 1A
         "Errors": [
           {
             "Fieldname": "SSN",
-            "Errors": [
-              {
-                "Fieldname": "First",
-                "Error": "First is a required field"
-              },
-              {
-                "Fieldname": "Middle",
-                "Error": "Middle is a required field"
-              },
-              {
-                "Fieldname": "Last",
-                "Error": "Last is a required field"
-              }
-            ]
+            "Error": ""
           }
         ]
       }

--- a/api/design/validate.md
+++ b/api/design/validate.md
@@ -227,6 +227,17 @@ FORMAT: 1A
 
         Authorization: Bearer
         Accept: application/json
+    + Body
+
+```json
+      {
+        "Last": "",
+        "First": "",
+        "Middle": "",
+        "Suffix": "",
+        "SuffixOther": ""
+      }
+```
 
 + Response 200 (application/json)
     + Headers
@@ -236,35 +247,30 @@ FORMAT: 1A
     + Body
 
 ```json
-    {
-      "Errors": [
-        {
-          "Fieldname": "Firstname",
-          "Error": ""
-        },
-        {
-          "Fieldname": "Lastname",
-          "Error": ""
-        },
-        {
-          "Fieldname": "Middlename",
-          "Error": ""
-        },
-        {
-          "Fieldname": "Suffix",
-          "Errors": [
-            {
-              "Fieldname": "Suffix",
-              "Error": ""
-            },
-            {
-              "Fieldname": "SuffixOther",
-              "Error": ""
-            }
-          ]
-        }
-      ]
-    }
+      {
+        "Errors": [
+          {
+            "Fieldname": "First",
+            "Error": ""
+          },
+          {
+            "Fieldname": "Last",
+            "Error": ""
+          },
+          {
+            "Fieldname": "Middle",
+            "Error": ""
+          },
+          {
+            "Fieldname": "Suffix",
+            "Error": ""
+          },
+          {
+            "Fieldname": "SuffixOther",
+            "Error": ""
+          }
+        ]
+      }
 ```
 
 + Response 500

--- a/api/handlers/validate.go
+++ b/api/handlers/validate.go
@@ -52,10 +52,13 @@ func ValidateState(w http.ResponseWriter, r *http.Request) {
 
 // ValidateSSN checks if a social security number is valid
 func ValidateSSN(w http.ResponseWriter, r *http.Request) {
-	//ssn := mux.Vars(r)["ssn"]
-	ssn := form.SSNField{}
+	ssn := mux.Vars(r)["ssn"]
+	field := form.SSNField{
+		SSN:        ssn,
+		Applicable: true,
+	}
 
-	_, err := ssn.Valid()
+	_, err := field.Valid()
 	stack := form.NewErrorStack("SSN", err)
 	EncodeErrJSON(w, stack)
 }

--- a/api/model/form/ssn_field.go
+++ b/api/model/form/ssn_field.go
@@ -22,11 +22,11 @@ func (s SSNField) Valid() (bool, error) {
 
 	// If Applicable, a SSN must be provided
 	if s.SSN == "" {
-		return false, ErrFieldRequired{"If Applicable is marked, a Social Security Number must be provided"}
+		return false, ErrFieldRequired{"if Applicable is marked, a Social Security Number must be provided"}
 	}
 
 	if ok := SSNRegexp.MatchString(s.SSN); !ok {
-		return false, ErrFieldInvalid{"Social Security Number is not a proper format"}
+		return false, ErrFieldInvalid{"is not a valid formatted Social Security Number"}
 	}
 
 	return true, nil

--- a/api/model/form/ssn_field.go
+++ b/api/model/form/ssn_field.go
@@ -1,50 +1,33 @@
 package form
 
-import (
-	"fmt"
-	"regexp"
+import "regexp"
+
+var (
+	// SSNRegexp validates the format of a Social Security Number
+	SSNRegexp = regexp.MustCompile("^\\d{3}\\d{2}\\d{4}$")
 )
 
 // SSNField stores a persons social security number
 // https://www.ssa.gov/employer/randomization.html
 type SSNField struct {
-	First         string
-	Middle        string
-	Last          string
-	NotApplicable bool
+	SSN        string
+	Applicable bool
 }
 
 // Valid validates the format of a Social Security Number if it is applicable
 func (s SSNField) Valid() (bool, error) {
-	if s.NotApplicable {
+	if !s.Applicable {
 		return true, nil
 	}
 
-	var stack ErrorStack
-	if s.First == "" {
-		stack.Append("First", ErrFieldRequired{"First is a required field"})
-	} else {
-		if ok, _ := regexp.MatchString("^\\d{3}$", s.First); !ok {
-			stack.Append("First", ErrFieldInvalid{fmt.Sprintf("`%s` is an invalid First value", s.First)})
-		}
+	// If Applicable, a SSN must be provided
+	if s.SSN == "" {
+		return false, ErrFieldRequired{"If Applicable is marked, a Social Security Number must be provided"}
 	}
 
-	if s.Middle == "" {
-		stack.Append("Middle", ErrFieldRequired{"Middle is a required field"})
-	} else {
-		if ok, _ := regexp.MatchString("^\\d{2}$", s.First); !ok {
-			stack.Append("Middle", ErrFieldInvalid{fmt.Sprintf("`%s` is an invalid Middle value", s.Middle)})
-		}
+	if ok := SSNRegexp.MatchString(s.SSN); !ok {
+		return false, ErrFieldInvalid{"Social Security Number is not a proper format"}
 	}
 
-	if s.Last == "" {
-		stack.Append("Last", ErrFieldRequired{"Last is a required field"})
-	} else {
-		if ok, _ := regexp.MatchString("^\\d{4}$", s.First); !ok {
-			stack.Append("Last", ErrFieldInvalid{fmt.Sprintf("`%s` is an invalid Last value", s.Last)})
-		}
-	}
-
-	// Make sure values are accurate
-	return !stack.HasErrors(), stack
+	return true, nil
 }

--- a/api/model/form/ssn_field_test.go
+++ b/api/model/form/ssn_field_test.go
@@ -1,0 +1,45 @@
+package form
+
+import "testing"
+
+func TestSSNField(t *testing.T) {
+	tests := []struct {
+		Field    SSNField
+		Expected bool
+	}{
+		{
+			SSNField{
+				SSN:        "123456789",
+				Applicable: true,
+			},
+			true,
+		},
+		{
+			SSNField{
+				SSN:        "1",
+				Applicable: true,
+			},
+			false,
+		},
+		{
+			SSNField{
+				SSN:        "",
+				Applicable: true,
+			},
+			false,
+		},
+		{
+			SSNField{
+				SSN:        "",
+				Applicable: false,
+			},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		if ok, _ := test.Field.Valid(); ok != test.Expected {
+			t.Errorf("Expected [%v] [%v] to be [%v]\n", test.Field, ok, test.Expected)
+		}
+	}
+}


### PR DESCRIPTION
**Notes**
- Added ssn field to handle server-side validation
- Added endpoint to `/validate/ssn/{ssn}`
- Updated API design documentation for ssn
- Related to issue #112

**Additional Notes**
I'll be pushing up a separate PR for the api doc updates for the other validation endpoints that aren't relevant in this ticket.