### PR TITLE
Reduce hit area on "Initial Only" checkboxes

### DIFF
--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -236,12 +236,14 @@ export default class Name extends ValidationElement {
                 />
           <HelpIcon />
           <div className="text-right">
-            <input id="firstInitialOnly"
-                   type="checkbox"
-                   value="firstInitial"
-                   checked={this.props.firstInitialOnly}
-                   onChange={this.handleChange} />
-            <label>Initial Only</label>
+            <div className="inline">
+              <input id="firstInitialOnly"
+                    type="checkbox"
+                    value="firstInitial"
+                    checked={this.props.firstInitialOnly}
+                    onChange={this.handleChange} />
+              <label>Initial Only</label>
+            </div>
           </div>
         </Help>
         <Help id="identification.name.middle.help" errorPrefix="name">
@@ -295,12 +297,14 @@ export default class Name extends ValidationElement {
                 />
           <HelpIcon />
           <div className="text-right">
-            <input id="lastInitialOnly"
-                   type="checkbox"
-                   value="lastInitial"
-                   checked={this.props.lastInitialOnly}
-                   onChange={this.handleChange} />
-            <label>Initial Only</label>
+            <div className="inline">
+              <input id="lastInitialOnly"
+                    type="checkbox"
+                    value="lastInitial"
+                    checked={this.props.lastInitialOnly}
+                    onChange={this.handleChange} />
+              <label>Initial Only</label>
+            </div>
           </div>
         </Help>
         <Help id="identification.name.suffix.help" errorPrefix="name" scrollIntoView="true">


### PR DESCRIPTION
Issue: #479 

The hit area has a dashed blue border around it

![hit-area-initial-only](https://cloud.githubusercontent.com/assets/697855/23024206/23fa87ba-f427-11e6-8cb7-ba1431722560.png)

## Notes

The CSS class was already present and used for the middle name checkboxes so just had to do the same for the first and last name options.