### PR TITLE
Fix for typo in birthplace help message

### DIFF
--- a/src/components/Form/Branch/Branch.jsx
+++ b/src/components/Form/Branch/Branch.jsx
@@ -32,22 +32,22 @@ export default class Branch extends React.Component {
             {this.props.children}
           </div>
           <div>
-              <Help id={this.props.help}>
-                <label>{this.props.label || ''}</label>
-                <RadioGroup className="option-list branch" selectedValue={this.state.value}>
-                  <Radio name={this.props.name}
-                    label={this.props.yesLabel}
-                    value={this.props.yesValue}
-                    onChange={this.yesNoClicked.bind(this, this.props.yesValue)}
-                  />
-                  <Radio name={this.props.name}
-                    label={this.props.noLabel}
-                    value={this.props.noValue}
-                    onChange={this.yesNoClicked.bind(this, this.props.noValue)}
-                  />
-                </RadioGroup>
-                <HelpIcon className="branch-help-icon" />
-              </Help>
+            <Help id={this.props.help}>
+              <label>{this.props.label || ''}</label>
+              <RadioGroup className="option-list branch" selectedValue={this.state.value}>
+                <Radio name={this.props.name}
+                       label={this.props.yesLabel}
+                       value={this.props.yesValue}
+                       onChange={this.yesNoClicked.bind(this, this.props.yesValue)}
+                       />
+                <Radio name={this.props.name}
+                       label={this.props.noLabel}
+                       value={this.props.noValue}
+                       onChange={this.yesNoClicked.bind(this, this.props.noValue)}
+                       />
+              </RadioGroup>
+              <HelpIcon className="branch-help-icon" />
+            </Help>
           </div>
         </div>
       )
@@ -61,15 +61,15 @@ export default class Branch extends React.Component {
         <label>{this.props.label || ''}</label>
         <RadioGroup className="option-list branch" selectedValue={this.state.value}>
           <Radio name={this.props.name}
-            label={this.props.yesLabel}
-            value={this.props.yesValue}
-            onChange={this.yesNoClicked.bind(this, this.props.yesValue)}
-          />
+                 label={this.props.yesLabel}
+                 value={this.props.yesValue}
+                 onChange={this.yesNoClicked.bind(this, this.props.yesValue)}
+                 />
           <Radio name={this.props.name}
-            label={this.props.noLabel}
-            value={this.props.noValue}
-            onChange={this.yesNoClicked.bind(this, this.props.noValue)}
-          />
+                 label={this.props.noLabel}
+                 value={this.props.noValue}
+                 onChange={this.yesNoClicked.bind(this, this.props.noValue)}
+                 />
         </RadioGroup>
       </div>
     )

--- a/src/components/Form/Weight/Weight.jsx
+++ b/src/components/Form/Weight/Weight.jsx
@@ -84,7 +84,7 @@ export default class Weight extends ValidationElement {
                   label={i18n.t('identification.traits.label.pounds')}
                   placeholder={i18n.t('identification.traits.placeholder.pounds')}
                   aria-describedby={this.errorName('weight')}
-                  help={i18n.t('identification.traits.help.pounds')}
+                  help="identification.traits.help.pounds"
                   disabled={this.state.disabled}
                   max="999"
                   maxlength="3"

--- a/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.jsx
+++ b/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.jsx
@@ -188,7 +188,7 @@ export default class ApplicantBirthPlace extends ValidationElement {
     return (
       <Branch name="is_domestic"
               value={this.state.domestic}
-              help={i18n.t('identification.birthplace.branch.help')}
+              help="identification.birthplace.branch.help"
               label={i18n.t('identification.birthplace.question.label')}
               onUpdate={this.onUpdate.bind(this)}>
       </Branch>

--- a/src/components/Section/Identification/Physical/Physical.jsx
+++ b/src/components/Section/Identification/Physical/Physical.jsx
@@ -114,7 +114,7 @@ export default class Physical extends ValidationElement {
         <div className={klass + ' no-label hair-colors'}>
           <Help id="identification.traits.help.hair">
             <HairColor name="hair"
-                       help={i18n.t('identification.traits.help.hair')}
+                       help="identification.traits.help.hair"
                        className=""
                        value={this.props.HairColor}
                        onUpdate={this.handleUpdate.bind(this, 'HairColor')}

--- a/src/config/locales/i18n.js
+++ b/src/config/locales/i18n.js
@@ -1,4 +1,4 @@
-import en from './en.js'
+import en from './en'
 
 const locales = { en }
 


### PR DESCRIPTION
Issue #365 

Fix was to pass in the locale ID as intended instead of the translated text. So do this:

```js
help="identification.birthplace.branch.help"
```

instead of this

```js
help={i18n.t('identification.birthplace.branch.help')}
```