### PR TITLE
Remove outside prop for checkboxes

### DIFF
--- a/src/components/Form/Checkbox/Checkbox.jsx
+++ b/src/components/Form/Checkbox/Checkbox.jsx
@@ -163,26 +163,25 @@ export default class Checkbox extends ValidationElement {
   }
 
   render () {
-    const checkbox = (<input className={this.inputClass()}
-                             id={this.state.name}
-                             name={this.state.name}
-                             type="checkbox"
-                             aria-describedby={this.errorName()}
-                             disabled={this.state.disabled}
-                             maxLength={this.state.maxlength}
-                             pattern={this.state.pattern}
-                             readOnly={this.state.readonly}
-                             required={this.state.required}
-                             value={this.state.value}
-                             onChange={this.handleChange}
-                             onFocus={this.handleFocus}
-                             onBlur={this.handleBlur} />)
     return (
       <div className={this.divClass()}>
-        {this.props.outside ? checkbox : ''}
         <label className={this.labelClass()}
                htmlFor={this.state.name}>
-          {!this.props.outside ? checkbox : ''}
+          <input className={this.inputClass()}
+                 id={this.state.name}
+                 name={this.state.name}
+                 type="checkbox"
+                 aria-describedby={this.errorName()}
+                 disabled={this.state.disabled}
+                 maxLength={this.state.maxlength}
+                 pattern={this.state.pattern}
+                 readOnly={this.state.readonly}
+                 required={this.state.required}
+                 value={this.state.value}
+                 onChange={this.handleChange}
+                 onFocus={this.handleFocus}
+                 onBlur={this.handleBlur}
+                 />
           {this.props.children}
           <span>{this.state.label}</span>
         </label>

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -327,7 +327,6 @@ export default class DateControl extends ValidationElement {
         <div className="coupled-flags">
           <Checkbox name="estimated"
                     label="Estimated"
-                    outside="true"
                     help=""
                     value={this.state.estimated}
                     onChange={this.handleChange}

--- a/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.jsx
+++ b/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.jsx
@@ -217,7 +217,6 @@ export default class ApplicantSSN extends ValidationElement {
           <div className="coupled-flags">
             <Checkbox name={this.partName('notApplicable')}
                       label="Not applicable"
-                      outside="true"
                       ref="notAapplicable"
                       help=""
                       value={this.state.notApplicable}


### PR DESCRIPTION
Do not give the option of placing the `<input>` element outside of the `<label>` for checkboxes.