### PR TITLE
Allow radio buttons to not go back to neutral state

### DIFF
--- a/src/components/Form/Address/Address.jsx
+++ b/src/components/Form/Address/Address.jsx
@@ -288,6 +288,7 @@ export default class Address extends ValidationElement {
           <Radio name="addressType"
                  label={i18n.t('address.options.us.label')}
                  value="United States"
+                 ignoreDeselect="true"
                  disabled={this.props.disabled}
                  onChange={this.handleChange.bind(this, 'addressType')}
                  onValidate={this.props.onValidate}
@@ -297,6 +298,7 @@ export default class Address extends ValidationElement {
           <Radio name="addressType"
                  label={i18n.t('address.options.apoFpo.label')}
                  value="APOFPO"
+                 ignoreDeselect="true"
                  disabled={this.props.disabled}
                  onChange={this.handleChange.bind(this, 'addressType')}
                  onValidate={this.props.onValidate}
@@ -306,6 +308,7 @@ export default class Address extends ValidationElement {
           <Radio name="addressType"
                  label={i18n.t('address.options.international.label')}
                  value="International"
+                 ignoreDeselect="true"
                  disabled={this.props.disabled}
                  onChange={this.handleChange.bind(this, 'addressType')}
                  onValidate={this.props.onValidate}

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -113,13 +113,6 @@ export default class DateControl extends ValidationElement {
         event.target.date = d
         super.handleChange(event)
 
-        // // Always make sure the day is re-validated
-        // if (['month', 'year', 'estimated'].includes(event.target.name)) {
-        //   this.refs.day.refs.input.focus()
-        //   this.refs.day.refs.input.blur()
-        //   event.target.focus()
-        // }
-
         if (this.props.onUpdate) {
           this.props.onUpdate({
             name: this.props.name,
@@ -261,7 +254,6 @@ export default class DateControl extends ValidationElement {
   }
 
   render () {
-    console.log('month:', this.state.month)
     let klass = `datecontrol ${this.props.className || ''} ${this.props.hideDay ? 'day-hidden' : ''}`.trim()
 
     return (

--- a/src/components/Form/Radio/Radio.jsx
+++ b/src/components/Form/Radio/Radio.jsx
@@ -39,8 +39,12 @@ export default class Radio extends ValidationElement {
    * Handle the click event.
    */
   handleClick (event) {
-    let futureChecked = !this.state.checked
-    let futureValue = futureChecked ? this.props.value : ''
+    if (this.props.ignoreDeselect) {
+      return
+    }
+
+    const futureChecked = !this.state.checked
+    const futureValue = futureChecked ? this.props.value : ''
     this.setState({checked: futureChecked, value: futureValue}, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({


### PR DESCRIPTION
Issue #626 

Essentially checkboxes and radio buttons were originally globally allowed to toggle between an active state and a neutral state (not normal in a radio of checkbox group). Still leaving this as this normal state since it is used widely we now can allow us to override this behavior by setting the following property:

```jsx
<Radio name="test" ignoreDeselect="true" />
```

