### PR TITLE
Check for undefined values because zero is valid but evals false

### DIFF
--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -91,7 +91,7 @@ export default class Number extends ValidationElement {
     let hits = 0
     status = true
 
-    if (typeof(this.state.value) !== 'undefined' && !isNaN(parseInt(this.state.value))) {
+    if (!isNaN(parseInt(this.state.value))) {
       if (status && this.props.min) {
         status = status && parseInt(this.state.value) >= parseInt(this.props.min)
         if (status === false) {

--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -83,7 +83,7 @@ export default class Number extends ValidationElement {
    */
   handleValidation (event, status) {
     if (status === false) {
-      super.handleValidation(event, status, errorCode)
+      super.handleValidation(event, status, null)
       return
     }
 
@@ -91,7 +91,7 @@ export default class Number extends ValidationElement {
     let hits = 0
     status = true
 
-    if (this.state.value) {
+    if (typeof(this.state.value) !== 'undefined' && !isNaN(parseInt(this.state.value))) {
       if (status && this.props.min) {
         status = status && parseInt(this.state.value) >= parseInt(this.props.min)
         if (status === false) {

--- a/src/components/Section/Identification/Physical/Physical.jsx
+++ b/src/components/Section/Identification/Physical/Physical.jsx
@@ -7,12 +7,12 @@ export default class Physical extends ValidationElement {
   constructor (props) {
     super(props)
     this.state = {
-      Height: props.Height || {},
-      Weight: props.Weight || 0,
-      HairColor: props.HairColor || {},
-      EyeColor: props.EyeColor || {},
-      Sex: props.Sex || {},
-      Comments: props.Comments || '',
+      Height: props.Height,
+      Weight: props.Weight,
+      HairColor: props.HairColor,
+      EyeColor: props.EyeColor,
+      Sex: props.Sex,
+      Comments: props.Comments,
       errorCodes: []
     }
   }
@@ -58,7 +58,15 @@ export default class Physical extends ValidationElement {
   }
 
   isValid () {
+    if (!this.state.Height) {
+      return false
+    }
+
     if (this.state.Height.feet < 1 || !this.state.Height.inches) {
+      return false
+    }
+
+    if (!this.state.Weight) {
       return false
     }
 
@@ -66,11 +74,23 @@ export default class Physical extends ValidationElement {
       return false
     }
 
+    if (!this.state.HairColor) {
+      return false
+    }
+
     if (!this.state.HairColor.length) {
       return false
     }
 
+    if (!this.state.EyeColor) {
+      return false
+    }
+
     if (!this.state.EyeColor.length) {
+      return false
+    }
+
+    if (!this.state.Sex) {
       return false
     }
 


### PR DESCRIPTION
Issue: #477 

Turns out we have this check:

```js
if (this.state.value) { /* do validation stuff */ }
```

and typically it comes in as a string such as `'0'` but on re-entry it is an integer like `0` which evaluates as `false` in Javascript land causing it to bypass validations.

