### PR TITLE
Reduce spacing around typeahead results

### DIFF
--- a/src/components/Form/Dropdown/Dropdown.scss
+++ b/src/components/Form/Dropdown/Dropdown.scss
@@ -32,7 +32,7 @@
                 margin-top: -0.5rem;
                 margin-bottom: 0rem;
                 margin-left: -1.7rem;
-                padding-top: 1.7rem;
+                padding-top: 0;
 
                 li {
                     margin-left: -1.64rem;
@@ -40,6 +40,12 @@
                     padding-top: 0.1rem;
                     padding-bottom: 0.1rem;
                     padding-left: 1.7rem;
+
+                    p {
+                        padding: 0;
+                        margin-top: 1rem;
+                        margin-bottom: 1rem;
+                    }
                 }
 
                 li:hover,


### PR DESCRIPTION
Issue #367 

Reduced the whitespace around the typeahead results.

![typeahead-styling](https://cloud.githubusercontent.com/assets/697855/22523534/be34b9cc-e88d-11e6-8d85-db908d7ae241.png)
