### PR TITLE
Update the URL for Glide

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,2 +1,2 @@
 FROM golang:1.7
-RUN curl https://glide.sh/get | sh
+RUN curl https://raw.githubusercontent.com/Masterminds/glide.sh/master/get | sh

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,2 +1,2 @@
 FROM golang:1.7
-RUN curl https://raw.githubusercontent.com/Masterminds/glide.sh/master/get | sh
+RUN go get -u github.com/Masterminds/glide

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,2 +1,6 @@
 FROM golang:1.7
-RUN go get -u github.com/Masterminds/glide
+RUN go get -u github.com/Masterminds/glide; \
+    cd $GOPATH/src/github.com/Masterminds/glide; \
+    git checkout tags/$(git describe --tags $(git rev-list --tags --max-count=1)); \
+    go install; \
+    cd $GOPATH/src


### PR DESCRIPTION
The URL to `https://glide.sh` went down and needs to be updated to ensure correct builds from a trusted source.

 - **Original**: 

```sh
curl https://glide.sh/get | sh
```

 - **Option 1**:

```sh
curl https://raw.githubusercontent.com/Masterminds/glide.sh/master/get | sh
```

This failed possibly due to references to the invalid URL.

 - **Option 2**:

```sh
go get -u github.com/Masterminds/glide
```

This works but pulls from `tip` rather than a `release` version.

 - **Option 3**:

```sh
go get -u github.com/Masterminds/glide
cd $GOPATH/src/github.com/Masterminds/glide
git checkout tags/$(git describe --tags $(git rev-list --tags --max-count=1))
go install
```

Here we use `go get` to pull the repository and store it in the `$GOPATH` appropriately. Then we checkout the latest tagged release and run `go install`.