### PR TITLE
Split docker-compose configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ yarn test
 The individual test results will be seen in the output, and the coverage
 results may be viewed after running ```yarn test```.
 
+### Executing feature specifications
+
+Running the feature specifications is an on-demand process and can be ran through [docker-compose][20] by specifying a different configuration file:
+
+```
+docker-compose -f nightwatch-compose.yml up
+```
+
 ### Packaging Application
 
 To package up the application, use the command:

--- a/nightwatch-compose.yml
+++ b/nightwatch-compose.yml
@@ -30,19 +30,6 @@ services:
     depends_on:
       - api
 
-  frontend:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend
-    env_file:
-      - .env
-    volumes:
-      - .:/usr/src/app
-      - /usr/src/app/node_modules
-    command: ./build-frontend.sh
-    networks:
-      - private
-
   api:
     build:
       context: .
@@ -63,6 +50,43 @@ services:
       - private
     depends_on:
       - db
+
+  hub:
+    image: selenium/hub:latest
+    expose:
+      - '4444'
+    networks:
+      - private
+
+  # Selenium nodes currently don't support docker networks.
+  # To get around this we emulate what `--link` would create for
+  # environment variables.
+  #
+  # Reference: https://github.com/SeleniumHQ/docker-selenium/issues/133
+  chrome:
+    image: selenium/node-chrome:latest
+    environment:
+      HUB_PORT_4444_TCP_ADDR: hub
+      HUB_PORT_4444_TCP_PORT: 4444
+    volumes:
+      - /dev/shm:/dev/shm
+    networks:
+      - private
+    depends_on:
+      - hub
+
+  nightwatch:
+    build:
+      context: .
+      dockerfile: Dockerfile.nightwatch
+    command: [npm, run, docker]
+    volumes:
+      - ./specs:/usr/src/app
+    networks:
+      - private
+    depends_on:
+      - chrome
+      - web
 
 networks:
   private:


### PR DESCRIPTION
This will allow the regular `docker-compose up` to run with just what it needs. If the feature specification suite needs to run please execute `docker-compose -f nightwatch-compose.yml up`.