### PR TITLE
Accordion addendum title now H3

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -218,7 +218,7 @@ export default class Accordion extends ValidationElement {
 
     let title = null
     if (this.props.appendTitle) {
-      title = <h2>{this.props.appendTitle}</h2>
+      title = <h3>{this.props.appendTitle}</h3>
     }
 
     let message = null


### PR DESCRIPTION
Issue: #832 

Changed from `H2` to `H3` for the title of the addendum section of the `Accordion`