### PR TITLE
Go import rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ __snapshots__/
 /css/
 /fonts/
 /img/
+TAGS
 
 # Test artifacts
 /jest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,32 @@
 ## Welcome!
 
-We're so glad you're thinking about contributing to an 18F open source project! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+We're so glad you're thinking about contributing to an 18F open source project! If you're unsure about anything,
+just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to
+change something. We love all friendly contributions.
 
-We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+We want to ensure a welcoming environment for all of our projects. Our staff follow the
+[18F Code of Conduct](https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md) and all contributors
+should do the same.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
+We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its
+[README](README.md).
 
-If you have any questions or want to read more, check out the [18F Open Source Policy GitHub repository](https://github.com/18f/open-source-policy), or just [shoot us an email](mailto:18f@gsa.gov).
+If you have any questions or want to read more, check out the
+[18F Open Source Policy GitHub repository](https://github.com/18f/open-source-policy), or just
+[shoot us an email](mailto:18f@gsa.gov).
+
+## Where to contribute?
+
+During the development process the development fork of the project will be hosted at [truetandem/e-QIP-prototype](https://github.com/truetandem/e-QIP-prototype).
+This may cause some confusion so we have outlined some basic steps for contributing:
+
+ 1. Clone the repository `git clone https://github.com/truetandem/e-QIP-prototype $GOPATH/src/18F/e-QIP-prototype`
+ 2. Change in to the new directory `cd $GOPATH/src/18F/e-QIP-prototype`
+ 3. Fork the code on Github
+ 4. Add a **git remote** with `git remote add fork <path/to/forked/repository>`
+ 5. Make changes and commit them locally
+ 6. Push to **fork** using `git push fork`
+ 7. Create a **pull request** from the forked repository to the [truetandem/e-QIP-prototype](https://github.com/truetandem/e-QIP-prototype) repository
 
 ## Public domain
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ truetandem/e-QIP-prototype#issue_number Commit description
 Clone the repository and `cd` into it:
 
 ```
+mkdir -p $GOPATH/src/github.com/18F
+cd $GOPATH/src/github.com/18F
 git clone https://github.com/18F/e-QIP-prototype
 cd e-QIP-prototype
 ```
@@ -74,6 +76,12 @@ this has been installed we execute a single command:
 
 ```
 npm install
+```
+
+For dependencies on the backend use [glide][17]:
+
+```
+glide install
 ```
 
 ### Building the application
@@ -159,6 +167,10 @@ For command-line alternatives there are the following:
  - For JavaScript, [JSHint][14] which may be installed with ```npm install -g jshint```
  - For HTML, [html-lint][15] which may be installed with ```npm install -g html-lint```
 
+### Contributing
+
+Please refer to the [contributing documentation][18].
+
 
 [badge_chat]: https://img.shields.io/badge/chat-slack-green.svg
 [badge_ci_18f]: https://travis-ci.org/18F/e-QIP-prototype.svg?branch=master
@@ -183,3 +195,5 @@ For command-line alternatives there are the following:
 [14]: http://jshint.com
 [15]: https://github.com/curtisj44/HTML-Lint
 [16]: https://www.npmjs.com
+[17]: https://github.com/Masterminds/glide
+[18]: CONTRIBUTING.md

--- a/api/db/db.go
+++ b/api/db/db.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/truetandem/e-QIP-prototype/api/cf"
+	"github.com/18F/e-QIP-prototype/api/cf"
 	pg "gopkg.in/pg.v5"
 )
 

--- a/api/glide.yaml
+++ b/api/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/truetandem/e-QIP-prototype/api
+package: github.com/18F/e-QIP-prototype/api
 import:
 - package: github.com/dgrijalva/jwt-go
   version: v3.0.0

--- a/api/handlers/2fa.go
+++ b/api/handlers/2fa.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/18F/e-QIP-prototype/api/twofactor"
 	"github.com/gorilla/mux"
-	"github.com/truetandem/e-QIP-prototype/api/twofactor"
 )
 
 var (

--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -12,8 +12,8 @@ import (
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/linkedin"
 
+	"github.com/18F/e-QIP-prototype/api/cf"
 	"github.com/gorilla/mux"
-	"github.com/truetandem/e-QIP-prototype/api/cf"
 )
 
 var (

--- a/api/handlers/basic_auth.go
+++ b/api/handlers/basic_auth.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/truetandem/e-QIP-prototype/api/model"
+	"github.com/18F/e-QIP-prototype/api/model"
 )
 
 // BasicAuth processes a users request to login with a Username and Password

--- a/api/handlers/jwt.go
+++ b/api/handlers/jwt.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/truetandem/e-QIP-prototype/api/db"
-	"github.com/truetandem/e-QIP-prototype/api/model"
+	"github.com/18F/e-QIP-prototype/api/db"
+	"github.com/18F/e-QIP-prototype/api/model"
 )
 
 var (

--- a/api/handlers/validate.go
+++ b/api/handlers/validate.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/18F/e-QIP-prototype/api/model/form"
 	"github.com/gorilla/mux"
-	"github.com/truetandem/e-QIP-prototype/api/model/form"
 )
 
 // ValidateAddress checks if an entire address is valid

--- a/api/main.go
+++ b/api/main.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/truetandem/e-QIP-prototype/api/cf"
-	"github.com/truetandem/e-QIP-prototype/api/handlers"
-	middleware "github.com/truetandem/e-QIP-prototype/api/middleware"
+	"github.com/18F/e-QIP-prototype/api/cf"
+	"github.com/18F/e-QIP-prototype/api/handlers"
+	middleware "github.com/18F/e-QIP-prototype/api/middleware"
 )
 
 func main() {

--- a/api/model/dbtest_helper.go
+++ b/api/model/dbtest_helper.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/truetandem/e-QIP-prototype/api/db"
+	"github.com/18F/e-QIP-prototype/api/db"
 
 	pg "gopkg.in/pg.v5"
 )

--- a/api/twofactor/twofactor.go
+++ b/api/twofactor/twofactor.go
@@ -9,12 +9,12 @@ import (
 	"net/url"
 	"text/template"
 
+	"github.com/18F/e-QIP-prototype/api/cf"
 	"github.com/dgryski/dgoogauth"
 	"github.com/keighl/mandrill"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/russross/blackfriday"
 	qr "github.com/skip2/go-qrcode"
-	"github.com/truetandem/e-QIP-prototype/api/cf"
 )
 
 const (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,10 @@ api:
   dockerfile: Dockerfile.api
   env_file:
     - .env
-  working_dir: /go/src/github.com/truetandem/e-QIP-prototype/api
+  working_dir: /go/src/github.com/18F/e-QIP-prototype/api
   command: ./run.sh
   volumes:
-    - .:/go/src/github.com/truetandem/e-QIP-prototype
+    - .:/go/src/github.com/18F/e-QIP-prototype
   ports:
     - "3000:3000"
   links:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,9 +4,9 @@ var gulp = require('gulp')
 var concat = require('gulp-concat')
 var sass = require('gulp-sass')
 var rename = require('gulp-rename')
-var envify = require('gulp-envify');
+var envify = require('gulp-envify')
 
-require('dotenv').config();
+require('dotenv').config()
 
 var paths = {
   entry: './src/boot.jsx',


### PR DESCRIPTION
Went with **Option 1: Rename the internal references to 18F repository** from #133 which described the following:

This involves just a few steps internally.

  1. We would change all paths from `github.com/truetandem/e-QIP-prototype` to `github.com/18F/e-QIP-prototype`.
  2. We can either...
    * leave the source code where it is and create a symlink to the 18F namespace
  ```
  mkdir -p $GOPATH/src/github.com/18F/
  cd $GOPATH/src/github.com/18F/
  ln -s $GOPATH/src/github.com/truetandem/e-QIP-prototype .
  ```
   * We can move the repository to the expected path
  ```
  mv $GOPATH/src/github.com/e-QIP-prototype $GOPATH/src/github.com/18F/
  ```

Either option always for minimal changes while still using the Go workspace. However, this does raise a question as to which is the authoritative source during the development lifecycle (i.e. if someone wanted to contribute which repository should they work against). Possible addition to the README and/or CONTRIBUTING:

```
1. Clone the repository `git clone <path/to/e-QIP-prototype> $GOPATH/src/<organization>`
2. Change in to the new directory `cd $GOPATH/src/<organization>/e-QIP-prototype`
3. Fork the code on Github
4. Add a `git remote` with `git remote add fork <URI to forked repository>`
5. Make changes and commit locally
6. Push to fork `git push fork`
7. Create pull request from forked repository to <18F/truetandem> repository
```