### PR TITLE
Fix scrolling messages in to view

### DIFF
--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -336,5 +336,6 @@ Field.defaultProps = {
   commentsActive: false,
   commentsAdd: 'comments.add',
   commentsRemove: 'comments.remove',
-  shrink: false
+  shrink: false,
+  scrollIntoView: true
 }


### PR DESCRIPTION
Issue #981 

During refactoring of the `Field` component it appears the default value for the property `scrollIntoView` was dropped.