### PR TITLE
Apply vertical-align:top for date controls

### DIFF
--- a/src/components/Form/DateControl/DateControl.scss
+++ b/src/components/Form/DateControl/DateControl.scss
@@ -5,17 +5,20 @@
     width: 14rem;
     display: inline-block;
     margin-right: 1rem;
+    vertical-align: top;
   }
 
   .day {
     width: 7rem;
     display: inline-block;
     margin-right: 1rem;
+    vertical-align: top;
   }
 
   .year {
     width: 8.5rem;
     display: inline-block;
+    vertical-align: top;
   }
 
   .coupled-flags {


### PR DESCRIPTION
Issue #624 

Not sure if the styles were coming from USWDS or internally, but the following classes needed to have `vertical-align: top;` applied:

 - `.usa-form-group .month`
 - `.usa-form-group .day`
 - `.usa-form-group .year`