### PR TITLE
truetandem/e-QIP-prototype#186 Fix active class applied to navigation

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,9 +1,57 @@
 import React from 'react'
-import { Link } from 'react-router'
+import { Link, hashHistory } from 'react-router'
 import { connect } from 'react-redux'
 import AuthenticatedView from '../../views/AuthenticatedView'
 
 class Navigation extends React.Component {
+
+  /**
+   * There is a bug in the react router which does not add the active
+   * class to items in the route hiearchy
+   */
+  isActive (route, pathname) {
+    return pathname.indexOf(route) !== -1
+  }
+
+  /**
+   * Determine if the route has any errors
+   */
+  hasErrors (route, pathname) {
+    // TODO: Pull this from true error state
+    return route.indexOf('birth') !== -1
+  }
+
+  /**
+   * Determine if the route is considered complete and valid
+   */
+  isValid (route, pathname) {
+    // TODO: Pull this from true error state
+    return route.indexOf('ssn') !== -1
+  }
+
+  /**
+   * Get the classes to be applied to a link. This includes the following:
+   *  - active
+   *  - has-errors
+   *  - is-valid
+   */
+  getClassName (route) {
+    let location = hashHistory.getCurrentLocation()
+    let pathname = location.pathname
+    let klass = ''
+
+    if (this.isActive(route, pathname)) {
+      klass += ' active'
+    }
+
+    if (this.hasErrors(route, pathname)) {
+      klass += ' has-errors'
+    } else if (this.isValid(route, pathname)) {
+      klass += ' is-valid'
+    }
+
+    return klass
+  }
 
   render () {
     let sectionNum = 0
@@ -13,14 +61,16 @@ class Navigation extends React.Component {
       return (
         <div key={section.name} className="section">
           <span className="title">
-            <Link to={url} activeClassName="active"><span className="number">{sectionNum}</span> {section.name}</Link>
+            <Link to={url} className={this.getClassName(url)}>
+              <span className="number">{sectionNum}</span> {section.name}
+            </Link>
           </span>
           {
             section.subsections.map(subsection => {
               const secUrl = `/form/${section.url}/${subsection.url}`
               return (
                 <div key={subsection.name} className="subsection" >
-                  <Link to={secUrl} activeClassName="active">{subsection.name}</Link>
+                  <Link to={secUrl} className={this.getClassName(secUrl)}>{subsection.name}</Link>
                 </div>
               )
             })
@@ -70,4 +120,13 @@ const sectionNavMap = [
     ]
   }
 ]
-export default AuthenticatedView(Navigation)
+
+function mapStateToProps (state) {
+  // TODO: Grab error states
+  let section = state.section || {}
+  return {
+    section: section
+  }
+}
+
+export default connect(mapStateToProps)(AuthenticatedView(Navigation))


### PR DESCRIPTION
The react-router has a bug where the parent element of any matching subroute would not be declared active. This is fine and easy to write in addition we also needed to start connecting error state to the class names as well.