### PR TITLE
Apply fix to resolve items being reordered

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-markdown": "^2.4.4",
     "react-test-renderer": "^15.3.2",
     "react-tokeninput": "^2.4.0",
+    "smoothscroll-polyfill": "^0.3.5",
     "uswds": "^0.13.1",
     "webpack": "^1.13.3",
     "webpack-stream": "^3.2.0"

--- a/src/boot.jsx
+++ b/src/boot.jsx
@@ -8,6 +8,10 @@ import store from './store'
 import { api } from './services/api'
 import { handleLoginSuccess, handleTwoFactorSuccess } from './actions/AuthActions'
 
+// This polyfill gives us more control over smooth scrolling throughout the application
+import smoothscroll from 'smoothscroll-polyfill'
+smoothscroll.polyfill()
+
 const app = document.getElementById('app')
 
 ReactDOM.render(

--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -11,13 +11,32 @@ export const chevron = (item = {}) => {
   return `toggle fa fa-chevron-${item.open ? 'up' : 'down'}`
 }
 
+export const doScroll = (first, item, scrollTo) => {
+  if (!first || !item || !scrollTo) {
+    return
+  }
+
+  // Get the position of the element we want to be visible
+  const pos = findPosition(document.getElementById(item.uuid))
+
+  // Get the top most point we want to display at least on the first addition
+  const top = findPosition(scrollTo)
+
+  // Find the offset from the top most element to the first item in the accordion for
+  // a fixed offset to constantly be applied
+  const offset = findPosition(document.getElementById(first)) - top
+
+  // Scroll to that position
+  window.scroll({ top: pos - offset, left: 0, behavior: 'smooth' })
+}
+
 export default class Accordion extends ValidationElement {
   constructor (props) {
     super(props)
 
     this.state = {
       initial: props.initial,
-      scrollToIndex: -1
+      scrollToId: ''
     }
 
     this.update = this.update.bind(this)
@@ -72,22 +91,40 @@ export default class Accordion extends ValidationElement {
    * item in to view.
    */
   componentDidUpdate () {
-    if (this.state.scrollToIndex !== -1) {
-      // Get the position of the element we want to be visible
-      const pos = findPosition(document.getElementById(this.props.items[this.state.scrollToIndex].uuid))
-
-      // Get the top most point we want to display at least on the first addition
-      const top = this.props.scrollTo
-            ? findPosition(document.getElementById(this.props.scrollTo))
-            : findPosition(this.refs.accordion)
-
-      // Find the offset from the top most element to the first item in the accordion for
-      // a fixed offset to constantly be applied
-      const offset = findPosition(document.getElementById(this.props.items[0].uuid)) - top
-
-      // Scroll to that position
-      window.scroll(0, pos - offset)
+    if (!this.state.scrollToId) {
+      return
     }
+
+    // Capture the UUID in a constant variable to ensure we don't lose scope
+    const id = this.state.scrollToId
+
+    // Reset the values to prohibit multiple calls due to various
+    // asynchronous behaviours potentially coming from outside this
+    // component
+    this.setState({ initial: false, scrollToId: '' }, () => {
+      // Find the item by UUID instead of index because we can't true the index
+      // will always be the same
+      const item = this.props.items.filter(x => x.uuid === id)[0]
+
+      // Calculate a magic number to phase the timeout value. This always
+      // for any CSS keyframe animations or transitions to take place prior
+      // to finding coordinates.
+      const index = this.props.items.findIndex(x => x.uuid === id)
+      const sindex = index < 0 ? 0 : index
+      const shift = (sindex / 10) * 0.3142
+      const timeout = this.props.timeout + (this.props.timeout * shift)
+      console.log('timeout', timeout)
+
+      const scrollTo = this.props.scrollTo
+            ? document.getElementById(this.props.scrollTo)
+            : this.refs.accordion
+
+      if (timeout === 0) {
+        doScroll(this.props.items[0], item, scrollTo)
+      } else {
+        window.setTimeout(() => { doScroll(this.props.items[0], item, scrollTo) }, timeout)
+      }
+    })
   }
 
   /**
@@ -103,15 +140,16 @@ export default class Accordion extends ValidationElement {
    * Flip the `open` bit for the item.
    */
   toggle (item) {
-    this.update(this.props.items.map(x => {
+    const items = [...this.props.items].map(x => {
       if (x.uuid === item.uuid) {
         x.open = !x.open
       }
 
       return x
-    }))
+    })
 
-    this.setState({ initial: false, scrollToIndex: -1 })
+    this.update(items)
+    this.setState({ initial: false, scrollToId: '' })
   }
 
   /**
@@ -131,8 +169,10 @@ export default class Accordion extends ValidationElement {
       item.open = false
     }
 
-    this.update(items.concat([this.newItem()]))
-    this.setState({ initial: false, scrollToIndex: items.length - 1 })
+    const item = this.newItem()
+    items = items.concat([item])
+    this.update(items)
+    this.setState({ initial: false, scrollToId: item.uuid })
   }
 
   /**
@@ -141,7 +181,7 @@ export default class Accordion extends ValidationElement {
   remove (item) {
     // Confirm deletion first
     if (this.props.skipWarning || window.confirm(i18n.t('collection.warning')) === true) {
-      let items = this.props.items.filter(x => {
+      let items = [...this.props.items].filter(x => {
         return x.uuid !== item.uuid
       })
 
@@ -150,7 +190,7 @@ export default class Accordion extends ValidationElement {
       }
 
       this.update(items)
-      this.setState({ initial: false, scrollToIndex: -1 })
+      this.setState({ initial: false, scrollToId: '' })
     }
   }
 
@@ -192,10 +232,16 @@ export default class Accordion extends ValidationElement {
     })
   }
 
+  /**
+   * Return the appropriate verbiage to use based on the items open state
+   */
   openText (item = {}) {
     return item.open ? this.props.closeLabel : this.props.openLabel
   }
 
+  /**
+   * Render the item summary which can be overriden with `customSummary`
+   */
   summary (item, index, initial = false) {
     return (
       <div>
@@ -219,6 +265,9 @@ export default class Accordion extends ValidationElement {
     )
   }
 
+  /**
+   * Render the item details which can be overriden with `customDetails`
+   */
   details (item, index, initial = false) {
     return (
       <div className={`details ${openState(item, initial)}`}>
@@ -236,7 +285,11 @@ export default class Accordion extends ValidationElement {
   content () {
     // Ensure we have the minimum amount of items required
     const initial = this.state.initial
-    return this.props.items.sort(this.props.sort).map((item, index, arr) => {
+    const items = this.props.sort
+          ? [...this.props.items].sort(this.props.sort)
+          : [...this.props.items]
+
+    return items.map((item, index, arr) => {
       return (
         <div className="item" id={item.uuid} key={item.uuid}>
           {
@@ -253,6 +306,9 @@ export default class Accordion extends ValidationElement {
     })
   }
 
+  /**
+   * Render the accordion addendum notice
+   */
   addendum () {
     if (!this.props.appendTitle && !this.props.appendMessage) {
       return null
@@ -283,6 +339,10 @@ export default class Accordion extends ValidationElement {
     )
   }
 
+  /**
+   * Render the accordion caption which is essentially a `table-caption`
+   * for the accordion
+   */
   caption () {
     return this.props.caption
       ? <div className="caption">{this.props.caption()}</div>
@@ -332,7 +392,8 @@ Accordion.defaultProps = {
   description: i18n.t('collection.summary'),
   caption: null,
   scrollTo: '',
-  sort: (a, b) => { return -1 },
+  timeout: 500,
+  sort: null,
   onUpdate: () => {},
   onValidate: () => {},
   summary: (item, index, initial = false) => {

--- a/src/components/Form/Accordion/Accordion.test.jsx
+++ b/src/components/Form/Accordion/Accordion.test.jsx
@@ -34,6 +34,7 @@ describe('The accordion component', () => {
     const expected = {
       minimum: 1,
       items: items,
+      timeout: 0,
       onUpdate: (x) => { items = x }
     }
     const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)

--- a/src/components/Form/Address/index.js
+++ b/src/components/Form/Address/index.js
@@ -1,2 +1,3 @@
-import Address from './Address'
+import Address, { throttle } from './Address'
 export default Address
+export { throttle }


### PR DESCRIPTION
Issue: #1041 

It appears two issues were surrounding this:
 1. At some indeterminate point the items in the array could be reordered
 2. The scrolling was initiated too quickly and did not account for the CSS animations/transitions to complete first thus throwing off the targeted position on the page

This may also resolve the issue on Safari browsers.