### PR TITLE
Gambling debt adjustments from punch list

### DIFF
--- a/src/components/Form/Checkbox/Checkbox.jsx
+++ b/src/components/Form/Checkbox/Checkbox.jsx
@@ -93,10 +93,6 @@ export default class Checkbox extends ValidationElement {
       klass += ' no-toggle'
     }
 
-    if (this.state.focus) {
-      klass += ' usa-input-focus'
-    }
-
     return klass.trim()
   }
 
@@ -120,10 +116,6 @@ export default class Checkbox extends ValidationElement {
    */
   inputClass () {
     let klass = ''
-
-    if (this.state.focus) {
-      klass += ' usa-input-focus'
-    }
 
     if (this.state.valid) {
       klass += ' usa-input-success'

--- a/src/components/Form/Checkbox/Checkbox.test.jsx
+++ b/src/components/Form/Checkbox/Checkbox.test.jsx
@@ -31,7 +31,7 @@ describe('The checkbox component', () => {
     const component = mount(<Checkbox name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(true)
+    expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(false)
     expect(component.find('div.hidden').length).toEqual(1)
   })
 

--- a/src/components/Form/Collection/Collection.jsx
+++ b/src/components/Form/Collection/Collection.jsx
@@ -237,7 +237,7 @@ export default class Collection extends ValidationElement {
     //
     // Also, if there are less than two items in the list skip the summary
     if (!this.props.summary || this.state.items.length < 2) {
-      const byline = () => {
+      const byline = (item) => {
         if (this.state.items.length < 2) {
           return ''
         }
@@ -256,7 +256,7 @@ export default class Collection extends ValidationElement {
         return (
           <div className="item" key={item.index}>
             <div className="details">
-              {byline()}
+              {byline(item)}
               {item.children}
             </div>
           </div>

--- a/src/components/Form/Collection/Collection.jsx
+++ b/src/components/Form/Collection/Collection.jsx
@@ -234,17 +234,29 @@ export default class Collection extends ValidationElement {
   getContent () {
     // If no summary details are provided then we do a simple display of everything
     // without worrying about the accordion look and feel.
-    if (!this.props.summary) {
+    //
+    // Also, if there are less than two items in the list skip the summary
+    if (!this.props.summary || this.state.items.length < 2) {
+      const byline = () => {
+        if (this.state.items.length < 2) {
+          return ''
+        }
+
+        return (
+          <div className="byline">
+            <a href="javascript:;;" className="remove" onClick={this.remove.bind(this, item.index)}>
+              <span>{i18n.t('collection.remove')}</span>
+              <i className="fa fa-times-circle" aria-hidden="true"></i>
+            </a>
+          </div>
+        )
+      }
+
       return this.state.items.map((item) => {
         return (
           <div className="item" key={item.index}>
             <div className="details">
-              <div className="byline">
-                <a href="javascript:;;" className="remove" onClick={this.remove.bind(this, item.index)}>
-                  <span>{i18n.t('collection.remove')}</span>
-                  <i className="fa fa-times-circle" aria-hidden="true"></i>
-                </a>
-              </div>
+              {byline()}
               {item.children}
             </div>
           </div>
@@ -275,7 +287,7 @@ export default class Collection extends ValidationElement {
                 </div>
               </a>
             </div>
-            <div className="details">
+            <div className="details gutters">
               <div className="byline">
                 <a href="javascript:;;" className="remove" onClick={this.remove.bind(this, item.index)}>
                   <span>{i18n.t('collection.remove')}</span>

--- a/src/components/Form/Collection/Collection.scss
+++ b/src/components/Form/Collection/Collection.scss
@@ -59,7 +59,6 @@
     }
 
     .details {
-
         &.gutters {
             padding-left: 4rem;
             padding-right: 4rem;

--- a/src/components/Form/Collection/Collection.scss
+++ b/src/components/Form/Collection/Collection.scss
@@ -59,8 +59,11 @@
     }
 
     .details {
-        padding-left: 4rem;
-        padding-right: 4rem;
+
+        &.gutters {
+            padding-left: 4rem;
+            padding-right: 4rem;
+        }
 
         .byline {
             text-align: right;

--- a/src/components/Form/Collection/Collection.test.jsx
+++ b/src/components/Form/Collection/Collection.test.jsx
@@ -33,11 +33,11 @@ describe('The Collection component', () => {
       )
     }
 
-    const component = mount(<Collection minimum="1" summary={summaryCallback}><div className="hello">hello</div></Collection>)
-    expect(component.find('div.hello').length).toEqual(1)
-    expect(component.find('.details').length).toEqual(1)
-    expect(component.find('.summary').length).toEqual(1)
-    expect(i).toEqual(1)
+    const component = mount(<Collection minimum="2" summary={summaryCallback}><div className="hello">hello</div></Collection>)
+    expect(component.find('div.hello').length).toBeGreaterThan(0)
+    expect(component.find('.details').length).toBeGreaterThan(0)
+    expect(component.find('.summary').length).toBeGreaterThan(0)
+    expect(i).toEqual(2)
   })
 
   it('can toggle summary item', () => {
@@ -49,23 +49,36 @@ describe('The Collection component', () => {
       )
     }
 
-    const component = mount(<Collection minimum="1" summary={summaryCallback}><div className="hello">hello</div></Collection>)
-    expect(component.find('div.hello').length).toEqual(1)
-    expect(component.find('.details').length).toEqual(1)
-    expect(component.find('.summary').length).toEqual(1)
-    expect(i).toEqual(1)
+    const component = mount(
+      <Collection minimum="2" summary={summaryCallback}>
+        <div className="hello">hello</div>
+      </Collection>
+    )
+    expect(component.find('div.hello').length).toBeGreaterThan(0)
+    expect(component.find('.details').length).toBeGreaterThan(0)
+    expect(component.find('.summary').length).toBeGreaterThan(0)
+    expect(i).toEqual(2)
 
-    component.find('.toggle').simulate('click')
+    component.find('.toggle').first().simulate('click')
     expect(component.find('div.hello').length).toEqual(0)
     expect(component.find('.details').length).toEqual(0)
     expect(component.find('.summary').length).toEqual(1)
-    expect(i).toEqual(2)
+    expect(i).toEqual(4)
   })
 
   it('can remove item from collection', () => {
-    const component = mount(<Collection minimum="1"><div className="hello">hello</div></Collection>)
-    expect(component.find('div.hello').length).toEqual(1)
-    component.find('a.remove').simulate('click')
-    expect(component.find('div.hello').length).toEqual(0)
+    let i = 0
+    const summaryCallback = (item, index) => {
+      i++
+      return (
+        <div className="table">Item {index}</div>
+      )
+    }
+
+    const component = mount(<Collection minimum="2" summary={summaryCallback}><div className="hello">hello</div></Collection>)
+    expect(component.find('.summary').length).toBeGreaterThan(0)
+    component.find('a.remove').first().simulate('click')
+    expect(component.find('.summary').length).toEqual(0)
+    expect(i).toEqual(2)
   })
 })

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -111,7 +111,7 @@ export default class DateRange extends ValidationElement {
                        onValidate={this.handleValidation}
                        />
         </div>
-        <div className="usa-grid">
+        <div className="arrow">
           <img src="../img/date-down-arrow.svg" />
         </div>
         <div className="usa-grid">

--- a/src/components/Form/DateRange/DateRange.scss
+++ b/src/components/Form/DateRange/DateRange.scss
@@ -19,6 +19,17 @@
         display: inline-block;
     }
 
+    .arrow {
+        height: 0;
+
+        img {
+            width: 1rem;
+            height: auto;
+            margin-top: -6.8rem;
+            margin-left: 3rem;
+        }
+    }
+
     .from-present {
         display: inline-block;
         margin-top: 4.6rem;
@@ -27,11 +38,5 @@
         .or {
             margin-right: 1rem;
         }
-    }
-
-    img {
-        width: 1rem;
-        height: width;
-        margin-left: 3rem;
     }
 }

--- a/src/components/Section/Financial/Gambling/Gambling.jsx
+++ b/src/components/Section/Financial/Gambling/Gambling.jsx
@@ -125,7 +125,7 @@ export default class Gambling extends ValidationElement {
     }
 
     const dates = from === '' && to === ''
-      ? i18n.t('financial.gambling.collection.summary.nodates')
+          ? i18n.t('financial.gambling.collection.summary.nodates')
       : `${from} - ${to}`
 
     return (
@@ -153,47 +153,50 @@ export default class Gambling extends ValidationElement {
                   summaryTitle={i18n.t('financial.gambling.collection.summary.title')}
                   appendLabel={i18n.t('financial.gambling.collection.append')}>
 
+        <h3>{i18n.t('financial.gambling.heading.details')}</h3>
+
+        <h4>{i18n.t('financial.gambling.heading.dates')}</h4>
+        <Help id="financial.gambling.help.dates">
+          <DateRange name="Dates"
+                     label={i18n.t('financial.gambling.label.dates')}
+                     onValidate={this.handleValidation}
+                     />
+          <HelpIcon className="dates-help-icon" />
+        </Help>
+
+        <h4>{i18n.t('financial.gambling.heading.losses')}</h4>
+        <Help id="financial.gambling.help.losses">
+          <i className="fa fa-dollar"></i>
+          <Number name="Losses"
+                  className="losses"
+                  placeholder={i18n.t('financial.gambling.placeholder.losses')}
+                  label={i18n.t('financial.gambling.label.losses')}
+                  min="0"
+                  onValidate={this.handleValidation}
+                  />
+          <HelpIcon className="losses-help-icon" />
+        </Help>
+
+        <h4>{i18n.t('financial.gambling.heading.description')}</h4>
+        <Help id="financial.gambling.help.description">
+          <Textarea name="Description"
+                    className="description"
+                    onValidate={this.handleValidation}
+                    label={i18n.t('financial.gambling.label.description')}
+                    />
+          <HelpIcon className="description-help-icon" />
+        </Help>
+
         <Comments name="Comments"
                   title={i18n.t('financial.gambling.label.comments')}
                   label={i18n.t('financial.gambling.help.comments')}
-                  onValidate={this.handleValidation}
-                  >
-          <h3>{i18n.t('financial.gambling.label.dates')}</h3>
-          <Help id="financial.gambling.help.dates">
-            <DateRange name="Dates"
-                       onValidate={this.handleValidation}
-                       />
-            <HelpIcon className="dates-help-icon" />
-          </Help>
-
-          <h3>{i18n.t('financial.gambling.label.losses')}</h3>
-          <Help id="financial.gambling.help.losses">
-            <i className="fa fa-dollar"></i>
-            <Number name="Losses"
-                    className="losses"
-                    placeholder={i18n.t('financial.gambling.placeholder.losses')}
-                    min="0"
-                    onValidate={this.handleValidation}
-                    />
-            <HelpIcon className="losses-help-icon" />
-          </Help>
-
-          <h3>{i18n.t('financial.gambling.label.description')}</h3>
-          <Help id="financial.gambling.help.description">
-            <Textarea name="Description"
-                      className="description"
-                      onValidate={this.handleValidation}
-                      label={''}
-                      />
-            <HelpIcon className="description-help-icon" />
-          </Help>
-
-          <h3>{i18n.t('financial.gambling.label.actions')}</h3>
+                  onValidate={this.handleValidation}>
+          <h4>{i18n.t('financial.gambling.heading.actions')}</h4>
           <Help id="financial.gambling.help.actions">
             <Textarea name="Actions"
                       className="actions"
                       onValidate={this.handleValidation}
-                      label={''}
+                      label={i18n.t('financial.gambling.label.actions')}
                       />
             <HelpIcon className="actions-help-icon" />
           </Help>

--- a/src/components/Section/Financial/Gambling/Gambling.scss
+++ b/src/components/Section/Financial/Gambling/Gambling.scss
@@ -49,17 +49,14 @@
 
         .dates-help-icon {
             vertical-align: top;
-            margin-top: 15rem;
-        }
-
-        .losses-help-icon {
-            margin-top: 2.6rem;
+            margin-top: 7.3rem;
+            margin-left: -15rem;
         }
 
         .description-help-icon,
         .actions-help-icon {
             vertical-align: top;
-            margin-top: 8rem;
+            margin-top: 10rem;
         }
     }
 }

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -261,11 +261,19 @@ const en = {
         },
         append: 'Add another gambling debt'
       },
-      label: {
+      heading: {
+        details: 'Enter your gambling debt',
         dates: 'Provide the date range of your financial problems due to gambling',
         losses: 'Provide an estimate of the amount (in U.S. dollars) of gambling losses incurred',
         description: 'Provide a description of your financial problems due to gambling',
         actions: 'If you have taken any action(s) to rectify your financial problems due to gambling, provide a description of your actions. If you have not taken any action(s) provide an explanation.',
+        comments: 'Add optional comment'
+      },
+      label: {
+        dates: 'Dates of debt',
+        losses: 'Losses',
+        description: 'Description',
+        actions: 'Action(s) taken or explanation',
         comments: 'Add optional comment'
       },
       help: {

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -107,15 +107,23 @@
 				transition:background-color 0.3s, color 0.3s, border-color 0.3s;
 			}
 
+            label.usa-input-focus {
+                box-shadow: 0 0 3px #3e94cf, 0 0 7px #3e94cf
+            }
+
 			label.checked, label:hover {
 				color: #fff;
 				border: 1px solid $eapp-green;
 				background: $eapp-green;
 			}
 
-            label.usa-input-focus {
-                box-shadow: 0 0 3px #3e94cf, 0 0 7px #3e94cf
+            label.checked.usa-input-focus,
+            label.checked:focus,
+            input [type="checkbox"].usa-input-focus,
+            input [type="checkbox"]:focus {
+                box-shadow: none;
             }
+
 		}
 
 		/* handle block style radio and checkboxes that are NOT toggles */
@@ -155,7 +163,7 @@
 					input[type="checkbox"], input[type="radio"] {
 						height:1px;
 						width:1px;
-					}					
+					}
 					span {
 						display: block;
 						position: absolute;
@@ -199,7 +207,7 @@
 							width:3rem;
 							margin-left:-1.5rem;
 						}
-						
+
 					}
 				}
 			}


### PR DESCRIPTION
Punch list items referenced in #317 

- [x] Flow of adding a debt. Follow the flow from the "Where you have lived" comps. User clicks yes, form is loaded (no summary at this point), user fills out form, if user selects "add another" then summary is created and page scroll back up to condensed summary and new form loaded.
- [x] Active state is being applied to yes/no buttons
- [x] Margins on date entry. Match margins of date range to comp.
- [x] Add headline on debt entry. Add headline above "Provide the date range of your financial..." Headline should be "Enter your gambling debt".
- [x] Align help circle to "From date" (align like amount, description)
- [x] Hit box on "Estimated" and all check boxes should not be visible.
- [x] Add comment below explanation is adding comment to full section. The style used here is for a specific element only. If we need full section comments a different style will have to be comped up.
- [x] All inputs should have a label. For example "Provide a description of your financial problems due to gambling" input label should be "Description".