### PR TITLE
Add missing not applicable to taxes section

### DIFF
--- a/src/components/Section/Financial/Taxes/Taxes.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { i18n } from '../../../../config'
 import { TaxesValidator } from '../../../../validators'
 import { ValidationElement, Branch, Show, Accordion, DateControl, Number, Field,
-         Checkbox, Text, Textarea } from '../../../Form'
+         Checkbox, Text, Textarea, NotApplicable } from '../../../Form'
 import FailureType from './FailureType'
 
 export default class Taxes extends ValidationElement {
@@ -187,13 +187,18 @@ export default class Taxes extends ValidationElement {
 
             <Field title={i18n.t('financial.taxes.heading.date')}
                    help="financial.taxes.help.date"
-                   adjustFor="labels"
+                   adjustFor="buttons"
                    shrink={true}>
-              <DateControl name="Date"
-                           className="taxes-date"
-                           hideDay={true}
-                           bind={true}
-                           />
+              <NotApplicable name="DateNotApplicable"
+                             label={i18n.t('financial.taxes.label.notapplicable')}
+                             or={i18n.m('financial.taxes.para.or')}
+                             bind={true}>
+                <DateControl name="Date"
+                             className="taxes-date"
+                             hideDay={true}
+                             bind={true}
+                             />
+              </NotApplicable>
             </Field>
 
             <Field title={i18n.t('financial.taxes.heading.description')}

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -1011,7 +1011,11 @@ const en = {
         file: 'File',
         pay: 'Pay',
         both: 'Both',
-        estimated: 'Estimated'
+        estimated: 'Estimated',
+        notapplicable: 'Not applicable'
+      },
+      para: {
+        or: 'or'
       },
       placeholder: {
         year: '2016',


### PR DESCRIPTION
Issue: #952 

There was a missing `NotApplicable` wrapper around a field in the **taxes** section.