### PR TITLE
Use 64mb ram for Golang backends

### DIFF
--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: eqip-prototype-api-staging
-  memory: 1G
+  memory: 64M
   instances: 2
   domain: fr.cloud.gov
   host: eqip-prototype-api-staging

--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: eqip-prototype-api
-  memory: 1G
+  memory: 64M
   instances: 2
   domain: fr.cloud.gov
   host: eqip-prototype-api


### PR DESCRIPTION
We're allocating much more RAM than we need:

`production` space:

```
$ cf app eqip-prototype-api
...
#0   running   2017-03-14 02:51:50 PM   0.0%   9.5M of 1G    94.9M of 1G
#1   running   2017-03-14 02:51:49 PM   0.0%   13.1M of 1G   94.9M of 1G
```

`staging` space:

```
$ cf app eqip-prototype-api-staging
...
#0   running   2017-03-15 02:37:30 PM   0.2%   10.3M of 1G   94.9M of 1G
#1   running   2017-03-15 02:37:28 PM   0.2%   6.1M of 1G    94.9M of 1G
```

(RAM usage is the the fifth column above)