### PR TITLE
Force validation on mount for Dropdown

### DIFF
--- a/src/components/Form/Dropdown/Dropdown.jsx
+++ b/src/components/Form/Dropdown/Dropdown.jsx
@@ -62,7 +62,21 @@ export default class Dropdown extends ValidationElement {
         }
       }
 
-      this.setState({options: arr})
+      this.setState({options: arr}, () => {
+        // Force validation. Particularly on first render we need to revalidate the
+        // value.
+        let event = {
+          target: {
+            id: this.props.id || '',
+            name: this.props.name,
+            value: this.state.value
+          },
+          persist: function () {},
+          fake: true
+        }
+
+        this.handleValidation(event)
+      })
     }
   }
 


### PR DESCRIPTION
Issue: #551 

When re-rendering the `Dropdown` component in an accordion the field was not re-validating the saved state.