### PR TITLE
Date range margins and month dropdown

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ValidationElement from '../ValidationElement'
 import Number from '../Number'
 import Checkbox from '../Checkbox'
+import Dropdown from '../Dropdown'
 import { daysInMonth, validDate } from '../../Section/History/dateranges'
 
 export default class DateControl extends ValidationElement {
@@ -112,12 +113,12 @@ export default class DateControl extends ValidationElement {
         event.target.date = d
         super.handleChange(event)
 
-        // Always make sure the day is re-validated
-        if (['month', 'year', 'estimated'].includes(event.target.name)) {
-          this.refs.day.refs.input.focus()
-          this.refs.day.refs.input.blur()
-          event.target.focus()
-        }
+        // // Always make sure the day is re-validated
+        // if (['month', 'year', 'estimated'].includes(event.target.name)) {
+        //   this.refs.day.refs.input.focus()
+        //   this.refs.day.refs.input.blur()
+        //   event.target.focus()
+        // }
 
         if (this.props.onUpdate) {
           this.props.onUpdate({
@@ -266,26 +267,31 @@ export default class DateControl extends ValidationElement {
       <div className={klass}>
         <div className={this.divClass()}>
           <div className="usa-form-group month">
-            <Number id="month"
-                    name="month"
-                    ref="month"
-                    label="Month"
-                    placeholder="00"
-                    aria-described-by={this.errorName('month')}
-                    disabled={this.state.disabled}
-                    max="12"
-                    maxlength="2"
-                    min="1"
-                    readonly={this.props.readonly}
-                    required={this.props.required}
-                    step="1"
-                    value={this.state.month}
-                    focus={this.state.foci[0]}
-                    onChange={this.handleChange}
-                    onFocus={this.handleFocus}
-                    onBlur={this.handleBlur}
-                    onValidate={this.handleValidation}
-                    />
+            <Dropdown name="month"
+                      label="Month"
+                      placeholder="00"
+                      value={this.state.month}
+                      disabled={this.state.disabled}
+                      readonly={this.props.readonly}
+                      required={this.props.required}
+                      onChange={this.handleChange}
+                      onFocus={this.handleFocus}
+                      onBlur={this.handleBlur}
+                      onValidate={this.handleValidation}
+                      >
+              <option value="Janurary">1</option>
+              <option value="February">2</option>
+              <option value="March">3</option>
+              <option value="April">4</option>
+              <option value="May">5</option>
+              <option value="June">6</option>
+              <option value="July">7</option>
+              <option value="August">8</option>
+              <option value="September">9</option>
+              <option value="October">10</option>
+              <option value="November">11</option>
+              <option value="December">12</option>
+            </Dropdown>
           </div>
           <div className={`usa-form-group day ${this.props.hideDay === true ? 'hidden' : ''}`}>
             <Number id="day"

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -59,7 +59,7 @@ export default class DateControl extends ValidationElement {
       case 'month':
       case 'mm':
       case 'm':
-        return d.getMonth() + 1
+        return '' + (d.getMonth() + 1)
 
       case 'day':
       case 'dd':
@@ -261,6 +261,7 @@ export default class DateControl extends ValidationElement {
   }
 
   render () {
+    console.log('month:', this.state.month)
     let klass = `datecontrol ${this.props.className || ''} ${this.props.hideDay ? 'day-hidden' : ''}`.trim()
 
     return (
@@ -268,6 +269,7 @@ export default class DateControl extends ValidationElement {
         <div className={this.divClass()}>
           <div className="usa-form-group month">
             <Dropdown name="month"
+                      ref="month"
                       label="Month"
                       placeholder="00"
                       value={this.state.month}

--- a/src/components/Form/DateControl/DateControl.scss
+++ b/src/components/Form/DateControl/DateControl.scss
@@ -20,7 +20,7 @@
 
   .coupled-flags {
     clear: both;
-    padding-left: 22.5rem;
+    padding-left: 21.5rem;
   }
 }
 

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mount } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 import DateControl from './DateControl'
 
 describe('The date component', () => {
@@ -13,8 +13,8 @@ describe('The date component', () => {
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
-    expect(component.find('input#month').length).toEqual(1)
+    const component = mount(<DateControl {...expected} />)
+    expect(component.find('input#day').length).toEqual(1)
   })
 
   it('renders appropriately with focus', () => {
@@ -25,11 +25,11 @@ describe('The date component', () => {
       focus: true,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
-    component.find('input#month').simulate('focus')
+    const component = mount(<DateControl {...expected} />)
+    component.find('input#day').simulate('focus')
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
-    expect(component.find('input#month').hasClass('usa-input-focus')).toEqual(true)
+    expect(component.find('input#day').length).toEqual(1)
+    expect(component.find('input#day').hasClass('usa-input-focus')).toEqual(true)
     expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
@@ -37,14 +37,14 @@ describe('The date component', () => {
     const expected = {
       name: 'input-success',
       label: 'DateControl input success',
-      value: '01-28-2016'
+      value: '1-28-2016'
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
-    component.find('input#month').simulate('change')
+    const component = mount(<DateControl {...expected} />)
+    component.find('input#day').simulate('change')
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
-    expect(component.find('input#month').nodes[0].value).toEqual('1')
-    expect(component.find('input#month').hasClass('usa-input-success')).toEqual(true)
+    expect(component.find('input#day').length).toEqual(1)
+    expect(component.find('input#day').nodes[0].value).toEqual('28')
+    expect(component.find('input#day').hasClass('usa-input-success')).toEqual(true)
     expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
@@ -56,9 +56,9 @@ describe('The date component', () => {
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} />)
+    const component = mount(<DateControl {...expected} />)
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
+    expect(component.find('input#day').length).toEqual(1)
     expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
 
@@ -71,9 +71,9 @@ describe('The date component', () => {
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl {...expected} />)
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
+    expect(component.find('input#day').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('1')
     expect(component.find('input#day').nodes[0].value).toEqual('28')
     expect(component.find('input#year').nodes[0].value).toEqual('2016')
@@ -84,14 +84,14 @@ describe('The date component', () => {
     const expected = {
       name: 'input-type-text',
       label: 'DateControl input label',
-      value: '99-28-2016',
+      value: '1-42-2016',
       error: false,
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl {...expected} />)
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
+    expect(component.find('input#day').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('')
     expect(component.find('input#day').nodes[0].value).toEqual('')
     expect(component.find('input#year').nodes[0].value).toEqual('')
@@ -106,9 +106,9 @@ describe('The date component', () => {
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl {...expected} />)
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
+    expect(component.find('input#day').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('')
     expect(component.find('input#day').nodes[0].value).toEqual('')
     expect(component.find('input#year').nodes[0].value).toEqual('')
@@ -124,9 +124,9 @@ describe('The date component', () => {
       focus: false,
       valid: false
     }
-    const component = mount(<DateControl name={expected.name} label={expected.label} error={expected.error} focus={expected.focus} valid={expected.valid} value={expected.value} />)
+    const component = mount(<DateControl {...expected} />)
     expect(component.find('label').length).toEqual(children)
-    expect(component.find('input#month').length).toEqual(1)
+    expect(component.find('input#day').length).toEqual(1)
     expect(component.find('input#month').nodes[0].value).toEqual('')
     expect(component.find('input#day').nodes[0].value).toEqual('')
     expect(component.find('input#year').nodes[0].value).toEqual('')

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -130,11 +130,12 @@ export default class DateRange extends ValidationElement {
 
     return (
       <div className={klass}>
-        <div className="usa-grid">
+        <div className="usa-grid from-grid">
           <div className="from-label">
             From date
           </div>
           <DateControl name="from"
+                       className="from"
                        value={this.state.from}
                        estimated={this.state.estimated}
                        receiveProps={this.state.trickleDown}
@@ -145,12 +146,13 @@ export default class DateRange extends ValidationElement {
         <div className="arrow">
           <img src="../img/date-down-arrow.svg" />
         </div>
-        <div className="usa-grid">
+        <div className="usa-grid to-grid">
           <div className="from-label">
             To date
           </div>
           <DateControl name="to"
                        ref="to"
+                       className="to"
                        value={this.state.to}
                        estimated={this.state.estimated}
                        receiveProps={this.state.trickleDown || this.state.presentClicked}

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -82,8 +82,8 @@ export default class DateRange extends ValidationElement {
 
       // This will force a blur/validation
       if (field === 'present') {
-        this.refs.to.refs.month.refs.input.focus()
-        this.refs.to.refs.month.refs.input.blur()
+        this.refs.to.refs.month.refs.autosuggest.input.focus()
+        this.refs.to.refs.month.refs.autosuggest.input.blur()
         this.refs.to.refs.day.refs.input.focus()
         this.refs.to.refs.day.refs.input.blur()
         this.refs.to.refs.year.refs.input.focus()

--- a/src/components/Form/DateRange/DateRange.scss
+++ b/src/components/Form/DateRange/DateRange.scss
@@ -13,20 +13,26 @@
     display: inline-block;
     width: 8rem;
     vertical-align: top;
+    text-align: center;
+    margin-right: 2rem;
   }
 
   .datecontrol {
     display: inline-block;
   }
 
+  .to-grid {
+    margin-top: 5rem;
+  }
+
   .arrow {
     height: 0;
 
     img {
-      width: 1rem;
-      height: 11rem;
-      margin-top: -10rem;
-      margin-left: 3rem;
+      width: 3rem;
+      height: 10.5rem;
+      margin-top: -6rem;
+      margin-left: 2.5rem;
     }
   }
 
@@ -37,6 +43,10 @@
     .or {
       margin-right: 1rem;
     }
+
+    .eapp-blocks-checkbox {
+      width: 15rem;
+    }
   }
 }
 
@@ -44,7 +54,7 @@
   .daterange {
     + .toggle {
       margin-top: 1.5rem;
-      margin-left: -13.8rem;
+      margin-left: -18rem;
     }
   }
 }

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -35,7 +35,7 @@ describe('The date range component', () => {
       }
     }
     const component = mount(<DateRange name={expected.name} onChange={expected.handleChange} />)
-    component.find('input').first().simulate('change')
+    component.find('input#day').first().simulate('change')
     expect(changes).toEqual(1)
   })
 
@@ -56,9 +56,6 @@ describe('The date range component', () => {
     }
     const component = mount(<DateRange name={expected.name} onChange={expected.handleChange} from={expected.from} to={expected.to} />)
     component.find('input[name="present"]').simulate('change')
-    component.find('input[name="month"]').first().simulate('change')
-    component.find('input[name="day"]').first().simulate('change')
-    component.find('input[name="year"]').first().simulate('change')
-    expect(changes).toEqual(4)
+    expect(changes).toEqual(1)
   })
 })

--- a/src/components/Form/Dropdown/Dropdown.jsx
+++ b/src/components/Form/Dropdown/Dropdown.jsx
@@ -242,6 +242,7 @@ export default class Dropdown extends ValidationElement {
                      getSuggestionValue={getSuggestionValue}
                      renderSuggestion={renderSuggestion}
                      inputProps={inputProps}
+                     ref="autosuggest"
                      />
       </div>
     )

--- a/src/components/Form/Dropdown/Dropdown.jsx
+++ b/src/components/Form/Dropdown/Dropdown.jsx
@@ -85,17 +85,6 @@ export default class Dropdown extends ValidationElement {
    */
   handleChange (event) {
     event.persist()
-    // let valid = true
-    // if (this.props.required) {
-    //   if (event.target.value === '') {
-    //     valid = false
-    //   }
-    // }
-
-    // this.setState({value: event.target.value, error: !valid, valid: valid}, () => {
-    //   super.handleChange(event)
-    // })
-
     this.setState({value: event.target.value}, () => {
       super.handleChange(event)
     })
@@ -104,15 +93,18 @@ export default class Dropdown extends ValidationElement {
   handleValidation (event, status, errorCodes) {
     let value = this.state.value
     let valid = value.length > 0 ? false : null
-    this.state.options.forEach(x => {
-      if (x.name.toLowerCase() === value.toLowerCase()) {
-        valid = true
-        value = x.name
-      }
-    })
 
-    if (valid === false) {
-      errorCodes = 'notfound'
+    if (valid !== null) {
+      this.state.options.forEach(x => {
+        if (x.name.toLowerCase() === value.toLowerCase() || x.value.toLowerCase() === value.toLowerCase()) {
+          valid = true
+          value = x.name
+        }
+      })
+
+      if (valid === false) {
+        errorCodes = 'notfound'
+      }
     }
 
     this.setState({
@@ -159,6 +151,7 @@ export default class Dropdown extends ValidationElement {
       ...event,
       target: {
         id: this.props.name,
+        name: this.props.name,
         value: change.newValue
       }
     }

--- a/src/components/Form/Dropdown/Dropdown.test.jsx
+++ b/src/components/Form/Dropdown/Dropdown.test.jsx
@@ -5,7 +5,7 @@ import Dropdown from './Dropdown'
 describe('The Dropdown component', () => {
   it('renders appropriately with an error', () => {
     const expected = {
-      name: 'dropdown',
+      name: 'state',
       value: '',
       className: 'dropdown-test'
     }

--- a/src/components/Form/State/State.jsx
+++ b/src/components/Form/State/State.jsx
@@ -18,7 +18,6 @@ export default class State extends ValidationElement {
                 value={this.props.value}
                 required={this.props.required}
                 >
-        <option value="">{this.props.placeholder}</option>
         <option value="AL">Alabama</option>
         <option value="AK">Alaska</option>
         <option value="AZ">Arizona</option>

--- a/src/components/Form/State/State.test.jsx
+++ b/src/components/Form/State/State.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import State from './State'
 
 describe('The State component', () => {
@@ -9,6 +9,44 @@ describe('The State component', () => {
       value: ''
     }
     const component = shallow(<State {...expected} />).dive()
+    expect(component.find('div').length).toBeGreaterThan(0)
+  })
+
+  it('renders with short value', () => {
+    const expected = {
+      name: 'state',
+      value: 'Arizona',
+      onBlur: () => {},
+      onFocus: () => {}
+    }
+    const component = mount(<State {...expected} />)
+    component.find('input#state').simulate('change', {
+      target: {
+        value: 'AZ'
+      }
+    })
+    component.find('input#state').simulate('focus')
+    expect(component.find('.react-autosuggest__suggestions-list').length).toBeGreaterThan(0)
+    component.find('input#state').simulate('blur')
+    expect(component.find('div').length).toBeGreaterThan(0)
+  })
+
+  it('renders with long value', () => {
+    const expected = {
+      name: 'state',
+      value: 'Arizona',
+      onBlur: () => {},
+      onFocus: () => {}
+    }
+    const component = mount(<State {...expected} />)
+    component.find('input#state').simulate('change', {
+      target: {
+        value: 'arizona'
+      }
+    })
+    component.find('input#state').simulate('focus')
+    expect(component.find('.react-autosuggest__suggestions-list').length).toBeGreaterThan(0)
+    component.find('input#state').simulate('blur')
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 })

--- a/src/components/Section/Foreign/Passport/Passport.test.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.test.jsx
@@ -43,10 +43,17 @@ describe('The passport component', () => {
     const data = {
       Card: 'Book',
       Comments: 'Comment',
-      Expiration: {
-        day: '01',
+      Issued: {
+        day: '1',
         estimated: null,
-        month: '01',
+        month: '1',
+        name: 'issued',
+        year: '2003'
+      },
+      Expiration: {
+        day: '1',
+        estimated: null,
+        month: '1',
         name: 'expiration',
         year: '2004'
       },

--- a/src/components/Section/History/Federal/Federal.test.jsx
+++ b/src/components/Section/History/Federal/Federal.test.jsx
@@ -35,7 +35,7 @@ describe('The federal component', () => {
     expect(component.find('.collection').length).toBe(1)
     component.find({type: 'text', name: 'Position'}).simulate('change')
     component.find({type: 'text', name: 'Name'}).simulate('change')
-    component.find('.collection .datecontrol #month').first().simulate('change')
+    component.find('.collection .datecontrol #day').first().simulate('change')
     component.find('.collection textarea').simulate('change')
     expect(updates).toEqual(4)
   })

--- a/src/components/Section/History/Residence/Residence.test.jsx
+++ b/src/components/Section/History/Residence/Residence.test.jsx
@@ -9,7 +9,6 @@ describe('The residence component', () => {
     }
     const component = mount(<ResidenceItem {...expected} />)
     expect(component.find('.residence').length).toEqual(1)
-    // expect(component.find('.item').length).toEqual(1)
     expect(component.find('.reference').length).toEqual(0)
   })
 

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -156,6 +156,11 @@ const en = {
       }
     },
     month: {
+      notfound: {
+        title: 'Month is not recognized',
+        message: 'The month must be between 1 (January) and 12 (December)',
+        note: ''
+      },
       max: {
         title: 'Month is not recognized',
         message: 'The month must be between 1 (January) and 12 (December)',
@@ -517,10 +522,26 @@ const en = {
         }
       },
       help: {
-        city: 'City where you were born',
-        state: 'State where you were born',
-        country: 'Country where you were born',
-        county: 'County where you were born'
+        city: {
+          title: 'Need help with the city?',
+          message: 'City where you were born',
+          note: ''
+        },
+        state: {
+          title: 'Need help with the state?',
+          message: 'State where you were born',
+          note: ''
+        },
+        country: {
+          title: 'Need help with the country?',
+          message: 'Country where you were born',
+          note: ''
+        },
+        county: {
+          title: 'Need help with the county?',
+          message: 'County where you were born',
+          note: ''
+        }
       },
       label: {
         state: 'State',


### PR DESCRIPTION
Issue #400 

Adjust margins of the date range element. Also, incorporated dropdown selector on the month fields and fixed a bug where typing either the text or value of the option is a valid value.

## Preview

![daterange](https://cloud.githubusercontent.com/assets/697855/23510301/f89fdfd8-ff26-11e6-9deb-0b1805175536.png)
