### PR TITLE
Add "not applicable" component

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -342,6 +342,7 @@ export default class DateControl extends ValidationElement {
                     className={this.props.className}
                     value={this.state.estimated}
                     checked={this.state.estimated}
+                    disabled={this.state.disabled}
                     onChange={this.handleChange}
                     />
         </div>

--- a/src/components/Form/Help/Help.jsx
+++ b/src/components/Form/Help/Help.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { i18n, markdown, markdownById } from '../../../config'
-import ReactMarkdown from 'react-markdown'
 import ValidationElement from '../ValidationElement'
 
 export default class Help extends ValidationElement {

--- a/src/components/Form/NotApplicable/NotApplicable.jsx
+++ b/src/components/Form/NotApplicable/NotApplicable.jsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { i18n } from '../../../config'
+import Checkbox from '../Checkbox'
+
+export default class NotApplicable extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      applicable: props.applicable
+    }
+
+    this.onUpdate = this.onUpdate.bind(this)
+  }
+
+  onUpdate (values) {
+    this.setState({ applicable: !this.state.applicable }, () => {
+      if (this.props.onUpdate) {
+        this.props.onUpdate({
+          name: this.props.name,
+          applicable: this.state.applicable
+        })
+      }
+    })
+  }
+
+  renderChildren () {
+    console.log('not applicable: ', !this.state.applicable)
+    if (this.state.applicable) {
+      return this.props.children
+    }
+
+    // return React.cloneElement(this.props.children, { disabled: true })
+    return React.Children.map(this.props.children, (child) => {
+      let extendedProps = { disabled: true }
+
+      return React.cloneElement(child, {
+        ...child.props,
+        ...extendedProps
+      })
+    })
+  }
+
+  render () {
+    // Append on any classes passed down
+    const klass = `${this.props.className || ''}`.trim()
+    const dithered = this.state.applicable ? '' : 'dithered'
+
+    // When there is nothing special do the status quo
+    return (
+      <div className="not-applicable">
+        <div className={`${klass} button`.trim()}>
+          <Checkbox name={this.props.name}
+                    label={this.props.label}
+                    checked={!this.state.applicable}
+                    onUpdate={this.onUpdate}
+                    />
+        </div>
+        <div className={`${klass} ${dithered} content`.trim()}>
+          {this.renderChildren()}
+        </div>
+      </div>
+    )
+  }
+}
+
+NotApplicable.defaultProps = {
+  name: 'NotApplicable',
+  label: i18n.t('financial.bankruptcy.notApplicable'),
+  applicable: true
+}

--- a/src/components/Form/NotApplicable/NotApplicable.scss
+++ b/src/components/Form/NotApplicable/NotApplicable.scss
@@ -1,0 +1,12 @@
+.not-applicable {
+  display: inline-block;
+
+  .button label {
+    width: 23.5rem;
+    margin-bottom: 4.6rem !important;
+  }
+
+  .dithered {
+    opacity: 0.5;
+  }
+}

--- a/src/components/Form/NotApplicable/NotApplicable.test.jsx
+++ b/src/components/Form/NotApplicable/NotApplicable.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import NotApplicable from './NotApplicable'
+
+describe('The not applicable component', () => {
+  it('displays checkbox button for not applicable along with children', () => {
+    const expected = {
+      name: 'notApplicable'
+    }
+
+    const component = mount(<NotApplicable {...expected}><input type="text" name="inside" /></NotApplicable>)
+    expect(component.find({type: 'checkbox'}).length).toEqual(1)
+    expect(component.find({type: 'text'}).length).toEqual(1)
+  })
+
+  it('displays checkbox button for not applicable along with children', () => {
+    const expected = {
+      name: 'notApplicable',
+      applicable: false
+    }
+
+    const component = mount(<NotApplicable {...expected}><input type="text" name="inside" /></NotApplicable>)
+    expect(component.find({type: 'text'}).nodes[0].disabled).toBe(true)
+  })
+})

--- a/src/components/Form/NotApplicable/NotApplicable.test.jsx
+++ b/src/components/Form/NotApplicable/NotApplicable.test.jsx
@@ -14,12 +14,15 @@ describe('The not applicable component', () => {
   })
 
   it('displays checkbox button for not applicable along with children', () => {
+    let updates = 0
     const expected = {
       name: 'notApplicable',
-      applicable: false
+      onUpdate: () => { updates++ }
     }
 
     const component = mount(<NotApplicable {...expected}><input type="text" name="inside" /></NotApplicable>)
+    component.find({type: 'checkbox'}).simulate('change')
     expect(component.find({type: 'text'}).nodes[0].disabled).toBe(true)
+    expect(updates).toEqual(1)
   })
 })

--- a/src/components/Form/NotApplicable/index.js
+++ b/src/components/Form/NotApplicable/index.js
@@ -1,0 +1,2 @@
+import NotApplicable from './NotApplicable'
+export default NotApplicable

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -18,6 +18,7 @@ import Radio from './Radio'
 import DateControl from './DateControl'
 import Svg from './Svg'
 import Suggestions from './Suggestions'
+import NotApplicable from './NotApplicable'
 
 // Composite components
 import Type from './Type'
@@ -87,5 +88,6 @@ export {
   Show,
   Svg,
   BranchCollection,
-  Suggestions
+  Suggestions,
+  NotApplicable
 }

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { i18n } from '../../../../config'
 import { BankruptcyValidator } from '../../../../validators'
-import { ValidationElement, Branch, Collection, Comments, DateControl, Number, Textarea, Help, HelpIcon,
-         Text, Name, Address, PetitionType, Checkbox } from '../../../Form'
+import { ValidationElement, Branch, Collection, Comments, DateControl, Number, Help, HelpIcon,
+         Text, Name, Address, PetitionType, Checkbox, NotApplicable } from '../../../Form'
 
 export default class Bankruptcy extends ValidationElement {
   constructor (props) {
@@ -174,12 +174,16 @@ export default class Bankruptcy extends ValidationElement {
         </div>
 
         <h3>{i18n.t('financial.bankruptcy.heading.dateDischarged')}</h3>
-        <div className="eapp-field-wrap">
+        <div className="eapp-field-wrap no-label">
           <Help id="financial.bankruptcy.dateDischarged.help">
-            <DateControl name="DateDischarged"
-                         className="datedischarged"
-                         onValidate={this.handleValidation}
-                         hideDay={true} />
+            <NotApplicable name="DischargeDateNotApplicable"
+                           onValidate={this.handleValidation}>
+              <DateControl name="DateDischarged"
+                           className="datedischarged"
+                           receiveProps="true"
+                           onValidate={this.handleValidation}
+                           hideDay={true} />
+            </NotApplicable>
             <HelpIcon className="datedischarged" />
           </Help>
         </div>

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -820,6 +820,7 @@ const en = {
         comments: 'Add optional comments'
       },
       title: 'In the last seven (7) years have you filed a petition under any chapter of the bankruptcy code?',
+      notApplicable: 'Not applicable',
       help: {
         title: 'Need help with bankruptcy?',
         message: 'Note: If you need to provide any additional comments about this information, enter them below.',

--- a/src/validators/bankruptcy.js
+++ b/src/validators/bankruptcy.js
@@ -67,6 +67,7 @@ export class BankruptcyItemValidator {
     this.totalAmount = state.TotalAmount
     this.dateFiled = state.DateFiled
     this.dateDischarged = state.DateDischarged
+    this.dateDischargedNotApplicable = state.DateDischargedNotApplicable
   }
 
   validPetitionType () {
@@ -97,6 +98,10 @@ export class BankruptcyItemValidator {
   }
 
   validDateDischarged () {
+    if (this.dateDischargedNotApplicable && !this.dateDischargedNotApplicable.applicable) {
+      return true
+    }
+
     return validGenericMonthYear(this.dateDischarged)
   }
 

--- a/src/validators/bankruptcy.test.js
+++ b/src/validators/bankruptcy.test.js
@@ -46,45 +46,46 @@ describe('Bankruptcy component validation', function () {
       {
         state: {
           HasBankruptcy: 'Yes',
-          List: [{
-            PetitionType: {
-              value: 'hello'
-            },
-            CourtAddress: {
-              addressType: 'United States',
-              address: '1234 Some Rd',
-              city: 'Arlington',
-              state: 'Virginia',
-              zipcode: '22202'
-            },
-            CourtInvolved: {
-              value: 'Some Court'
-            },
-            CourtNumber: {
-              value: 'C1234'
-            },
-            DateFiled: {
-              month: 1,
-              year: 2010
-            },
-            DateDischarged: {
-              month: 1,
-              year: 2012
-            },
-            NameDebt: {
-              first: 'Foo',
-              firstInitialOnly: false,
-              middle: 'J',
-              middleInitialOnly: true,
-              noMiddleName: false,
-              last: 'Bar',
-              lastInitialOnly: false,
-              suffix: 'Jr'
-            },
-            TotalAmount: {
-              value: 200
+          List: [
+            {
+              PetitionType: {
+                value: 'hello'
+              },
+              CourtAddress: {
+                addressType: 'United States',
+                address: '1234 Some Rd',
+                city: 'Arlington',
+                state: 'Virginia',
+                zipcode: '22202'
+              },
+              CourtInvolved: {
+                value: 'Some Court'
+              },
+              CourtNumber: {
+                value: 'C1234'
+              },
+              DateFiled: {
+                month: 1,
+                year: 2010
+              },
+              DateDischarged: {
+                month: 1,
+                year: 2012
+              },
+              NameDebt: {
+                first: 'Foo',
+                firstInitialOnly: false,
+                middle: 'J',
+                middleInitialOnly: true,
+                noMiddleName: false,
+                last: 'Bar',
+                lastInitialOnly: false,
+                suffix: 'Jr'
+              },
+              TotalAmount: {
+                value: 200
+              }
             }
-          }
           ]
         },
         expected: true
@@ -92,11 +93,59 @@ describe('Bankruptcy component validation', function () {
       {
         state: {
           HasBankruptcy: 'Yes',
-          List: [{
-            PetitionType: {
-              value: 'hello'
+          List: [
+            {
+              PetitionType: {
+                value: 'hello'
+              },
+              CourtAddress: {
+                addressType: 'United States',
+                address: '1234 Some Rd',
+                city: 'Arlington',
+                state: 'Virginia',
+                zipcode: '22202'
+              },
+              CourtInvolved: {
+                value: 'Some Court'
+              },
+              CourtNumber: {
+                value: 'C1234'
+              },
+              DateFiled: {
+                month: 1,
+                year: 2010
+              },
+              DateDischargedNotApplicable: {
+                applicable: false
+              },
+              NameDebt: {
+                first: 'Foo',
+                firstInitialOnly: false,
+                middle: 'J',
+                middleInitialOnly: true,
+                noMiddleName: false,
+                last: 'Bar',
+                lastInitialOnly: false,
+                suffix: 'Jr'
+              },
+              TotalAmount: {
+                value: 200
+              }
             }
-          }]
+          ]
+        },
+        expected: true
+      },
+      {
+        state: {
+          HasBankruptcy: 'Yes',
+          List: [
+            {
+              PetitionType: {
+                value: 'hello'
+              }
+            }
+          ]
         },
         expected: false
       }


### PR DESCRIPTION
Issue #520 

This was broken in to a separate component because it will be used more often in later sections where the design pattern dictates. Essentially we can apply a "not applicable" around any group of elements and allow for the toggling of each child `disabled` property with additional styles.

## Usage

```jsx
<NotApplicable name="FooNotApplicable">
  <DateControl {...this.props.Foo} />
</NotApplicable>
```

## Preview

![bankruptcy-discharge-na](https://cloud.githubusercontent.com/assets/697855/23866078/17a0e8bc-07ee-11e7-9527-7c7ada20416d.png)
