### PR TITLE
Production manifest sync'd with staging updates

### DIFF
--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -5,8 +5,8 @@ applications:
   instances: 2
   domain: fr.cloud.gov
   host: eqip-prototype-api
-  buildpack: https://github.com/cloudfoundry/go-buildpack.git
+  buildpack: https://github.com/cloudfoundry/go-buildpack
   path: api
-  command: ./run.sh
+  command: ./api
   env:
     GOVERSION: go1.7.4


### PR DESCRIPTION
On staging we are executing the API binary directly instead of recompiling. This is to make sure we do the same on production.