### PR TITLE
Added missing heading and styles for explanation of "other" employment activity

### DIFF
--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -84,16 +84,12 @@ export class EmploymentItem extends ValidationElement {
     return (
       <div>
         <h3>{i18n.t(`history.employment.default.heading.activity`)}</h3>
-        <div className="eapp-field-wrap no-label">
-          <Help id={`history.employment.default.activity.help`}>
-            <EmploymentActivity
-              {...this.props.EmploymentActivity}
-              onUpdate={this.onUpdate.bind(this, 'EmploymentActivity')}
-              name="EmploymentActivity"
-              />
-            <HelpIcon className="activity"/>
-          </Help>
-        </div>
+        <EmploymentActivity
+          {...this.props.EmploymentActivity}
+          onUpdate={this.onUpdate.bind(this, 'EmploymentActivity')}
+          name="EmploymentActivity"
+          className="eapp-field-wrap no-label"
+          />
 
         <h3>{i18n.t(`history.employment.default.heading.datesEmployed`)}</h3>
         <div className="eapp-field-wrap">

--- a/src/components/Section/History/Employment/Employment.scss
+++ b/src/components/Section/History/Employment/Employment.scss
@@ -47,9 +47,19 @@
   }
 
   .employment-activity {
+    .option-list {
+      max-width: 92% !important;
+    }
+
     label {
       height: 8rem;
       width: 24rem;
+      padding-top: 2rem;
+    }
+
+    .other {
+      display: inline-block;
+      width: 92%;
       padding-top: 2rem;
     }
   }

--- a/src/components/Section/History/Employment/EmploymentActivity.jsx
+++ b/src/components/Section/History/Employment/EmploymentActivity.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
-import { ValidationElement, Textarea, Help, HelpIcon, Radio, RadioGroup } from '../../../Form'
+import { ValidationElement, Textarea, Help, HelpIcon, Radio, RadioGroup, Show } from '../../../Form'
 
 export default class EmploymentActivity extends ValidationElement {
   constructor (props) {
@@ -66,112 +66,118 @@ export default class EmploymentActivity extends ValidationElement {
   render () {
     return (
       <div className="employment-activity">
-        <RadioGroup name="employment_activity" className="option-list" selectedValue={this.state.value}>
-          <div>{i18n.t('history.employment.default.activity.title')}</div>
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.activeMilitary')}
-            value="ActiveMilitary"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.nationalGuard')}
-            value="NationalGuard"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.usphs')}
-            value="USPHS"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.otherFederal')}
-            value="OtherFederal"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.stateGovernment')}
-            value="StateGovernment"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.federalContractor')}
-            value="FederalContractor"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <div>Other employment</div>
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.nonGovernment')}
-            value="NonGovernment"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.selfEmployment')}
-            value="SelfEmployment"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.unemployment')}
-            value="Unemployment"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-          <Radio
-            label={i18n.t('history.employment.default.activity.type.other')}
-            value="Other"
-            disabled={this.props.disabled}
-            onChange={this.handleFieldChange.bind(this, 'value')}
-            onValidate={this.props.onValidate}
-            onBlur={this.handleBlur}
-            onFocus={this.handleFocus}
-          />
-        </RadioGroup>
-        {
-          this.state.value === 'Other' && (
-            <Help id="history.employment.activity.other.help">
+        <div className={this.props.className}>
+          <Help id={`history.employment.default.activity.help`}>
+            <RadioGroup name="employment_activity" className="option-list" selectedValue={this.state.value}>
+              <div>{i18n.t('history.employment.default.activity.title')}</div>
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.activeMilitary')}
+                value="ActiveMilitary"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.nationalGuard')}
+                value="NationalGuard"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.usphs')}
+                value="USPHS"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.otherFederal')}
+                value="OtherFederal"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.stateGovernment')}
+                value="StateGovernment"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.federalContractor')}
+                value="FederalContractor"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <div>Other employment</div>
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.nonGovernment')}
+                value="NonGovernment"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.selfEmployment')}
+                value="SelfEmployment"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.unemployment')}
+                value="Unemployment"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+              <Radio
+                label={i18n.t('history.employment.default.activity.type.other')}
+                value="Other"
+                disabled={this.props.disabled}
+                onChange={this.handleFieldChange.bind(this, 'value')}
+                onValidate={this.props.onValidate}
+                onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
+                />
+            </RadioGroup>
+            <HelpIcon className="activity"/>
+          </Help>
+        </div>
+        <Show when={this.state.value === 'Other'}>
+          <div className="eapp-field-wrap">
+            <Help id="history.employment.other.activity.other.help">
               <Textarea name="otherExplanation"
-                value={this.state.otherExplanation}
-                label={i18n.t('history.employment.default.activity.other.label')}
-                onChange={this.handleFieldChange.bind(this, 'otherExplanation')}
-              />
-              <HelpIcon className="other" />
+                        className="other"
+                        value={this.state.otherExplanation}
+                        label={i18n.t('history.employment.default.activity.other.label')}
+                        onChange={this.handleFieldChange.bind(this, 'otherExplanation')}
+                        />
+              <HelpIcon />
             </Help>
-          )
-        }
+          </div>
+        </Show>
       </div>
     )
   }

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2090,6 +2090,7 @@ const en = {
           status: 'Select the employment status for this position',
           address: 'Provide the address of employment',
           telephone: 'Provide your employment telephone number',
+          reference: 'Provide a reference',
           physicalAddress: 'Is/was your physical work address different than your employer\'s address?',
           additionalActivity: 'Additional periods of activity with this employer'
         },
@@ -2207,6 +2208,15 @@ const en = {
           physicalAddress: 'Is/was your physical work address different than your employer\'s address?',
           additionalActivity: 'Additional periods of activity with this employer'
         },
+        activity: {
+          other: {
+            help: {
+              title: 'Need help with employment activity?',
+              message: 'Please explain the type of employment activity',
+              note: ''
+            }
+          }
+        },
         employer: {
           label: 'Employer name',
           help: {
@@ -2220,14 +2230,6 @@ const en = {
           help: {
             title: 'Need help with the position title?',
             message: 'Provide the name of your position title',
-            note: ''
-          }
-        },
-        employer: {
-          label: 'Employer name',
-          help: {
-            title: 'Need help with the employer name?',
-            message: 'Provide the name of your employer',
             note: ''
           }
         },


### PR DESCRIPTION
Issue #548 

There was a missing heading reference for the "Self employment" activity type. Also, fix some styling issues for the explanation textarea associated with the "Other" activity type.
