### PR TITLE
truetandem/e-QIP-prototype#238 Updated Number field to use input text…

### DIFF
--- a/src/components/Form/CheckboxGroup/CheckboxGroup.jsx
+++ b/src/components/Form/CheckboxGroup/CheckboxGroup.jsx
@@ -1,12 +1,19 @@
 import React from 'react'
 
 export default function CheckboxGroup (props) {
-
   const children = React.Children.map(props.children, (checkbox) => {
-    // Check if current value matches one of the checkbox options
-    let checked = !!(props.selectedValues.find(v => {
-      return (v === checkbox.props.value)
-    }))
+    let checked = null
+
+    // Handle empty array case so that .find() doesn't error
+    if (!props.selectedValues || props.selectedValues.length === 0) {
+      checked = false
+    } else {
+      // Check if current value matches one of the checkbox options. Boolify it
+      // if a value is found
+      checked = !!(props.selectedValues.find(v => {
+        return (v === checkbox.props.value)
+      }))
+    }
 
     // Use function when you want custom behavior
     if (props.selectedValueFunc) {

--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -30,6 +30,11 @@ export default class Number extends ValidationElement {
    */
   handleChange (event) {
     event.persist()
+    // Prevent non-numerical values from being entered
+    if (!event.target.value.match(/^(\s*|\d+)$/)) {
+      return
+    }
+
     this.setState({ value: event.target.value }, () => {
       super.handleChange(event)
     })
@@ -187,7 +192,7 @@ export default class Number extends ValidationElement {
         <input className={this.inputClass()}
                id={this.state.name}
                name={this.state.name}
-               type="number"
+               type="text"
                placeholder={this.state.placeholder}
                aria-describedby={this.errorName()}
                disabled={this.state.disabled}


### PR DESCRIPTION
… field
**Notes**
- Updated `Number.jsx` to use `text` input type. Resolves bug #238
- Added regex to prevent non-numerical values from being entered into the field
- Also included fix for CheckboxGroup. The `.find()` errors out with an empty array.