### PR TITLE
Increased bottom margin on close link

### DIFF
--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -77,6 +77,7 @@
         padding: 1rem;
         cursor: pointer;
         text-decoration: none;
+        margin-bottom: 2.2rem;
 
         span {
           border-bottom: 1px dashed $eapp-blue;


### PR DESCRIPTION
Issue: #838 

Increased the bottom margin on the _close_ link at the bottom of an open accordion pane.