### PR TITLE
Relocate error messages, locales, and injection into validation methods

### DIFF
--- a/src/components/Form/Address/Address.test.jsx
+++ b/src/components/Form/Address/Address.test.jsx
@@ -7,12 +7,11 @@ describe('The Address component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Address name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Address name={expected.name} label={expected.label} value={expected.value} />)
     component.find('textarea[name="address"]').simulate('change')
-    expect(component.find('div.hidden').length).toBeGreaterThan(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -20,7 +19,6 @@ describe('The Address component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -38,7 +36,6 @@ describe('The Address component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -56,7 +53,6 @@ describe('The Address component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -74,7 +70,6 @@ describe('The Address component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/ApoFpo/ApoFpo.jsx
+++ b/src/components/Form/ApoFpo/ApoFpo.jsx
@@ -7,11 +7,6 @@ export default class ApoFpo extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false
@@ -38,10 +33,9 @@ export default class ApoFpo extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             minlength="2"
             maxlength="2"
             required="true"

--- a/src/components/Form/ApoFpo/ApoFpo.test.jsx
+++ b/src/components/Form/ApoFpo/ApoFpo.test.jsx
@@ -7,13 +7,12 @@ describe('The ApoFpo component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<ApoFpo name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<ApoFpo name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Checkbox/Checkbox.jsx
+++ b/src/components/Form/Checkbox/Checkbox.jsx
@@ -5,13 +5,6 @@ export default class Checkbox extends ValidationElement {
   constructor (props) {
     super(props)
     this.state = {
-      name: props.name,
-      label: props.label,
-      value: props.value,
-      help: props.help,
-      disabled: props.disabled,
-      readonly: props.readonly,
-      required: props.required,
       checked: props.checked,
       focus: props.focus || false,
       error: props.error || false,
@@ -56,13 +49,6 @@ export default class Checkbox extends ValidationElement {
   }
 
   /**
-   * Generated name for the error message.
-   */
-  errorName () {
-    return '' + this.state.name + '-error'
-  }
-
-  /**
    * Style classes applied to the wrapper.
    */
   divClass () {
@@ -98,21 +84,6 @@ export default class Checkbox extends ValidationElement {
   }
 
   /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
-  /**
    * Style classes applied to the input element.
    */
   inputClass () {
@@ -130,27 +101,22 @@ export default class Checkbox extends ValidationElement {
       return (
         <div className={this.divClass()}>
           <input className={this.inputClass()}
-                 id={this.state.name}
-                 name={this.state.name}
+                 id={this.props.name}
+                 name={this.props.name}
                  type="checkbox"
-                 aria-describedby={this.errorName()}
-                 disabled={this.state.disabled}
-                 readOnly={this.state.readonly}
-                 value={this.state.value}
+                 disabled={this.props.disabled}
+                 readOnly={this.props.readonly}
+                 value={this.props.value}
                  onChange={this.handleChange}
                  onFocus={this.handleFocus}
                  onBlur={this.handleBlur}
                  checked={this.state.checked}
                  />
           <label className={this.labelClass()}
-                 htmlFor={this.state.name}>
+                 htmlFor={this.props.name}>
             {this.props.children}
-            <span>{this.state.label}</span>
+            <span>{this.props.label}</span>
           </label>
-          <div className={this.errorClass()}>
-            <i className="fa fa-exclamation"></i>
-            {this.state.help}
-          </div>
         </div>
       )
     }
@@ -158,27 +124,22 @@ export default class Checkbox extends ValidationElement {
     return (
       <div className={this.divClass()}>
         <label className={this.labelClass()}
-               htmlFor={this.state.name}>
+               htmlFor={this.props.name}>
           <input className={this.inputClass()}
-                 id={this.state.name}
-                 name={this.state.name}
+                 id={this.props.name}
+                 name={this.props.name}
                  type="checkbox"
-                 aria-describedby={this.errorName()}
-                 disabled={this.state.disabled}
-                 readOnly={this.state.readonly}
-                 value={this.state.value}
+                 disabled={this.props.disabled}
+                 readOnly={this.props.readonly}
+                 value={this.props.value}
                  onChange={this.handleChange}
                  onFocus={this.handleFocus}
                  onBlur={this.handleBlur}
                  checked={this.state.checked}
                  />
           {this.props.children}
-          <span>{this.state.label}</span>
+          <span>{this.props.label}</span>
         </label>
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.state.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Form/Checkbox/Checkbox.test.jsx
+++ b/src/components/Form/Checkbox/Checkbox.test.jsx
@@ -7,63 +7,58 @@ describe('The checkbox component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false
     }
-    const component = mount(<Checkbox name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Checkbox name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       error: false,
       focus: true,
       valid: false
     }
-    const component = mount(<Checkbox name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Checkbox name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(false)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Text input success',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: true
     }
-    const component = mount(<Checkbox name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Checkbox name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Text input label',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<Checkbox name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Checkbox name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -71,7 +66,6 @@ describe('The checkbox component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -89,7 +83,6 @@ describe('The checkbox component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -107,7 +100,6 @@ describe('The checkbox component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -125,7 +117,6 @@ describe('The checkbox component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/City/City.jsx
+++ b/src/components/Form/City/City.jsx
@@ -8,10 +8,6 @@ export default class City extends ValidationElement {
 
     this.state = {
       name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false,
@@ -57,10 +53,9 @@ export default class City extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             minlength="2"
             maxlength="100"
             required="true"

--- a/src/components/Form/City/City.test.jsx
+++ b/src/components/Form/City/City.test.jsx
@@ -7,13 +7,12 @@ describe('The City component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<City name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<City name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Code/Code.jsx
+++ b/src/components/Form/Code/Code.jsx
@@ -7,11 +7,6 @@ export default class Code extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false
@@ -38,10 +33,9 @@ export default class Code extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             minlength="2"
             maxlength="2"
             required="true"

--- a/src/components/Form/Code/Code.test.jsx
+++ b/src/components/Form/Code/Code.test.jsx
@@ -7,41 +7,38 @@ describe('The Code component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Code name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Code name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('error on minimum length', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: '1'
     }
-    const component = mount(<Code name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Code name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 
   it('error on maximum length', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: '123'
     }
-    const component = mount(<Code name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Code name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 })

--- a/src/components/Form/County/County.jsx
+++ b/src/components/Form/County/County.jsx
@@ -7,11 +7,6 @@ export default class County extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false,
@@ -57,10 +52,9 @@ export default class County extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             minlength="2"
             maxlength="100"
             required="true"

--- a/src/components/Form/County/County.test.jsx
+++ b/src/components/Form/County/County.test.jsx
@@ -7,14 +7,13 @@ describe('The County component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<County name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<County name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -22,7 +21,6 @@ describe('The County component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -40,7 +38,6 @@ describe('The County component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -58,7 +55,6 @@ describe('The County component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -76,7 +72,6 @@ describe('The County component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -8,14 +8,7 @@ export default class DateControl extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
       disabled: props.disabled,
-      pattern: props.pattern,
-      readonly: props.readonly,
-      required: props.required,
       value: props.value,
       estimated: props.estimated,
       focus: props.focus || false,
@@ -290,8 +283,8 @@ export default class DateControl extends ValidationElement {
                     max="12"
                     maxlength="2"
                     min="1"
-                    readonly={this.state.readonly}
-                    required={this.state.required}
+                    readonly={this.props.readonly}
+                    required={this.props.required}
                     step="1"
                     value={this.state.month}
                     focus={this.state.foci[0]}
@@ -311,8 +304,8 @@ export default class DateControl extends ValidationElement {
                     max="31"
                     maxlength="2"
                     min="1"
-                    readonly={this.state.readonly}
-                    required={this.state.required}
+                    readonly={this.props.readonly}
+                    required={this.props.required}
                     step="1"
                     value={this.state.day}
                     focus={this.state.foci[1]}
@@ -332,8 +325,8 @@ export default class DateControl extends ValidationElement {
                     max="9999"
                     maxlength="4"
                     min="1775"
-                    pattern={this.state.pattern}
-                    readonly={this.state.readonly}
+                    pattern={this.props.pattern}
+                    readonly={this.props.readonly}
                     step="1"
                     value={this.state.year}
                     focus={this.state.foci[2]}
@@ -347,7 +340,6 @@ export default class DateControl extends ValidationElement {
         <div className="coupled-flags">
           <Checkbox name="estimated"
                     label="Estimated"
-                    help=""
                     toggle="false"
                     className={this.props.className}
                     value={this.state.estimated}

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -9,12 +9,11 @@ describe('The date component', () => {
     const expected = {
       name: 'input-error',
       label: 'DateControl input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('input#month').length).toEqual(1)
   })
 
@@ -22,122 +21,115 @@ describe('The date component', () => {
     const expected = {
       name: 'input-focus',
       label: 'DateControl input focused',
-      help: 'Helpful error message',
       error: false,
       focus: true,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     component.find('input#month').simulate('focus')
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
     expect(component.find('input#month').hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'DateControl input success',
-      help: 'Helpful error message',
       value: '01-28-2016'
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
     component.find('input#month').simulate('change')
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('1')
     expect(component.find('input#month').hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'DateControl input label',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders with valid date', () => {
     const expected = {
       name: 'input-type-text',
       label: 'DateControl input label',
-      help: 'Helpful error message',
       value: '01-28-2016',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('1')
     expect(component.find('input#day').nodes[0].value).toEqual('28')
     expect(component.find('input#year').nodes[0].value).toEqual('2016')
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders with invalid date', () => {
     const expected = {
       name: 'input-type-text',
       label: 'DateControl input label',
-      help: 'Helpful error message',
       value: '99-28-2016',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('')
     expect(component.find('input#day').nodes[0].value).toEqual('')
     expect(component.find('input#year').nodes[0].value).toEqual('')
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders with undefined date', () => {
     const expected = {
       name: 'input-type-text',
       label: 'DateControl input label',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('')
     expect(component.find('input#day').nodes[0].value).toEqual('')
     expect(component.find('input#year').nodes[0].value).toEqual('')
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders with date as random input', () => {
     const expected = {
       name: 'input-type-text',
       label: 'DateControl input label',
-      help: 'Helpful error message',
       value: 'the quick brown fox...',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#month').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('')
     expect(component.find('input#day').nodes[0].value).toEqual('')
     expect(component.find('input#year').nodes[0].value).toEqual('')
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -79,21 +79,6 @@ export default class DateRange extends ValidationElement {
     })
   }
 
-  /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
   render () {
     const klass = `daterange usa-grid ${this.props.className || ''}`.trim()
 
@@ -136,10 +121,6 @@ export default class DateRange extends ValidationElement {
               <span>Present</span>
             </Checkbox>
           </div>
-        </div>
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.state.error}
         </div>
       </div>
     )

--- a/src/components/Form/Dropdown/Dropdown.jsx
+++ b/src/components/Form/Dropdown/Dropdown.jsx
@@ -161,13 +161,6 @@ export default class Dropdown extends ValidationElement {
   }
 
   /**
-   * Generated name for the error message.
-   */
-  errorName () {
-    return '' + this.props.name + '-error'
-  }
-
-  /**
    * Style classes applied to the wrapper.
    */
   divClass () {
@@ -189,21 +182,6 @@ export default class Dropdown extends ValidationElement {
 
     if (this.state.error) {
       klass += ' usa-input-error-label'
-    }
-
-    return klass.trim()
-  }
-
-  /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
     }
 
     return klass.trim()
@@ -253,10 +231,6 @@ export default class Dropdown extends ValidationElement {
                      renderSuggestion={renderSuggestion}
                      inputProps={inputProps}
                      />
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.props.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Form/Email/Email.jsx
+++ b/src/components/Form/Email/Email.jsx
@@ -63,7 +63,6 @@ export default class Email extends ValidationElement {
                label={this.props.label}
                placeholder={this.props.placeholder}
                className={`email ${this.props.className || ''}`.trim()}
-               help={this.props.help}
                type="email"
                disabled={this.props.disabled}
                maxlength={this.props.maxlength}

--- a/src/components/Form/Email/Email.test.jsx
+++ b/src/components/Form/Email/Email.test.jsx
@@ -94,7 +94,7 @@ describe('The Email component', () => {
     tests.forEach((t) => {
       const component = mount(<Email name="test-emails" label="Email" value={t.address} />)
       component.find('input').simulate('blur')
-      expect(component.find('div.hidden').length).toEqual(t.valid ? 1 : 1)
+      expect(component.find('.usa-input-error-label').length).toEqual(t.valid ? 0 : 1)
     })
   })
 })

--- a/src/components/Form/EyeColor/EyeColor.jsx
+++ b/src/components/Form/EyeColor/EyeColor.jsx
@@ -33,7 +33,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.black')}
                  value="Black"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -54,7 +53,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.blue')}
                  value="Blue"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -75,7 +73,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.brown')}
                  value="Brown"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -96,7 +93,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.gray')}
                  value="Gray"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -117,7 +113,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.green')}
                  value="Green"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -138,7 +133,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.hazel')}
                  value="Hazel"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -159,7 +153,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.maroon')}
                  value="Maroon"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -180,7 +173,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.multi')}
                  value="Multicolored"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -194,7 +186,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.pink')}
                  value="Pink"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}
@@ -215,7 +206,6 @@ export default class EyeColor extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.eye.unknown')}
                  value="Unknown"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  onChange={this.handleChange}
                  onValidate={this.props.onValidate}

--- a/src/components/Form/EyeColor/EyeColor.test.jsx
+++ b/src/components/Form/EyeColor/EyeColor.test.jsx
@@ -7,12 +7,11 @@ describe('The EyeColor component', () => {
     const expected = {
       name: 'eye-color',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<EyeColor name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<EyeColor name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input[name="eye-color"]').first().simulate('change')
     expect(component.find('input[name="eye-color"]').length).toEqual(10)
-    expect(component.find('div.hidden').length).toEqual(10)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Generic/Generic.jsx
+++ b/src/components/Form/Generic/Generic.jsx
@@ -142,21 +142,6 @@ export default class Generic extends ValidationElement {
   }
 
   /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error && this.props.help) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
-  /**
    * Style classes applied to the input element.
    */
   inputClass () {
@@ -209,10 +194,6 @@ export default class Generic extends ValidationElement {
                onPaste={this.props.onPaste}
                ref="input"
                />
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.props.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Form/Generic/Generic.test.jsx
+++ b/src/components/Form/Generic/Generic.test.jsx
@@ -7,66 +7,58 @@ describe('The generic component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       type: 'text',
       error: true,
       focus: false,
       valid: false
     }
-    const component = shallow(<Generic name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Generic name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: true,
       valid: false
     }
-    const component = shallow(<Generic name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Generic name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Text input success',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: true
     }
-    const component = shallow(<Generic name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Generic name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Text input label',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: false
     }
-    const component = shallow(<Generic name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Generic name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
   })
 })

--- a/src/components/Form/HairColor/HairColor.jsx
+++ b/src/components/Form/HairColor/HairColor.jsx
@@ -60,7 +60,6 @@ export default class HairColor extends ValidationElement {
                     label={i18n.t('identification.traits.hair.bald')}
                     value="Bald"
                     labelClass="black"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -76,7 +75,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-black"
                     label={i18n.t('identification.traits.hair.black')}
                     value="Black"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -94,7 +92,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-blonde"
                     label={i18n.t('identification.traits.hair.blonde')}
                     value="Blonde"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -112,7 +109,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-brown"
                     label={i18n.t('identification.traits.hair.brown')}
                     value="Brown"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -130,7 +126,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-gray"
                     label={i18n.t('identification.traits.hair.gray')}
                     value="Gray"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -148,7 +143,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-red"
                     label={i18n.t('identification.traits.hair.red')}
                     value="Red"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -166,7 +160,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-sandy"
                     label={i18n.t('identification.traits.hair.sandy')}
                     value="Sandy"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -184,7 +177,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-white"
                     label={i18n.t('identification.traits.hair.white')}
                     value="White"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -202,7 +194,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-blue"
                     label={i18n.t('identification.traits.hair.blue')}
                     value="Blue"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -220,7 +211,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-green"
                     label={i18n.t('identification.traits.hair.green')}
                     value="Green"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -238,7 +228,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-orange"
                     label={i18n.t('identification.traits.hair.orange')}
                     value="Orange"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -256,7 +245,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-pink"
                     label={i18n.t('identification.traits.hair.pink')}
                     value="Pink"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -274,7 +262,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-purple"
                     label={i18n.t('identification.traits.hair.purple')}
                     value="Purple"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}
@@ -292,7 +279,6 @@ export default class HairColor extends ValidationElement {
           <Checkbox name="hair-unknown"
                     label={i18n.t('identification.traits.hair.unknown')}
                     value="Unknown"
-                    help={this.props.help}
                     disabled={this.props.disabled}
                     onChange={this.handleChange}
                     onValidate={this.handleValidation}

--- a/src/components/Form/HairColor/HairColor.test.jsx
+++ b/src/components/Form/HairColor/HairColor.test.jsx
@@ -7,12 +7,11 @@ describe('The HairColor component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<HairColor name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<HairColor name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#hair-bald').simulate('change')
     expect(component.find('input').length).toEqual(14)
-    expect(component.find('div.hidden').length).toEqual(14)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Height/Height.jsx
+++ b/src/components/Form/Height/Height.jsx
@@ -36,8 +36,8 @@ export default class Height extends ValidationElement {
    */
   handleValidation (event, status, errors) {
     this.setState({error: status === false, valid: status === true, errors: errors}, () => {
-      let e = { [this.state.name]: errors }
-      let s = { [this.state.name]: { status: status } }
+      let e = { [this.props.name]: errors }
+      let s = { [this.props.name]: { status: status } }
       super.handleValidation(event, s, e)
     })
   }
@@ -61,49 +61,10 @@ export default class Height extends ValidationElement {
   }
 
   /**
-   * Generated name for the error message.
-   */
-  errorName (part) {
-    return '' + this.props.name + '-' + part + '-error'
-  }
-
-  /**
    * Generated name for the part of the address elements.
    */
   partName (part) {
     return '' + this.props.name + '-' + part
-  }
-
-  /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.errors && (this.state.errors.inches || this.state.errors.feet)) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
-  errorMessage () {
-    let message = ''
-    if (!this.state.errors) {
-      return message
-    }
-
-    for (let e in this.state.errors) {
-      console.log('e', e)
-      console.log('e-more', this.state.errors[e])
-      if (this.state.errors[e]) {
-        message += i18n.t(`identification.traits.help.${e}`)
-      }
-    }
-
-    return message
   }
 
   render () {
@@ -114,7 +75,6 @@ export default class Height extends ValidationElement {
                   name="feet"
                   label={i18n.t('identification.traits.label.feet')}
                   placeholder={i18n.t('identification.traits.placeholder.feet')}
-                  aria-describedby={this.errorName('feet')}
                   disabled={this.props.disabled}
                   max="9"
                   maxlength="1"
@@ -134,7 +94,6 @@ export default class Height extends ValidationElement {
                   name="inches"
                   label={i18n.t('identification.traits.label.inches')}
                   placeholder={i18n.t('identification.traits.placeholder.inches')}
-                  aria-describedby={this.errorName('inches')}
                   disabled={this.props.disabled}
                   max="11"
                   maxlength="2"
@@ -148,10 +107,6 @@ export default class Height extends ValidationElement {
                   onBlur={this.handleBlur}
                   onValidate={this.handleValidation}
                   />
-        </div>
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.errorMessage()}
         </div>
       </div>
     )

--- a/src/components/Form/Height/Height.test.jsx
+++ b/src/components/Form/Height/Height.test.jsx
@@ -7,24 +7,22 @@ describe('The Height component', () => {
     let expected = {
       name: 'height',
       label: 'Feet',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Height name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Height name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#feet').simulate('change')
     expect(component.find('label[htmlFor="feet"]').text()).toEqual(expected.label)
     expect(component.find('input[name="feet"]').length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(3)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
 
     expected = {
       name: 'height',
       label: 'Inches',
-      help: 'Helpful error message',
       value: ''
     }
     component.find('input#inches').simulate('change')
     expect(component.find('label[htmlFor="inches"]').text()).toEqual(expected.label)
     expect(component.find('input[name="inches"]').length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(3)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Help/Help.scss
+++ b/src/components/Form/Help/Help.scss
@@ -1,45 +1,53 @@
 @import 'eqip-colors';
 
 .help {
-    padding-top:4.6rem;
-    line-height:4.6rem;
+    padding-top: 4.6rem;
+    line-height: 4.6rem;
 
 	> label {
-		top:0 !important;
+		top: 0 !important;
 	}
+
     .toggle {
         display: inline-block;
         vertical-align: top;
 		margin-left: 0.8rem;
 
 		svg {
-			display:inline-block;
-            height:3.7rem;
-			vertical-align:middle;
-	    	.eapp-help-icon, .eapp-help-circle {
-			    transition:fill 0.3s;
+			display: inline-block;
+            height: 3.7rem;
+			vertical-align: middle;
+
+	    	.eapp-help-icon,
+            .eapp-help-circle {
+			    transition: fill 0.3s;
 			}
+
 	    	.eapp-help-icon {
-	        	fill:$eapp-blue-light;
+	        	fill: $eapp-blue-light;
         	}
+
 	    	.eapp-help-circle {
-			    fill:$eapp-blue-lightest;
+			    fill: $eapp-blue-lightest;
 		    }
         }
-        &:hover, &.active {
+
+        &:hover,
+        &.active {
             svg {
 		    	.eapp-help-icon {
-		        	fill:$eapp-blue-lightest;
+		        	fill: $eapp-blue-lightest;
 	        	}
+
 		    	.eapp-help-circle {
-				    fill:$eapp-blue-light;
+				    fill: $eapp-blue-light;
 			    }
             }
         }
     }
 
     .message {
-		width:93%;
+		width: 93%;
         padding: 2rem 3rem 3.5rem 3rem;
         background: $eapp-blue-lightest;
         border: 2px solid $eapp-blue-lighter;
@@ -59,25 +67,29 @@
             background: $eapp-blue-light;
             border-radius: 50%;
         }
+
 		div * {
-			padding:0 !important;
+			padding: 0 !important;
 		}
+
         .eapp-help-close {
             display: block;
             margin-top: 1rem;
         }
+
         &.eapp-error-message {
-	        background:$eapp-red-lightest;
-			border-color:$eapp-red-light;
-			width:100%;
+	        background: $eapp-red-lightest;
+			border-color: $eapp-red-light;
+
 			> i {
-				background-color:$eapp-red;
+				background-color: $eapp-red;
 			}
         }
     }
 }
+
 .no-label {
 	.help {
-		padding-top:0;
+		padding-top: 0;
 	}
 }

--- a/src/components/Form/MaidenName/MaidenName.jsx
+++ b/src/components/Form/MaidenName/MaidenName.jsx
@@ -68,7 +68,6 @@ export default class MaidenName extends ValidationElement {
           <Radio name="maiden-name"
                  label=""
                  value="Yes"
-                 help={this.props.help}
                  disabled={this.props.disabled}
                  readonly={this.props.readonly}
                  required={this.props.required}
@@ -85,10 +84,9 @@ export default class MaidenName extends ValidationElement {
           <Radio name="maiden-name"
                  label=""
                  value="No"
-                 help={this.state.help}
-                 disabled={this.state.disabled}
-                 readonly={this.state.readonly}
-                 required={this.state.required}
+                 disabled={this.props.disabled}
+                 readonly={this.props.readonly}
+                 required={this.props.required}
                  focus={this.state.focus}
                  error={this.state.error}
                  valid={this.state.valid}

--- a/src/components/Form/MilitaryState/MilitaryState.jsx
+++ b/src/components/Form/MilitaryState/MilitaryState.jsx
@@ -9,7 +9,6 @@ export default class MilitaryState extends ValidationElement {
       return (
         <State name={this.props.name}
                label={this.props.label}
-               help={this.props.help}
                placeholder={this.props.placeholder}
                className={this.props.className}
                disabled={this.props.disabled}
@@ -30,7 +29,6 @@ export default class MilitaryState extends ValidationElement {
       return (
         <Dropdown name={this.props.name}
                   label={this.props.label}
-                  help={this.props.help}
                   placeholder={this.props.placeholder}
                   className={this.props.className}
                   disabled={this.props.disabled}

--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -11,8 +11,6 @@ export default class Name extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
       first: props.first,
       firstInitialOnly: props.firstInitialOnly,
       last: props.last,
@@ -116,8 +114,8 @@ export default class Name extends ValidationElement {
     }
 
     this.setState({error: complexStatus === false, valid: complexStatus === true, errorCodes: codes}, () => {
-      let e = { [this.state.name]: codes }
-      let s = { [this.state.name]: { status: complexStatus } }
+      let e = { [this.props.name]: codes }
+      let s = { [this.props.name]: { status: complexStatus } }
       if (this.state.error === false || this.state.valid === true) {
         super.handleValidation(event, s, e)
         return
@@ -151,7 +149,7 @@ export default class Name extends ValidationElement {
    * Generated name for the part of the address elements.
    */
   partName (part) {
-    return '' + this.state.name + '-' + part
+    return '' + this.props.name + '-' + part
   }
 
   /**
@@ -176,14 +174,13 @@ export default class Name extends ValidationElement {
     return (
       <div className={klass}>
         {this.props.title && <h2>{this.props.title}</h2>}
-        <Help id="identification.name.first.help">
+        <Help id="identification.name.first.help" errorPrefix="name">
           <Text name="first"
                 label="First name"
                 pattern="^[a-zA-Z\-\.' ]*$"
                 maxlength="100"
                 className="first"
                 placeholder="Please enter your first name or initial"
-                help="The first name (or initial) is optional but cannot exceed 100 characters"
                 value={this.state.first}
                 onChange={this.handleChange}
                 onValidate={this.handleValidation}
@@ -192,23 +189,21 @@ export default class Name extends ValidationElement {
                 />
           <HelpIcon />
           <div className="text-right">
-            <input
-              id="firstInitialOnly"
-              type="checkbox"
-              value="firstInitial"
-              checked={this.props.firstInitialOnly}
-              onChange={this.handleChange} />
+            <input id="firstInitialOnly"
+                   type="checkbox"
+                   value="firstInitial"
+                   checked={this.props.firstInitialOnly}
+                   onChange={this.handleChange} />
             <label>Initial Only</label>
           </div>
         </Help>
-        <Help id="identification.name.middle.help">
+        <Help id="identification.name.middle.help" errorPrefix="name">
           <Text name="middle"
                 label="Middle name or initial"
                 minlength="0"
                 maxlength="100"
                 className="middle"
                 placeholder="Please enter your middle name or initial"
-                help="The middle name (or initial) is optional but cannot exceed 100 characters"
                 value={this.state.middle}
                 onChange={this.handleChange}
                 onValidate={this.handleValidation}
@@ -235,14 +230,13 @@ export default class Name extends ValidationElement {
             </div>
           </div>
         </Help>
-        <Help id="identification.name.last.help">
+        <Help id="identification.name.last.help" errorPrefix="name">
           <Text name="last"
                 label="Last name"
                 maxlength="100"
                 className="last"
                 pattern="^[a-zA-Z\-\.' ]*$"
                 placeholder="Please enter your last name"
-                help="The last name is required, cannot exceed 100 characters, and we only support letters, hyphens (-), periods (.), apostrophes ('), and spaces."
                 value={this.state.last}
                 onChange={this.handleChange}
                 onValidate={this.handleValidation}
@@ -251,16 +245,15 @@ export default class Name extends ValidationElement {
                 />
           <HelpIcon />
           <div className="text-right">
-            <input
-              id="lastInitialOnly"
-              type="checkbox"
-              value="lastInitial"
-              checked={this.props.lastInitialOnly}
-              onChange={this.handleChange} />
+            <input id="lastInitialOnly"
+                   type="checkbox"
+                   value="lastInitial"
+                   checked={this.props.lastInitialOnly}
+                   onChange={this.handleChange} />
             <label>Initial Only</label>
           </div>
         </Help>
-        <Help id="identification.name.suffix.help" scrollIntoView="true">
+        <Help id="identification.name.suffix.help" errorPrefix="name" scrollIntoView="true">
           <label>Suffix <span className="optional">(Optional)</span></label>
 
           <RadioGroup className="option-list suffix" selectedValue={this.state.suffix}>

--- a/src/components/Form/Name/Name.test.jsx
+++ b/src/components/Form/Name/Name.test.jsx
@@ -7,10 +7,9 @@ describe('The Name component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Name name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Name name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#last').simulate('change')
     expect(component.find('div.hidden').length).toBeGreaterThan(0)
   })
@@ -61,7 +60,7 @@ describe('The Name component', () => {
     expected.forEach((ex) => {
       const component = mount(<Name name={ex.name} first={ex.first} last={ex.last} middle={ex.middle} />)
       component.find('input#' + ex.part).simulate('change')
-      expect(component.find('div.hidden').length === component.find('span').length).toEqual(ex.valid)
+      expect(component.find('.usa-input-error-label').length === component.find('span').length).toEqual(ex.valid)
     })
   })
 
@@ -70,7 +69,6 @@ describe('The Name component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -88,7 +86,6 @@ describe('The Name component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -106,7 +103,6 @@ describe('The Name component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -124,7 +120,6 @@ describe('The Name component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -164,21 +164,6 @@ export default class Number extends ValidationElement {
   }
 
   /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error && this.state.help) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
-  /**
    * Style classes applied to the input element.
    */
   inputClass () {
@@ -216,10 +201,6 @@ export default class Number extends ValidationElement {
                onFocus={this.handleFocus}
                onBlur={this.handleBlur}
                />
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.state.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Form/Number/Number.test.jsx
+++ b/src/components/Form/Number/Number.test.jsx
@@ -7,66 +7,61 @@ describe('The number component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       type: 'text',
       error: true,
       focus: false,
       valid: false
     }
-    const component = shallow(<Number name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Number name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: true,
       valid: false
     }
-    const component = shallow(<Number name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Number name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Text input success',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: true
     }
-    const component = shallow(<Number name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Number name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Text input label',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: false
     }
-    const component = shallow(<Number name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = shallow(<Number name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Password/Password.jsx
+++ b/src/components/Form/Password/Password.jsx
@@ -7,15 +7,6 @@ export default class Password extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      disabled: props.disabled,
-      maxlength: props.maxlength,
-      pattern: props.pattern,
-      readonly: props.readonly,
-      required: props.required,
       value: props.value,
       focus: props.focus || false,
       error: props.error || false,
@@ -61,16 +52,15 @@ export default class Password extends ValidationElement {
 
   render () {
     return (
-      <Generic name={this.state.name}
-               label={this.state.label}
-               placeholder={this.state.placeholder}
-               help={this.state.help}
+      <Generic name={this.props.name}
+               label={this.props.label}
+               placeholder={this.props.placeholder}
                type="password"
-               disabled={this.state.disabled}
-               maxlength={this.state.maxlength}
-               pattern={this.state.pattern}
-               readonly={this.state.readonly}
-               required={this.state.required}
+               disabled={this.props.disabled}
+               maxlength={this.props.maxlength}
+               pattern={this.props.pattern}
+               readonly={this.props.readonly}
+               required={this.props.required}
                value={this.state.value}
                focus={this.state.focus}
                error={this.state.error}

--- a/src/components/Form/Radio/Radio.jsx
+++ b/src/components/Form/Radio/Radio.jsx
@@ -73,13 +73,6 @@ export default class Radio extends ValidationElement {
   }
 
   /**
-   * Generated name for the error message.
-   */
-  errorName () {
-    return '' + this.state.name + '-error'
-  }
-
-  /**
    * Style classes applied to the wrapper.
    */
   divClass () {
@@ -108,21 +101,6 @@ export default class Radio extends ValidationElement {
 
     if (this.state.focus) {
       klass += ' usa-input-focus'
-    }
-
-    return klass.trim()
-  }
-
-  /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
     }
 
     return klass.trim()
@@ -164,7 +142,6 @@ export default class Radio extends ValidationElement {
                  id={id}
                  name={this.state.name}
                  type="radio"
-                 aria-describedby={this.errorName()}
                  disabled={this.state.disabled}
                  readOnly={this.state.readonly}
                  value={this.state.value}
@@ -177,10 +154,6 @@ export default class Radio extends ValidationElement {
           {this.props.children}
           <span>{this.state.label}</span>
         </label>
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.state.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Form/Radio/Radio.test.jsx
+++ b/src/components/Form/Radio/Radio.test.jsx
@@ -7,61 +7,56 @@ describe('The radio component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false
     }
-    const component = mount(<Radio name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Radio name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
     expect(component.find('input[name="' + expected.name + '"]').length).toEqual(1)
-    expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       error: false,
       focus: true,
       valid: false
     }
-    const component = mount(<Radio name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Radio name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input[name="' + expected.name + '"]').length).toEqual(1)
     expect(component.find('input[name="' + expected.name + '"]').hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Text input success',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: true
     }
-    const component = mount(<Radio name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Radio name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Text input label',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<Radio name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Radio name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input[name="' + expected.name + '"]').length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -69,7 +64,6 @@ describe('The radio component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -87,7 +81,6 @@ describe('The radio component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -105,7 +98,6 @@ describe('The radio component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -123,7 +115,6 @@ describe('The radio component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/Service/Service.jsx
+++ b/src/components/Form/Service/Service.jsx
@@ -7,11 +7,6 @@ export default class Service extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false
@@ -38,10 +33,9 @@ export default class Service extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             minlength="1"
             maxlength="1"
             required="true"

--- a/src/components/Form/Service/Service.test.jsx
+++ b/src/components/Form/Service/Service.test.jsx
@@ -7,27 +7,25 @@ describe('The Service component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Service name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Service name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('error on maximum length', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: '12'
     }
-    const component = mount(<Service name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Service name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 })

--- a/src/components/Form/Sex/Sex.jsx
+++ b/src/components/Form/Sex/Sex.jsx
@@ -47,7 +47,6 @@ export default class Sex extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.sex.female')}
                  placeholder={this.props.placeholder}
-                 help={this.props.help}
                  required="true"
                  value="female"
                  checked={this.state.value === 'female'}
@@ -67,7 +66,6 @@ export default class Sex extends ValidationElement {
           <Radio name={this.props.name}
                  label={i18n.t('identification.traits.sex.male')}
                  placeholder={this.props.placeholder}
-                 help={this.props.help}
                  required="true"
                  value="male"
                  checked={this.state.value === 'male'}

--- a/src/components/Form/Street/Street.jsx
+++ b/src/components/Form/Street/Street.jsx
@@ -7,11 +7,6 @@ export default class Street extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false
@@ -56,11 +51,10 @@ export default class Street extends ValidationElement {
 
   render () {
     return (
-      <Textarea name={this.state.name}
+      <Textarea name={this.props.name}
             className={this.props.className}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             required="true"
             value={this.state.value}
             error={this.state.error}

--- a/src/components/Form/Street/Street.test.jsx
+++ b/src/components/Form/Street/Street.test.jsx
@@ -7,13 +7,12 @@ describe('The Street component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Street name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Street name={expected.name} label={expected.label} value={expected.value} />)
     component.find('textarea#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('textarea#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Telephone/Telephone.test.jsx
+++ b/src/components/Form/Telephone/Telephone.test.jsx
@@ -39,13 +39,12 @@ describe('The Telephone component', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Telephone input label',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<Telephone name={expected.name} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} domestic={true} />)
+    const component = mount(<Telephone name={expected.name} error={expected.error} focus={expected.focus} valid={expected.valid} domestic={true} />)
     expect(component.find('input#Domestic-phonetype').length).toEqual(1)
     expect(component.find('input[name="domestic_first"]').length).toEqual(1)
     expect(component.find('input[name="domestic_second"]').length).toEqual(1)
@@ -57,7 +56,6 @@ describe('The Telephone component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -75,7 +73,6 @@ describe('The Telephone component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -93,7 +90,6 @@ describe('The Telephone component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -111,7 +107,6 @@ describe('The Telephone component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/Text/Text.jsx
+++ b/src/components/Form/Text/Text.jsx
@@ -61,7 +61,6 @@ export default class Text extends ValidationElement {
       <Generic name={this.props.name}
                label={this.props.label}
                placeholder={this.props.placeholder}
-               help={this.props.help}
                type="text"
                className={this.props.className}
                disabled={this.props.disabled}

--- a/src/components/Form/Text/Text.test.jsx
+++ b/src/components/Form/Text/Text.test.jsx
@@ -7,67 +7,60 @@ describe('The text component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       type: 'text',
       error: true,
       focus: false,
       valid: false,
       readonly: true
     }
-    const component = mount(<Text name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} readonly={expected.readonly} />)
-    // expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
+    const component = mount(<Text name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} readonly={expected.readonly} />)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    // expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: true,
       valid: false
     }
-    const component = mount(<Text name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Text name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Text input success',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: true
     }
-    const component = mount(<Text name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Text name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    // expect(component.find('input#' + expected.name).hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Text input label',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<Text name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Text name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/Textarea/Textarea.jsx
+++ b/src/components/Form/Textarea/Textarea.jsx
@@ -142,21 +142,6 @@ export default class Textarea extends ValidationElement {
   }
 
   /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
-  /**
    * Style classes applied to the input element.
    */
   inputClass () {
@@ -194,10 +179,6 @@ export default class Textarea extends ValidationElement {
                   onFocus={this.handleFocus}
                   onBlur={this.handleBlur}
                   />
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.state.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Form/Textarea/Textarea.test.jsx
+++ b/src/components/Form/Textarea/Textarea.test.jsx
@@ -7,63 +7,56 @@ describe('The textarea component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false
     }
-    const component = mount(<Textarea name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
-    // expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
+    const component = mount(<Textarea name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('textarea#' + expected.name).length).toEqual(1)
-    // expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       error: false,
       focus: true,
       valid: false
     }
-    const component = mount(<Textarea name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Textarea name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('textarea#' + expected.name).length).toEqual(1)
     expect(component.find('textarea#' + expected.name).hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Text input success',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: true
     }
-    const component = mount(<Textarea name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Textarea name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('textarea#' + expected.name).length).toEqual(1)
-    // expect(component.find('textarea#' + expected.name).hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Text input label',
-      help: 'Helpful error message',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<Textarea name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Textarea name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('textarea#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -71,7 +64,6 @@ describe('The textarea component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -89,7 +81,6 @@ describe('The textarea component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -107,7 +98,6 @@ describe('The textarea component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -125,7 +115,6 @@ describe('The textarea component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Form/Type/Type.jsx
+++ b/src/components/Form/Type/Type.jsx
@@ -7,11 +7,6 @@ export default class Type extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false
@@ -38,10 +33,9 @@ export default class Type extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             minlength="2"
             maxlength="2"
             required="true"

--- a/src/components/Form/Type/Type.test.jsx
+++ b/src/components/Form/Type/Type.test.jsx
@@ -7,41 +7,38 @@ describe('The Type component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<Type name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Type name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('error on minimum length', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: '1'
     }
-    const component = mount(<Type name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Type name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 
   it('error on maximum length', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: '123'
     }
-    const component = mount(<Type name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Type name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(1)
   })
 })

--- a/src/components/Form/Url/Url.jsx
+++ b/src/components/Form/Url/Url.jsx
@@ -7,15 +7,7 @@ export default class Url extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      disabled: props.disabled,
-      maxlength: props.maxlength,
       pattern: props.pattern || '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$',
-      readonly: props.readonly,
-      required: props.required,
       value: props.value,
       focus: props.focus || false,
       error: props.error || false,
@@ -61,16 +53,15 @@ export default class Url extends ValidationElement {
 
   render () {
     return (
-      <Generic name={this.state.name}
-               label={this.state.label}
-               placeholder={this.state.placeholder}
-               help={this.state.help}
+      <Generic name={this.props.name}
+               label={this.props.label}
+               placeholder={this.props.placeholder}
                type="url"
-               disabled={this.state.disabled}
-               maxlength={this.state.maxlength}
+               disabled={this.props.disabled}
+               maxlength={this.props.maxlength}
                pattern={this.state.pattern}
-               readonly={this.state.readonly}
-               required={this.state.required}
+               readonly={this.props.readonly}
+               required={this.props.required}
                value={this.state.value}
                focus={this.state.focus}
                error={this.state.error}

--- a/src/components/Form/Url/Url.test.jsx
+++ b/src/components/Form/Url/Url.test.jsx
@@ -7,68 +7,61 @@ describe('The URL component', () => {
     const expected = {
       name: 'input-error',
       label: 'Url input error',
-      help: 'Helpful error message',
       type: 'text',
       error: true,
       focus: false,
       valid: false,
       readonly: true
     }
-    const component = mount(<Url name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} readonly={expected.readonly} />)
-    // expect(component.find('label.usa-input-error-label').text()).toEqual(expected.label)
+    const component = mount(<Url name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} readonly={expected.readonly} />)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    // expect(component.find('div.message').text()).toEqual(expected.help)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with focus', () => {
     const expected = {
       name: 'input-focus',
       label: 'Url input focused',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: true,
       valid: false
     }
-    const component = mount(<Url name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Url name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
     expect(component.find('input#' + expected.name).hasClass('usa-input-focus')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders appropriately with validity checks', () => {
     const expected = {
       name: 'input-success',
       label: 'Url input success',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: true
     }
-    const component = mount(<Url name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Url name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    // expect(component.find('input#' + expected.name).hasClass('usa-input-success')).toEqual(true)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('renders sane defaults', () => {
     const expected = {
       name: 'input-type-text',
       label: 'Url input label',
-      help: 'Helpful error message',
       type: 'text',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<Url name={expected.name} label={expected.label} help={expected.help} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<Url name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -76,7 +69,6 @@ describe('The URL component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -94,7 +86,6 @@ describe('The URL component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -112,7 +103,6 @@ describe('The URL component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -130,7 +120,6 @@ describe('The URL component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -174,7 +163,7 @@ describe('The URL component', () => {
     tests.forEach((t) => {
       const component = mount(<Url name="test-urls" label="URL" value={t.url} />)
       component.find('input').simulate('blur')
-      expect(component.find('div.hidden').length).toEqual(t.valid ? 1 : 1)
+      expect(component.find('.usa-input-error-label').length).toEqual(t.valid ? 0 : 1)
     })
   })
 })

--- a/src/components/Form/Weight/Weight.jsx
+++ b/src/components/Form/Weight/Weight.jsx
@@ -8,11 +8,6 @@ export default class Weight extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false,
@@ -37,8 +32,8 @@ export default class Weight extends ValidationElement {
    */
   handleValidation (event, status, errors) {
     this.setState({error: status === false, valid: status === true, errors: errors}, () => {
-      let e = { [this.state.name]: errors }
-      let s = { [this.state.name]: { status: status } }
+      let e = { [this.props.name]: errors }
+      let s = { [this.props.name]: { status: status } }
       super.handleValidation(event, s, e)
     })
   }
@@ -65,14 +60,14 @@ export default class Weight extends ValidationElement {
    * Generated name for the error message.
    */
   errorName (part) {
-    return '' + this.state.name + '-' + part + '-error'
+    return '' + this.props.name + '-' + part + '-error'
   }
 
   /**
    * Generated name for the part of the address elements.
    */
   partName (part) {
-    return '' + this.state.name + '-' + part
+    return '' + this.props.name + '-' + part
   }
 
   render () {
@@ -84,13 +79,12 @@ export default class Weight extends ValidationElement {
                   label={i18n.t('identification.traits.label.pounds')}
                   placeholder={i18n.t('identification.traits.placeholder.pounds')}
                   aria-describedby={this.errorName('weight')}
-                  help="identification.traits.help.pounds"
-                  disabled={this.state.disabled}
+                  disabled={this.props.disabled}
                   max="999"
                   maxlength="3"
                   min="10"
-                  readonly={this.state.readonly}
-                  required={this.state.required}
+                  readonly={this.props.readonly}
+                  required={this.props.required}
                   step="1"
                   value={this.state.value}
                   onChange={this.handleChange}

--- a/src/components/Form/Weight/Weight.test.jsx
+++ b/src/components/Form/Weight/Weight.test.jsx
@@ -7,13 +7,12 @@ describe('The Weight component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Pounds',
-      help: 'Helpful error message',
       value: 10
     }
-    const component = mount(<Weight name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<Weight name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#pounds').simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#pounds').length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Form/ZipCode/ZipCode.jsx
+++ b/src/components/Form/ZipCode/ZipCode.jsx
@@ -7,11 +7,6 @@ export default class ZipCode extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
-      label: props.label,
-      placeholder: props.placeholder,
-      help: props.help,
-      required: props.required,
       value: props.value,
       error: props.error || false,
       valid: props.valid || false
@@ -30,9 +25,9 @@ export default class ZipCode extends ValidationElement {
   /**
    * Handle the validation event.
    */
-  handleValidation (event, status) {
+  handleValidation (event, status, error) {
     this.setState({error: status === false, valid: status === true}, () => {
-      super.handleValidation(event, status)
+      super.handleValidation(event, status, error)
     })
   }
 
@@ -56,10 +51,9 @@ export default class ZipCode extends ValidationElement {
 
   render () {
     return (
-      <Text name={this.state.name}
-            label={this.state.label}
-            placeholder={this.state.placeholder}
-            help={this.state.help}
+      <Text name={this.props.name}
+            label={this.props.label}
+            placeholder={this.props.placeholder}
             className={this.props.className}
             minlength="5"
             maxlength="10"

--- a/src/components/Form/ZipCode/ZipCode.test.jsx
+++ b/src/components/Form/ZipCode/ZipCode.test.jsx
@@ -7,13 +7,12 @@ describe('The ZipCode component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<ZipCode name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<ZipCode name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#' + expected.name).simulate('change')
     expect(component.find('label').text()).toEqual(expected.label)
     expect(component.find('input#' + expected.name).length).toEqual(1)
-    expect(component.find('div.hidden').length).toEqual(1)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Section/Foreign/Passport/Passport.test.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.test.jsx
@@ -12,7 +12,7 @@ describe('The passport component', () => {
     expect(component.find('input#first').length).toEqual(0)
     expect(component.find('input#number').length).toEqual(0)
     expect(component.find('input#month').length).toEqual(0)
-    expect(component.find('div.hidden').length).toBeGreaterThan(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('display passport field if "Yes" is selected', () => {
@@ -23,7 +23,7 @@ describe('The passport component', () => {
     expect(component.find('input[name="has_passport"]').length).toEqual(2)
     expect(component.find('input#number').length).toEqual(1)
     expect(component.find('input#month').length).toEqual(2)
-    expect(component.find('div.hidden').length).toBeGreaterThan(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('display no passport information if "No" is selected', () => {
@@ -35,6 +35,6 @@ describe('The passport component', () => {
     expect(component.find('input#first').length).toEqual(0)
     expect(component.find('input#number').length).toEqual(0)
     expect(component.find('input#month').length).toEqual(0)
-    expect(component.find('div.hidden').length).toBeGreaterThan(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.jsx
@@ -8,9 +8,7 @@ export default class ApplicantBirthDate extends ValidationElement {
     super(props)
 
     this.state = {
-      name: props.name,
       value: props.value,
-      help: props.help,
       estimated: props.estimated,
       errorCodes: []
     }
@@ -48,7 +46,6 @@ export default class ApplicantBirthDate extends ValidationElement {
       }
     })
 
-    let help = this.state.help
     if (status === true && this.state.value !== '') {
       // Calculation to get the age of something compared to now.
       let now = new Date()
@@ -61,7 +58,6 @@ export default class ApplicantBirthDate extends ValidationElement {
 
       if (age < 17 || age > 129) {
         status = false
-        help = i18n.t('identification.birthplace.error.age')
         error = 'age'
       }
     }
@@ -74,9 +70,9 @@ export default class ApplicantBirthDate extends ValidationElement {
       complexStatus = true
     }
 
-    this.setState({error: complexStatus === false, valid: complexStatus === true, help: help, errorCodes: codes}, () => {
-      let e = { [this.state.name]: codes }
-      let s = { [this.state.name]: { status: complexStatus } }
+    this.setState({error: complexStatus === false, valid: complexStatus === true, errorCodes: codes}, () => {
+      let e = { [this.props.name]: codes }
+      let s = { [this.props.name]: { status: complexStatus } }
       if (this.state.error === false || this.state.valid === true) {
         super.handleValidation(event, s, e)
         return
@@ -93,7 +89,6 @@ export default class ApplicantBirthDate extends ValidationElement {
           // Display and assign the errors as necessary
           if (response.Errors) {
             response.Errors.forEach((e) => {
-              this.setState({help: e.Error})
             })
           }
         })
@@ -142,35 +137,13 @@ export default class ApplicantBirthDate extends ValidationElement {
     return ''
   }
 
-  /**
-   * Generated name for the error message.
-   */
-  errorName () {
-    return '' + this.state.name + '-error'
-  }
-
-  /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.error) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
   render () {
     const klass = `birthdate ${this.props.className || ''}`.trim()
 
     return (
       <div className={klass}>
         <Help id="identification.birthdate.help">
-          <DateControl name={this.state.name}
+          <DateControl name={this.props.name}
                        value={this.state.value}
                        estimated={this.state.estimated}
                        onChange={this.handleChange}
@@ -178,10 +151,6 @@ export default class ApplicantBirthDate extends ValidationElement {
                        />
           <HelpIcon />
         </Help>
-        <div className={this.errorClass()}>
-          <i className="fa fa-exclamation"></i>
-          {this.state.help}
-        </div>
       </div>
     )
   }

--- a/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
+++ b/src/components/Section/Identification/ApplicantBirthDate/ApplicantBirthDate.test.jsx
@@ -7,11 +7,10 @@ describe('The applicant birth date component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<ApplicantBirthDate name={expected.name} label={expected.label} help={expected.help} value={expected.value} />)
+    const component = mount(<ApplicantBirthDate name={expected.name} label={expected.label} value={expected.value} />)
     component.find('input#month').simulate('change')
-    expect(component.find('div.hidden').length).toBeGreaterThan(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.test.jsx
+++ b/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.test.jsx
@@ -9,12 +9,11 @@ describe('The ApplicantBirthPlace component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: ''
     }
-    const component = mount(<ApplicantBirthPlace name={expected.name} label={expected.label} help={expected.help} value={expected.value} country=''/>)
+    const component = mount(<ApplicantBirthPlace name={expected.name} label={expected.label} value={expected.value} country=''/>)
     component.find('input#city').simulate('blur')
-    expect(component.find('div.hidden').length).toEqual(children)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
   it('bubbles up validate event', () => {
@@ -22,7 +21,6 @@ describe('The ApplicantBirthPlace component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -40,7 +38,6 @@ describe('The ApplicantBirthPlace component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -58,7 +55,6 @@ describe('The ApplicantBirthPlace component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -76,7 +72,6 @@ describe('The ApplicantBirthPlace component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.jsx
+++ b/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.jsx
@@ -209,31 +209,6 @@ export default class ApplicantSSN extends ValidationElement {
   }
 
   /**
-   * Style classes applied to the span element.
-   */
-  errorClass () {
-    let klass = 'eapp-error-message'
-
-    if (this.state.errorCodes.length > 0) {
-      klass += ' message'
-    } else {
-      klass += ' hidden'
-    }
-
-    return klass.trim()
-  }
-
-  errorMessage () {
-    return this.state.errorCodes.map(e => {
-      return (
-        <li>
-          {i18n.t(`identification.ssn.error.${e}`)}
-        </li>
-      )
-    })
-  }
-
-  /**
    * Prevents clipboard events from making changes to the value of the elements
    */
   disallowClipboard (event) {
@@ -304,7 +279,7 @@ export default class ApplicantSSN extends ValidationElement {
 
     return (
       <div className={klass}>
-        <Help id="identification.ssn.help">
+        <Help id="identification.ssn.help" errorPrefix="ssn">
           <label>Social security number</label>
           <Text name="first"
                 ref="first"
@@ -366,10 +341,6 @@ export default class ApplicantSSN extends ValidationElement {
                       onFocus={this.props.onFocus}
                       onBlur={this.props.onBlur}
                       />
-          </div>
-          <div className={this.errorClass()}>
-            <i className="fa fa-exclamation"></i>
-            <ul>{this.errorMessage()}</ul>
           </div>
         </Help>
       </div>

--- a/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.test.jsx
+++ b/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.test.jsx
@@ -10,15 +10,14 @@ describe('The ApplicantSSN component', () => {
     const expected = {
       name: 'input-focus',
       label: 'Text input focused',
-      help: 'Helpful error message',
       value: '',
       handleBlur: function (event) {
         blurs++
       }
     }
-    const component = mount(<ApplicantSSN name={expected.name} label={expected.label} help={expected.help} value={expected.value} onBlur={expected.handleBlur} />)
+    const component = mount(<ApplicantSSN name={expected.name} label={expected.label} value={expected.value} onBlur={expected.handleBlur} />)
     component.find('input#last').simulate('change')
-    expect(component.find('div.hidden').length).toEqual(validElements)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
     expect(blurs).toEqual(0)
   })
 
@@ -58,7 +57,6 @@ describe('The ApplicantSSN component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -76,7 +74,6 @@ describe('The ApplicantSSN component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -94,7 +91,6 @@ describe('The ApplicantSSN component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,
@@ -112,7 +108,6 @@ describe('The ApplicantSSN component', () => {
     const expected = {
       name: 'input-error',
       label: 'Text input error',
-      help: 'Helpful error message',
       error: true,
       focus: false,
       valid: false,

--- a/src/components/Section/Identification/Physical/Physical.test.jsx
+++ b/src/components/Section/Identification/Physical/Physical.test.jsx
@@ -19,6 +19,6 @@ describe('The physical attributes section', () => {
     expect(component.find('input#hair-bald').length).toEqual(1)
     expect(component.find('input[name="eye"]').length).toBeGreaterThan(0)
     expect(component.find('input[name="sex"]').length).toBeGreaterThan(0)
-    expect(component.find('div.hidden').length).toBeGreaterThan(0)
+    expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 })

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -55,6 +55,71 @@ const en = {
     add: 'Add comment',
     remove: 'Remove comment'
   },
+  error: {
+    name: {
+      last: {
+        required: '',
+        length: 'The last name cannot exceed 100 characters',
+        pattern: 'We only support letters, hyphens (-), periods (.), apostrophes (\'), and spaces'
+      },
+      first: {
+        length: 'The first name cannot exceed 100 characters',
+        pattern: 'We only support letters, hyphens (-), periods (.), apostrophes (\'), and spaces'
+      },
+      middle: {
+        length: 'The middle name cannot exceed 100 characters',
+        pattern: 'We only support letters, hyphens (-), periods (.), apostrophes (\'), and spaces'
+      }
+    },
+    birthdate: {
+      age: 'Applicants must be older than 16 and less than 130 years of age'
+    },
+    ssn: {
+      first: {
+        pattern: 'The first part of the social security number must be 3 digits between 0 and 9'
+      },
+      middle: {
+        pattern: 'The middle part of the social security number must be 2 digits between 0 and 9'
+      },
+      last: {
+        pattern: 'The last part of the social security number must be 4 digits between 0 and 9'
+      },
+      verifyFirst: {
+        pattern: 'The first part of the social security number must be 3 digits between 0 and 9'
+      },
+      verifyMiddle: {
+        pattern: 'The middle part of the social security number must be 2 digits between 0 and 9'
+      },
+      verifyLast: {
+        pattern: 'The last part of the social security number must be 4 digits between 0 and 9'
+      }
+    },
+    month: {
+      length: 'The month must be between 1 (January) and 12 (December)'
+    },
+    day: {
+      length: 'The day must be a valid day for the month'
+    },
+    year: {
+      length: 'The year must be a valid year'
+    },
+    weight: {
+      pounds: {
+        length: 'We only accept a value between 10 and 999 pounds'
+      }
+    },
+    height: {
+      feet: {
+        length: 'Feet must be between 1 and 9'
+      },
+      inches: {
+        length: 'Inches must be between 0 and 11'
+      }
+    },
+    zipcode: {
+      pattern: 'The zipcode can be either the 5 or 9 digit variation'
+    }
+  },
   section: {
     back: 'Back',
     next: 'Next'
@@ -85,26 +150,13 @@ const en = {
     name: {
       title: 'Your full name',
       last: {
-        help: 'Your last name is required.  If you have only 1 name, enter it in the last name field',
-        error: {
-          required: '',
-          length: 'The last name cannot exceed 100 characters',
-          pattern: 'We only support letters, hyphens (-), periods (.), apostrophes (\'), and spaces'
-        }
+        help: 'Your last name is required.  If you have only 1 name, enter it in the last name field'
       },
       first: {
-        help: 'If your first name is an initial place the initial in this field.  If you do not have a first name leave this field empty.',
-        error: {
-          length: 'The first name cannot exceed 100 characters',
-          pattern: 'We only support letters, hyphens (-), periods (.), apostrophes (\'), and spaces'
-        }
+        help: 'If your first name is an initial place the initial in this field.  If you do not have a first name leave this field empty.'
       },
       middle: {
-        help: 'Enter all of your middle names here.  If your middle name is an initial place the initial in the field.  If you do not have a middle name leave this field empty.',
-        error: {
-          length: 'The middle name cannot exceed 100 characters',
-          pattern: 'We only support letters, hyphens (-), periods (.), apostrophes (\'), and spaces'
-        }
+        help: 'Enter all of your middle names here.  If your middle name is an initial place the initial in the field.  If you do not have a middle name leave this field empty.'
       },
       suffix: {
         help: 'If you are a Jr., Sr., etc. select your Suffix from the list provided.  If your suffix does not appear in this list, select Other and enter your suffix in the provided field'
@@ -140,10 +192,7 @@ const en = {
     },
     birthdate: {
       title: 'Date of birth',
-      help: 'Provide your date of birth, or the closest possible estimate you can provide',
-      error: {
-        age: 'Applicants must be older than 16 and less than 130 years of age'
-      }
+      help: 'Provide your date of birth, or the closest possible estimate you can provide'
     },
     birthplace: {
       title: 'Place of birth',
@@ -210,26 +259,6 @@ const en = {
         last: '0000',
         middle: '00',
         first: '000'
-      },
-      error: {
-        first: {
-          pattern: 'The first part of the social security number must be 3 digits between 0 and 9'
-        },
-        middle: {
-          pattern: 'The middle part of the social security number must be 2 digits between 0 and 9'
-        },
-        last: {
-          pattern: 'The last part of the social security number must be 4 digits between 0 and 9'
-        },
-        verifyFirst: {
-          pattern: 'The first part of the social security number must be 3 digits between 0 and 9'
-        },
-        verifyMiddle: {
-          pattern: 'The middle part of the social security number must be 2 digits between 0 and 9'
-        },
-        verifyLast: {
-          pattern: 'The last part of the social security number must be 4 digits between 0 and 9'
-        }
       }
     },
     traits: {


### PR DESCRIPTION
Issue #407 

Initially all error messages were coupled to their associated inputs following the U.S. Web Design Standards as a template. However, with the current design implementation and a better usability we have had to break this apart. To do this it was necessary to

 1. remove of deprecated help/error messages
 2. allow the `Help` component to inject itself into child validation methods/callbacks
 3. combine the error messages and parsing of markdown
 4. relocate the error messages in the localization file to one central location

![2017-02-06_143354_585165529](https://cloud.githubusercontent.com/assets/697855/22663106/4f765370-ec79-11e6-862b-735aaf3c9fdf.png)

