### PR TITLE
Navigation folding for all but active section

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -109,7 +109,23 @@ class Navigation extends React.Component {
       const url = `/form/${section.url}`
       const sectionClass = this.getClassName(url, pathname)
       const sectionIcon = this.getIcon(sectionClass)
+      const subsections = section.subsections.map(subsection => {
+        const subUrl = `/form/${section.url}/${subsection.url}`
+        const subClass = this.getClassName(subUrl, pathname)
+        const subIcon = this.getIcon(subClass)
+        return (
+          <div key={subsection.name} className="subsection" >
+            <Link to={subUrl} className={subClass}>
+              <span className="name">{subsection.name}</span>
+              {subIcon}
+            </Link>
+          </div>
+        )
+      })
+
+      // Increment the section number
       sectionNum++
+
       return (
         <div key={section.name} className="section">
           <span className="title">
@@ -119,21 +135,7 @@ class Navigation extends React.Component {
               {sectionIcon}
             </Link>
           </span>
-          {
-            section.subsections.map(subsection => {
-              const subUrl = `/form/${section.url}/${subsection.url}`
-              const subClass = this.getClassName(subUrl, pathname)
-              const subIcon = this.getIcon(subClass)
-              return (
-                <div key={subsection.name} className="subsection" >
-                  <Link to={subUrl} className={subClass}>
-                    <span className="name">{subsection.name}</span>
-                    {subIcon}
-                  </Link>
-                </div>
-              )
-            })
-          }
+          { this.isActive(url, pathname) ? subsections : '' }
         </div>
       )
     })


### PR DESCRIPTION
Previously, due to demos, we had auto-expanded all sections and the associated subsections regardless of whether they were active. This is not the final behavior desired at this juncture so this resolves that.