### PR TITLE
Include es6-promise polyfill for IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
     "enzyme": "^2.6.0",
+    "es6-promise": "^4.0.5",
     "eslint": "^3.10.2",
     "eslint-config-standard": "^6.2.1",
     "eslint-plugin-promise": "^3.3.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,9 +51,15 @@ function plugins () {
   }
 
   // Plugins used by all environments
-  plugins.push(new webpack.EnvironmentPlugin([
-    'API_BASE_URL'
-  ]))
+  [
+    new webpack.EnvironmentPlugin(['API_BASE_URL']),
+    new webpack.ProvidePlugin({
+      'Promise': 'es6-promise',
+      'fetch': 'imports?this=>global!exports?global.fetch!whatwg-fetch'
+    })
+  ].forEach((p) => {
+    plugins.push(p)
+  })
 
   return plugins
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
+es6-promise@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
+
 es6-set@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.4.tgz#9516b6761c2964b92ff479456233a247dc707ce8"
@@ -3676,7 +3680,7 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
   dependencies:
     js-tokens "^2.0.0"
 
-"loose-envify@github:tomashanacek/loose-envify":
+loose-envify@tomashanacek/loose-envify:
   version "1.0.0"
   resolved "https://codeload.github.com/tomashanacek/loose-envify/tar.gz/274d08b592bab76b3a7ab099a669ccd1b4a7a34f"
   dependencies:


### PR DESCRIPTION
IE 11 and less requires a polyfill for promises. This is introduced within the webpack configuration as a plugin.