### PR TITLE
Re-aligned help icon on relative type selection

### DIFF
--- a/src/components/Section/Family/Relatives/Relative.scss
+++ b/src/components/Section/Family/Relatives/Relative.scss
@@ -9,6 +9,7 @@
     top: 25% !important;
   }
 
+  .relative-relation,
   .relative-residence-documentnumber,
   .relative-courtname,
   .relative-employer-relationship,

--- a/src/components/Section/Family/Relatives/Relatives.scss
+++ b/src/components/Section/Family/Relatives/Relatives.scss
@@ -7,20 +7,26 @@
     top: 25% !important;
   }
 
-  .relatives-relation label {
-    height: 10rem;
-    width: 18rem;
-    overflow: hidden;
+  .relatives-relation {
+    display: inline-block;
+    width: 92%;
+    max-width: 64rem;
 
-    > span {
-      display: block;
-      height: 100%;
+    label {
+      height: 10rem;
+      width: 18rem;
+      overflow: hidden;
 
-      > div {
-        top: 35%;
+      > span {
+        display: block;
+        height: 100%;
 
-        > p {
-          padding: 0;
+        > div {
+          top: 35%;
+
+          > p {
+            padding: 0;
+          }
         }
       }
     }


### PR DESCRIPTION
Issue: #837 

Re-align the help icon for the relative type selection(s) in `Relatives` and `Relative` components.