### PR TITLE
Allow overflow to be visible on extended buttons

### DIFF
--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -186,6 +186,7 @@ select {
       height: 7.6rem;
       min-width: 12rem;
       cursor: pointer;
+      overflow: visible;
 
       input[type='checkbox'],
       input[type='radio'] {


### PR DESCRIPTION
Issue: #985 

Overflow needed to be visible since the span is positioned outside of its parent.