### PR TITLE
Font sizes and misc

### DIFF
--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -97,6 +97,10 @@
         padding: 0 5.5%;
       }
 
+      h2 {
+        margin-top: 10rem;
+      }
+
       > .close {
         display: block;
         text-align: right;

--- a/src/components/Form/Address/Address.jsx
+++ b/src/components/Form/Address/Address.jsx
@@ -178,7 +178,7 @@ export default class Address extends ValidationElement {
 
     return (
       <div className={klass}>
-        <label className="bold">{this.props.label}</label>
+        <label>{this.props.label}</label>
         <RadioGroup className="address-options" selectedValue={this.state.addressType}>
           <Radio name="addressType"
                  label={i18n.m('address.options.us.label')}
@@ -468,6 +468,7 @@ export default class Address extends ValidationElement {
 
 Address.defaultProps = {
   suggestions: [],
+  label: i18n.t('address.label'),
   validate: false,
   geocodeErrorCode: null,
   tab: (input) => { input.focus() },

--- a/src/components/Form/Address/Address.scss
+++ b/src/components/Form/Address/Address.scss
@@ -54,8 +54,8 @@
     }
   }
 
-  label.bold {
-    font-weight: 600;
+  > label {
+    margin-top: 0.6rem;
   }
 
   .address-suggestion {

--- a/src/components/Form/Field/Field.scss
+++ b/src/components/Form/Field/Field.scss
@@ -5,15 +5,11 @@
   border-left: 0.75rem solid #fff;
   padding-left: 1rem;
   margin-left: -1.75rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 7rem;
 
   &.with-comments {
     border-left: 0.75rem solid $eapp-grey-light;
     padding-left: 1rem;
-  }
-
-  @media screen and (max-width: 1100px) {
-    margin-bottom: 1.5rem;
   }
 
   > .title {
@@ -34,27 +30,28 @@
     }
 
     &.h2 {
-      font-size: 4rem;
-
-      @media screen and (max-width: 1100px) {
-        font-size: 3rem;
-      }
+      font-size: 2.75rem;
     }
 
     &.h3 {
-      font-size: 2.3rem;
-
-      @media screen and (max-width: 1100px) {
-        font-size: 1.8rem;
-      }
+      font-size: 1.85rem;
+      margin-top: 1.5rem;
+      line-height: 1.7;
     }
 
     &.h4 {
       font-size: 1.7rem;
+      line-height: 1.7;
     }
 
     &.h5 {
+      font-size: 1.6rem;
+      line-height: 1.6;
+    }
+
+    &.h6 {
       font-size: 1.5rem;
+      line-height: 1.7;
     }
   }
 

--- a/src/components/Form/NotApplicable/NotApplicable.scss
+++ b/src/components/Form/NotApplicable/NotApplicable.scss
@@ -6,10 +6,6 @@
     margin-bottom: 4.6rem !important;
   }
 
-  .button p {
-    margin-top: -2rem;
-    padding-bottom: 2rem !important;
-  }
   .or {
     margin-top: 2rem;
     margin-bottom: 2rem;

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -198,7 +198,7 @@ export default class Telephone extends ValidationElement {
 
   dsn () {
     return (
-      <div>
+      <div className="numbers">
         <label className={this.state.noNumber ? 'disabled' : ''}>{i18n.t('telephone.dsn.label')}</label>
         <Text name="dsn_first"
               className="number three"
@@ -250,7 +250,7 @@ export default class Telephone extends ValidationElement {
 
   domestic () {
     return (
-      <div>
+      <div className="numbers">
         <label className={this.state.noNumber ? 'disabled' : ''}>{i18n.t('telephone.domestic.label')}</label>
 
         <span className="separator">(</span>
@@ -305,7 +305,7 @@ export default class Telephone extends ValidationElement {
               onBlur={this.handleBlur}
               onValidate={this.handleValidation}
               />
-        <span className="separator"></span>
+        <span className="separator pound">#</span>
         <Text name="domestic_extension"
               className="number six"
               placeholder="000000"
@@ -336,7 +336,7 @@ export default class Telephone extends ValidationElement {
 
   international () {
     return (
-      <div className="international">
+      <div className="international numbers">
         <label className={this.state.noNumber ? 'disabled' : ''}>{i18n.t('telephone.international.label')}</label>
         <span className="separator">+</span>
         <Text name="int_first"
@@ -372,7 +372,7 @@ export default class Telephone extends ValidationElement {
               onBlur={this.handleBlur}
               onValidate={this.handleValidation}
               />
-        <span className="separator"></span>
+        <span className="separator pound">#</span>
         <Text name="domestic_extension"
               className="number six"
               placeholder="000000"

--- a/src/components/Form/Telephone/Telephone.scss
+++ b/src/components/Form/Telephone/Telephone.scss
@@ -1,6 +1,13 @@
 .telephone {
   display: inline-block;
 
+  .numbers {
+    > label {
+      font-weight: bold;
+      margin-bottom: -2.6rem;
+    }
+  }
+
   .number {
     &.three {
       width: 8rem;
@@ -29,8 +36,12 @@
   }
 
   .separator.extension {
-    padding-left: 2rem;
-    padding-right: 2rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .separator.pound {
+    margin-left: 1rem;
   }
 
   .number, .separator {
@@ -54,7 +65,7 @@
   }
 
   .timeofday {
-    margin-top: -1rem;
+    margin-top: -2rem;
     margin-bottom: 2rem;
     margin-left: 1.5rem;
     z-index: 1;

--- a/src/components/Section/Design/Design.jsx
+++ b/src/components/Section/Design/Design.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { push } from '../../../middleware/history'
+import { i18n } from '../../../config'
+import AuthenticatedView from '../../../views/AuthenticatedView'
+import { updateApplication, reportErrors, reportCompletion } from '../../../actions/ApplicationActions'
+import { ValidationElement, IntroHeader } from '../../Form'
+import { SectionViews, SectionView } from '../SectionView'
+import Headings from './Headings'
+
+class Design extends ValidationElement {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      subsection: props.subsection
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        <SectionViews current={this.props.subsection} dispatch={this.props.dispatch}>
+          <SectionView name="">
+            <Headings />
+          </SectionView>
+
+          <SectionView name="headings">
+            <Headings />
+          </SectionView>
+        </SectionViews>
+      </div>
+    )
+  }
+}
+
+function mapStateToProps (state) {
+  let section = state.section || {}
+  return {
+    Section: section
+  }
+}
+
+Design.defaultProps = {
+  subsection: ''
+}
+
+export default connect(mapStateToProps)(AuthenticatedView(Design))

--- a/src/components/Section/Design/Design.test.jsx
+++ b/src/components/Section/Design/Design.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import MockAdapter from 'axios-mock-adapter'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { mount } from 'enzyme'
+import { Provider } from 'react-redux'
+import Design from './Design'
+
+describe('The citizenship section', () => {
+  // Setup
+  const middlewares = [ thunk ]
+  const mockStore = configureMockStore(middlewares)
+
+  it('hidden when not authenticated', () => {
+    const store = mockStore({ authentication: [], application: {} })
+    const component = mount(<Provider store={store}><Design /></Provider>)
+    expect(component.find('div').length).toEqual(0)
+  })
+
+  it('visible when authenticated', () => {
+    const store = mockStore({ authentication: { authenticated: true, twofactor: true, application: {} } })
+    const component = mount(<Provider store={store}><Design /></Provider>)
+    expect(component.find('div').length).toBeGreaterThan(0)
+  })
+
+  it('can go to each subsection', () => {
+    const sections = ['headings']
+    const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
+
+    sections.forEach((section) => {
+      const component = mount(<Provider store={store}><Design subsection={section} /></Provider>)
+      expect(component.find('div').length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/src/components/Section/Design/Headings/Headings.jsx
+++ b/src/components/Section/Design/Headings/Headings.jsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import { i18n } from '../../../../config'
+import { ValidationElement, Branch, Field, Telephone, Accordion, Country,
+         Address, RadioGroup, Radio, DateRange, DateControl, Text, Name } from '../../../Form'
+
+export default class Headings extends ValidationElement {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      List: props.List || []
+    }
+
+    this.summary = this.summary.bind(this)
+    this.updateList = this.updateList.bind(this)
+  }
+
+  updateList (items) {
+    this.setState({ List: items })
+  }
+
+  summary (item, index) {
+    let number = i18n.t('identification.contacts.collection.summary.unknownPhone')
+    if (item.Telephone && !item.noNumber && item.Telephone.number) {
+      number = item.Telephone.number
+
+      switch (item.Telephone.type) {
+        case 'DSN':
+          number = `${number.slice(0, 3)}-${number.slice(3, 7)}`
+          break
+
+        case 'International':
+          number = `+${number.slice(0, 3)} ${number.slice(3, 13)}`
+          if (item.Telephone.extension) {
+            number += ` x${item.Telephone.extension}`
+          }
+          break
+
+        case 'Domestic':
+        default:
+          number = `(${number.slice(0, 3)}) ${number.slice(3, 6)}-${number.slice(6, 10)}`
+          if (item.Telephone.extension) {
+            number += ` x${item.Telephone.extension}`
+          }
+          break
+      }
+    }
+
+    return (
+      <span>
+        <span className="index">{i18n.t('identification.contacts.collection.summary.phoneNumber')} {index + 1}:</span>
+        <span><strong>{number}</strong></span>
+      </span>
+    )
+  }
+
+  render () {
+    return (
+      <div className="headings">
+        <h2>(h2) Section title</h2>
+
+        <Field title="(h3) Name component">
+          <Name name="TestName" />
+        </Field>
+
+        <Field title="(h3) Date component with no day" adjustFor="labels">
+          <DateControl name="TestDateWithNoDay" hideDay={true} />
+        </Field>
+
+        <Field title="(h4) Text component" titleSize="h4">
+          <Text name="TestH4" />
+        </Field>
+
+        <Field title="(h5) Text component" titleSize="h5">
+          <Text name="TestH5" />
+        </Field>
+
+        <Field title="(h6) Text component" titleSize="h6">
+          <Text name="TestH6" />
+        </Field>
+
+        <Field title="(h3) Date range component" titleSize="h4" adjustFor="daterange">
+          <DateRange name="TestDateRange" />
+        </Field>
+
+        <Field title="(h3) RadioGroup component" adjustFor="buttons">
+          <RadioGroup>
+            <Radio name="citizenship-status-citizen"
+                   label={i18n.t('citizenship.status.label.citizenshipstatus.citizen')}
+                   value="Citizen"
+                   className="citizenship-status-citizen"
+                   onChange={this.updateCitizenshipStatus}
+                   />
+            <Radio name="citizenship-status-foreignborn"
+                   label={i18n.t('citizenship.status.label.citizenshipstatus.foreignborn')}
+                   value="ForeignBorn"
+                   className="citizenship-status-foreignborn"
+                   onChange={this.updateCitizenshipStatus}
+                   />
+            <Radio name="citizenship-status-naturalized"
+                   label={i18n.m('citizenship.status.label.citizenshipstatus.naturalized')}
+                   value="Naturalized"
+                   className="citizenship-status-naturalized"
+                   onChange={this.updateCitizenshipStatus}
+                   />
+            <Radio name="citizenship-status-derived"
+                   label={i18n.m('citizenship.status.label.citizenshipstatus.derived')}
+                   value="Derived"
+                   className="citizenship-status-derived"
+                   onChange={this.updateCitizenshipStatus}
+                   />
+            <Radio name="citizenship-status-notcitizen"
+                   label={i18n.m('citizenship.status.label.citizenshipstatus.notcitizen')}
+                   value="NotCitizen"
+                   className="citizenship-status-notcitizen"
+                   onChange={this.updateCitizenshipStatus}
+                   />
+          </RadioGroup>
+        </Field>
+
+        <Field title="(h3) Address component" adjustFor="big-buttons">
+          <Address name="TestAddress" />
+        </Field>
+
+        <Branch label="(h3) Branch component" labelSize="h3" />
+
+        <Field title="(h3) Country component with single value">
+          <Country name="TestCountrySingle" />
+        </Field>
+
+        <Field title="(h3) Country component with multiple value">
+          <Country name="TestCountrySingle" multiple={true} />
+        </Field>
+
+        <h3>(h3) {i18n.t('identification.contacts.heading.phoneNumber')}</h3>
+        <p>(p) {i18n.t('identification.contacts.para.phoneNumber')}</p>
+
+        <Accordion minimum="1"
+                   items={this.state.List}
+                   summary={this.summary}
+                   description={i18n.t('identification.contacts.collection.phoneNumbers.summary.title')}
+                   appendLabel={i18n.t('identification.contacts.collection.phoneNumbers.append')}
+                   onUpdate={this.updateList}>
+          <Field help="identification.contacts.help.phoneNumber">
+            <Telephone name="Telephone" bind={true} />
+          </Field>
+        </Accordion>
+      </div>
+    )
+  }
+}
+
+Headings.defaultProps = {
+  List: []
+}

--- a/src/components/Section/Design/Headings/Headings.jsx
+++ b/src/components/Section/Design/Headings/Headings.jsx
@@ -20,36 +20,10 @@ export default class Headings extends ValidationElement {
   }
 
   summary (item, index) {
-    let number = i18n.t('identification.contacts.collection.summary.unknownPhone')
-    if (item.Telephone && !item.noNumber && item.Telephone.number) {
-      number = item.Telephone.number
-
-      switch (item.Telephone.type) {
-        case 'DSN':
-          number = `${number.slice(0, 3)}-${number.slice(3, 7)}`
-          break
-
-        case 'International':
-          number = `+${number.slice(0, 3)} ${number.slice(3, 13)}`
-          if (item.Telephone.extension) {
-            number += ` x${item.Telephone.extension}`
-          }
-          break
-
-        case 'Domestic':
-        default:
-          number = `(${number.slice(0, 3)}) ${number.slice(3, 6)}-${number.slice(6, 10)}`
-          if (item.Telephone.extension) {
-            number += ` x${item.Telephone.extension}`
-          }
-          break
-      }
-    }
-
     return (
       <span>
         <span className="index">{i18n.t('identification.contacts.collection.summary.phoneNumber')} {index + 1}:</span>
-        <span><strong>{number}</strong></span>
+        <span><strong>{i18n.t('identification.contacts.collection.summary.unknownPhone')}</strong></span>
       </span>
     )
   }

--- a/src/components/Section/Design/Headings/Headings.scss
+++ b/src/components/Section/Design/Headings/Headings.scss
@@ -1,0 +1,23 @@
+.headings {
+  .citizenship-status-citizen label,
+  .citizenship-status-foreignborn label,
+  .citizenship-status-naturalized label,
+  .citizenship-status-derived label,
+  .citizenship-status-notcitizen label {
+    width: 100%;
+    height: 12rem;
+    width: 30rem;
+    padding-top: 1.75rem;
+
+    > span {
+      display: inline-block;
+      line-height: 1.6;
+    }
+  }
+
+  .citizenship-status-notcitizen label,
+  .citizenship-status-naturalized label,
+  .citizenship-status-derived label {
+    padding-top: 3rem;
+  }
+}

--- a/src/components/Section/Design/Headings/Headings.test.jsx
+++ b/src/components/Section/Design/Headings/Headings.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import Headings from './Headings'
+
+describe('The headings component', () => {
+  it('no error on empty', () => {
+    const expected = {
+      name: 'headings'
+    }
+    const component = mount(<Headings {...expected} />)
+    expect(component.find('.headings').length).toBe(1)
+  })
+})

--- a/src/components/Section/Design/Headings/index.js
+++ b/src/components/Section/Design/Headings/index.js
@@ -1,0 +1,2 @@
+import Headings from './Headings'
+export default Headings

--- a/src/components/Section/Design/index.js
+++ b/src/components/Section/Design/index.js
@@ -1,0 +1,2 @@
+import Design from './Design'
+export default Design

--- a/src/components/Section/Financial/Delinquent/Delinquent.jsx
+++ b/src/components/Section/Financial/Delinquent/Delinquent.jsx
@@ -118,7 +118,7 @@ export default class Delinquent extends ValidationElement {
     return (
       <div className="delinquent">
         <Branch name="has_delinquent"
-                className="delinquent-branch eapp-field-wrap no-label"
+                className="delinquent-branch eapp-field-wrap"
                 value={this.state.HasDelinquent}
                 help="financial.delinquent.help.branch"
                 onUpdate={this.updateBranch}>

--- a/src/components/Section/History/Education/Education.scss
+++ b/src/components/Section/History/Education/Education.scss
@@ -1,9 +1,4 @@
 .history {
-  .school-name {
-    width: 92%;
-    display: inline-block;
-  }
-
   .type label,
   .diploma label {
     width: 25rem;

--- a/src/components/Section/History/Employment/AdditionalActivity.jsx
+++ b/src/components/Section/History/Employment/AdditionalActivity.jsx
@@ -1,28 +1,16 @@
 import React from 'react'
 import { i18n } from '../../../../config'
-import { ValidationElement, Show, Accordion, DateRange, Text, Field, Branch } from '../../../Form'
+import { ValidationElement, Show, BranchCollection, DateRange, Text, Field } from '../../../Form'
 
 export default class AdditionalActivity extends ValidationElement {
   constructor (props) {
     super(props)
+
     this.state = {
-      List: props.List || [],
-      HasAdditionalActivity: props.HasAdditionalActivity
+      List: props.List
     }
 
-    this.onBranchUpdate = this.onBranchUpdate.bind(this)
     this.myDispatch = this.myDispatch.bind(this)
-  }
-
-  doUpdate () {
-    if (this.props.onUpdate) {
-      let update = {
-        name: this.props.name,
-        List: this.state.List,
-        HasAdditionalActivity: this.state.HasAdditionalActivity || ''
-      }
-      this.props.onUpdate(update)
-    }
   }
 
   /**
@@ -36,22 +24,12 @@ export default class AdditionalActivity extends ValidationElement {
 
   myDispatch (collection) {
     this.setState({ List: collection }, () => {
-      this.doUpdate()
-    })
-  }
-
-  onBranchUpdate (val) {
-    let list = [...this.state.List]
-    if (val === 'No') {
-      list = []
-    }
-    this.setState({ HasAdditionalActivity: val, List: list }, () => {
       if (this.props.onUpdate) {
-        this.props.onUpdate({
+        let update = {
           name: this.props.name,
-          List: this.state.List,
-          HasAdditionalActivity: this.state.HasAdditionalActivity
-        })
+          List: this.state.List
+        }
+        this.props.onUpdate(update)
       }
     })
   }
@@ -60,57 +38,52 @@ export default class AdditionalActivity extends ValidationElement {
     const klass = `activity ${this.props.className || ''}`.trim()
 
     return (
-      <div>
-        <h4>{i18n.t('history.employment.default.additionalActivity.label')}</h4>
-        <div className={klass}>
-          <Branch name="additionalActivity"
-                  className="no-label"
-                  value={this.state.HasAdditionalActivity}
-                  help="history.employment.default.additionalActivity.help"
-                  onUpdate={this.onBranchUpdate}>
-          </Branch>
-        </div>
-        <Show when={this.state.HasAdditionalActivity === 'Yes'}>
-          <Accordion minimum="1"
-                     items={this.state.List}
-                     onUpdate={this.myDispatch}
-                     onValidate={this.handleValidation}
-                     appendLabel={i18n.t('history.employment.default.additionalActivity.collection.append')}>
+      <div className={klass}>
+        <BranchCollection label={i18n.t('history.employment.default.additionalActivity.label')}
+                          labelSize="h4"
+                          appendLabel={i18n.t('history.employment.default.additionalActivity.collection.append')}
+                          appendSize="h4"
+                          help="history.employment.default.additionalActivity.help"
+                          items={this.state.List}
+                          onUpdate={this.myDispatch}
+                          onValidate={this.handleValidation}>
+          <Field title={i18n.t('history.employment.default.additionalActivity.heading.position')}
+                 titleSize="h4"
+                 help="history.employment.default.additionalActivity.position.help"
+                 adjustFor="labels">
+            <Text name="Position"
+                  className="text"
+                  label={i18n.t('history.employment.default.additionalActivity.position.label')}
+                  bind={true}
+                  />
+          </Field>
 
-            <Field title={i18n.t('history.employment.default.additionalActivity.heading.position')}
-                   titleSize="h4"
-                   help="history.employment.default.additionalActivity.position.help"
-                   adjustFor="labels">
-              <Text name="Position"
-                    className="text"
-                    label={i18n.t('history.employment.default.additionalActivity.position.label')}
-                    bind={true}
-                    />
-            </Field>
+          <Field title={i18n.t('history.employment.default.additionalActivity.heading.supervisor')}
+                 titleSize="h4"
+                 help="history.employment.default.additionalActivity.supervisor.help"
+                 adjustFor="labels">
+            <Text name="Supervisor"
+                  className="text"
+                  label={i18n.t('history.employment.default.additionalActivity.supervisor.label')}
+                  bind={true}
+                  />
+          </Field>
 
-            <Field title={i18n.t('history.employment.default.additionalActivity.heading.supervisor')}
-                   titleSize="h4"
-                   help="history.employment.default.additionalActivity.supervisor.help"
-                   adjustFor="labels">
-              <Text name="Supervisor"
-                    className="text"
-                    label={i18n.t('history.employment.default.additionalActivity.supervisor.label')}
-                    bind={true}
-                    />
-            </Field>
-
-            <Field title={i18n.t('history.employment.default.additionalActivity.heading.datesEmployed')}
-                   titleSize="h4"
-                   help="history.employment.default.additionalActivity.datesEmployed.help"
-                   adjustFor="daterange"
-                   shrink={true}>
-              <DateRange name="DatesEmployed"
-                         bind={true}
-                         />
-            </Field>
-          </Accordion>
-        </Show>
+          <Field title={i18n.t('history.employment.default.additionalActivity.heading.datesEmployed')}
+                 titleSize="h4"
+                 help="history.employment.default.additionalActivity.datesEmployed.help"
+                 adjustFor="daterange"
+                 shrink={true}>
+            <DateRange name="DatesEmployed"
+                       bind={true}
+                       />
+          </Field>
+        </BranchCollection>
       </div>
     )
   }
+}
+
+AdditionalActivity.defaultProps = {
+  List: []
 }

--- a/src/components/Section/History/Employment/AdditionalActivity.test.jsx
+++ b/src/components/Section/History/Employment/AdditionalActivity.test.jsx
@@ -5,8 +5,8 @@ import AdditionalActivity from './AdditionalActivity'
 describe('The employment additional activity component', () => {
   it('renders default additional activity', () => {
     const component = mount(<AdditionalActivity name="activity" />)
-    expect(component.find({type: 'radio', name: 'additionalActivity', value: 'Yes'}).hasClass('selected')).toBe(false)
-    expect(component.find({type: 'radio', name: 'additionalActivity', value: 'No'}).hasClass('selected')).toBe(false)
+    expect(component.find('.branch .yes').length).toBe(1)
+    expect(component.find('.branch .no').length).toBe(1)
   })
 
   it('toggles yes/no for additional activity', () => {
@@ -14,11 +14,10 @@ describe('The employment additional activity component', () => {
     let onUpdate = () => { updates++ }
     const component = mount(<AdditionalActivity name="activity" onUpdate={onUpdate} />)
 
-    const selected = component.find({type: 'radio', name: 'additionalActivity', value: 'Yes'})
-    selected.simulate('change')
-    expect(component.find('.accordion').length).toBeGreaterThan(0)
-    component.find({type: 'radio', name: 'additionalActivity', value: 'No'}).simulate('change')
-    expect(component.find('.accordion').length).toBe(0)
+    component.find('.branch .yes input').at(0).simulate('change')
+    expect(component.find({ type: 'text', name: 'Position' }).length).toBe(1)
+    component.find('.branch .no input').at(0).simulate('change')
+    expect(component.find({ type: 'text', name: 'Position' }).length).toBe(0)
     expect(updates).toBeGreaterThan(1)
   })
 
@@ -30,6 +29,7 @@ describe('The employment additional activity component', () => {
       },
       items: [
         {
+          Has: 'Yes',
           Position: {
             name: 'Position',
             value: 'Dev'
@@ -40,9 +40,8 @@ describe('The employment additional activity component', () => {
     }
 
     const component = mount(<AdditionalActivity {...expected} />)
-    expect(component.find('.accordion').length).toBeGreaterThan(0)
-    let position = component.find('input[name="Position"]')
-    position.simulate('change')
+    component.find('.branch .yes input').at(0).simulate('change')
+    component.find({ type: 'text', name: 'Position' }).simulate('change')
     expect(updates).toBeGreaterThan(0)
   })
 })

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -252,7 +252,7 @@ export class EmploymentItem extends ValidationElement {
                                 {...this.props.Additional}
                                 onUpdate={this.onUpdate.bind(this, 'Additional')}
                                 onValidate={this.props.onValidate}
-                                className="additional-activity" />
+                                />
           </div>
         </Show>
 

--- a/src/components/Section/History/Employment/Employment.scss
+++ b/src/components/Section/History/Employment/Employment.scss
@@ -1,56 +1,17 @@
 .history {
-  .employment-left {
-    label {
-      height: 8rem;
-      width: 24rem;
-      padding-top: 2rem;
-    }
-  }
-
-  .explanation-left {
-    padding-top: 5rem !important;
-  }
-
-  .date-left {
-    line-height: initial !important;
-    padding-top: 5rem !important;
-
-    > label {
-      position: relative;
-      padding-bottom: 2rem;
-    }
-  }
-
   .employment-activity {
-    .option-list {
-      max-width: 92% !important;
-    }
-
-    label {
+    .block label {
       height: 8rem;
       width: 24rem;
       padding-top: 2rem;
     }
+  }
 
-    .other {
-      display: inline-block;
-      width: 92%;
-      padding-top: 2rem;
+  .employment-left {
+    .block label {
+      height: 8rem;
+      width: 24rem;
+      padding-top: 1.5rem;
     }
-  }
-
-  .additional-activity {
-    margin-bottom: 10rem;
-  }
-
-  .daterange, .text, .employment-activity {
-    display: inline-block;
-  }
-
-  .full-width,
-  .reason-description {
-    display: inline-block;
-    width: 92%;
-    max-width: 64rem;
   }
 }

--- a/src/components/Section/History/Employment/PhysicalAddress.jsx
+++ b/src/components/Section/History/Employment/PhysicalAddress.jsx
@@ -72,7 +72,6 @@ export default class PhysicalAddress extends ValidationElement {
   options () {
     return (
       <Branch name="physicalAddress"
-              className="no-label"
               value={this.state.HasDifferentAddress}
               help="history.employment.default.physicalAddress.help"
               onUpdate={this.onBranchUpdate}>

--- a/src/components/Section/History/Employment/Reprimand.jsx
+++ b/src/components/Section/History/Employment/Reprimand.jsx
@@ -32,24 +32,26 @@ export default class Reprimand extends ValidationElement {
 
   render () {
     return (
-      <BranchCollection label={i18n.t('history.employment.default.reprimand.para')}
+      <BranchCollection label={i18n.t('history.employment.default.reprimand.label')}
+                        appendLabel={i18n.t('history.employment.default.reprimand.append')}
                         help="history.employment.default.reprimand.help"
                         items={this.state.Reasons}
-                        onUpdate={this.updateReasons}
-                        >
+                        onUpdate={this.updateReasons}>
         <div>
-          <Field className="explanation-left">
+          <Field title={i18n.t('history.employment.default.reprimand.description.label')}
+                 titleSize="h4"
+                 className="explanation-left">
             <Textarea name="Text"
                       bind={true}
-                      label={i18n.t('history.employment.default.reprimand.description.label')}
                       maxlength="100"
                       onValidate={this.props.onValidate}
                       />
           </Field>
-          <Field className="date-left"
+          <Field title={i18n.t('history.employment.default.reprimand.date.label')}
+                 titleSize="h4"
+                 className="date-left"
                  adjustFor="labels"
                  shrink={true}>
-            <label>{i18n.t('history.employment.default.reprimand.date.label')}</label>
             <DateControl name="Date"
                          bind={true}
                          hideDay={true}

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -134,7 +134,6 @@ export default class Federal extends ValidationElement {
             <Field title={i18n.t('history.federal.heading.name')}
                    help="history.federal.help.name">
               <Text name="Name"
-                    className="text"
                     bind={true}
                     />
             </Field>
@@ -142,7 +141,6 @@ export default class Federal extends ValidationElement {
             <Field title={i18n.t('history.federal.heading.position')}
                    help="history.federal.help.position">
               <Text name="Position"
-                    className="text"
                     bind={true}
                     />
             </Field>

--- a/src/components/Section/History/Federal/Federal.test.jsx
+++ b/src/components/Section/History/Federal/Federal.test.jsx
@@ -11,7 +11,7 @@ describe('The federal component', () => {
     component.find({type: 'radio', name: 'has_federalservice', value: 'Yes'}).simulate('change')
     expect(component.find('.accordion').length).toBeGreaterThan(0)
     expect(component.find('.accordion .daterange').length).toBeGreaterThan(0)
-    expect(component.find('.accordion .text').length).toBeGreaterThan(0)
+    expect(component.find('.accordion input').length).toBeGreaterThan(0)
     expect(component.find('.accordion .address').length).toBeGreaterThan(0)
   })
 

--- a/src/components/Section/History/summaries.jsx
+++ b/src/components/Section/History/summaries.jsx
@@ -46,7 +46,7 @@ export const ResidenceCaption = (props) => {
 /**
  * Renders a formatted summary information for a residence row
  */
-export const ResidenceSummary = (item, errors) => {
+export const ResidenceSummary = (item, errors, open) => {
   let address = ''
   let address1 = ''
   let address2 = ''
@@ -68,7 +68,7 @@ export const ResidenceSummary = (item, errors) => {
   }
 
   const dates = dateSummary(item)
-  const svg = errors
+  const svg = errors && !open
         ? <Svg src="img/exclamation-point.svg" />
         : null
 
@@ -105,7 +105,7 @@ const PersonSummary = (item, errors) => {
 export const ResidenceCustomSummary = (item, index, initial, callback, toggle, openText, remove, byline) => {
   return CustomSummary(
     (x) => { return new ResidenceValidator(x, null).isValid() },
-    (x, e) => { return ResidenceSummary(x, e) },
+    (x, e) => { return ResidenceSummary(x, e, item.open) },
     (x, e) => {
       const ps = PersonSummary(x, e)
       if (ps === null) {
@@ -136,12 +136,12 @@ export const EmploymentCaption = (props) => {
 /**
  * Renders a formatted summary information for an employment row
  */
-export const EmploymentSummary = (item, errors) => {
+export const EmploymentSummary = (item, errors, open) => {
   const employer = item.Employment && item.Employment.value
         ? item.Employment.value
     : i18n.t('history.employment.default.collection.summary.unknown')
   const dates = dateSummary(item)
-  const svg = errors === true
+  const svg = errors && !open
     ? <Svg src="img/exclamation-point.svg" />
         : null
 
@@ -182,7 +182,7 @@ const ActivitySummary = (item, errors) => {
 export const EmploymentCustomSummary = (item, index, initial, callback, toggle, openText, remove, byline) => {
   return CustomSummary(
     (x) => { return new EmploymentValidator(x, null).isValid() },
-    (x, e) => { return EmploymentSummary(x, e) },
+    (x, e) => { return EmploymentSummary(x, e, item.open) },
     (x, e) => {
       return ActivitySummary(x, e)
         .filter(activity => activity !== null)
@@ -212,10 +212,10 @@ export const EducationCaption = (props) => {
 /**
  * Renders a formatted summary information for an education row
  */
-export const EducationSummary = (item, errors) => {
+export const EducationSummary = (item, errors, open) => {
   const school = (item.Name && item.Name.value ? item.Name.value : 'N/A')
   const dates = dateSummary(item)
-  const svg = errors
+  const svg = errors && !open
         ? <Svg src="img/exclamation-point.svg" />
         : null
 
@@ -260,7 +260,7 @@ const DiplomaSummary = (item, errors) => {
 export const EducationCustomSummary = (item, index, initial, callback, toggle, openText, remove, byline) => {
   return CustomSummary(
     (x) => { return new EducationValidator(x, null).isValid() },
-    (x, e) => { return EducationSummary(x, e) },
+    (x, e) => { return EducationSummary(x, e, item.open) },
     (x, e) => {
       return DiplomaSummary(x, e)
         .filter(diploma => diploma !== null)

--- a/src/components/Section/Legal/Police/DomesticViolence.jsx
+++ b/src/components/Section/Legal/Police/DomesticViolence.jsx
@@ -53,7 +53,7 @@ export default class DomesticViolence extends ValidationElement {
         <Field title={i18n.t('legal.police.heading.domesticExplanation')}
                titleSize="h4">
           <Textarea
-            className="explanation no-label"
+            className="explanation"
             name="explanation"
             onUpdate={this.updateExplanation} />
         </Field>

--- a/src/components/Section/Psychological/ExistingConditions/ExistingConditions.jsx
+++ b/src/components/Section/Psychological/ExistingConditions/ExistingConditions.jsx
@@ -113,7 +113,7 @@ export default class ExistingConditions extends ValidationElement {
         <h3>{i18n.t('psychological.existingConditions.heading.hasCondition')}</h3>
         {i18n.m('psychological.existingConditions.para.hasCondition')}
         <Branch name="hascondition"
-                className="eapp-field-wrap no-label hascondition"
+                className="eapp-field-wrap hascondition"
                 value={this.state.HasCondition}
                 onValidate={this.handleValidation}
                 onUpdate={this.updateHasCondition}>
@@ -181,7 +181,7 @@ export default class ExistingConditions extends ValidationElement {
 
             <h3>{i18n.t('psychological.existingConditions.heading.didNotFollow')}</h3>
             <Branch name="didNotFollow"
-              className="eapp-field-wrap no-label didnotfollow"
+              className="eapp-field-wrap didnotfollow"
               value={this.state.DidNotFollow}
               help="psychological.existingConditions.help.didNotFollow"
               onValidate={this.handleValidation}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -432,7 +432,7 @@ export default class Relative extends ValidationElement {
             <h3>{i18n.t('relationships.relatives.heading.maiden')}</h3>
             <Branch name="maiden_diff"
                     help="relationships.relatives.help.maiden"
-                    className="eapp-field-wrap no-label relative-maiden-diff"
+                    className="eapp-field-wrap relative-maiden-diff"
                     value={this.state.MaidenSameAsListed}
                     yesLabel={i18n.t('relationships.relatives.label.maiden.same')}
                     noLabel={i18n.t('relationships.relatives.label.maiden.diff')}
@@ -857,7 +857,7 @@ export default class Relative extends ValidationElement {
                                  or={i18n.m('relationships.relatives.para.or')}
                                  onUpdate={this.updateEmployerRelationshipNotApplicable}>
                     <Branch name="has_affiliation"
-                            className="no-label relative-affiliation"
+                            className="relative-affiliation"
                             value={this.state.HasAffiliation}
                             help="relationships.relatives.help.affiliation"
                             onUpdate={this.updateHasAffiliation}

--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -11,6 +11,7 @@ import Military from './Military'
 import History from './History'
 import Legal from './Legal'
 import Psychological from './Psychological'
+import Design from './Design'
 import { SectionView, SectionViews } from './SectionView'
 
 class Section extends React.Component {
@@ -63,6 +64,9 @@ class Section extends React.Component {
         </SectionView>
         <SectionView name="psychological">
           <Psychological subsection={this.props.subsection} />
+        </SectionView>
+        <SectionView name="design">
+          <Design subsection={this.props.subsection} />
         </SectionView>
       </SectionViews>
     )

--- a/src/components/Section/SectionView.scss
+++ b/src/components/Section/SectionView.scss
@@ -26,7 +26,7 @@
       }
 
       .btn-cell {
-        width: 40%;
+        width: 30%;
         border-radius: 3px;
         transition: background-color 0.3s;
         background-color: $eapp-blue;
@@ -43,7 +43,7 @@
           margin: 0;
           line-height: normal !important;
           width: 100%;
-          padding: 2rem;
+          padding: 1.5rem 2rem;
           background: none;
 
           &:hover {

--- a/src/components/SectionTitle/SectionTitle.scss
+++ b/src/components/SectionTitle/SectionTitle.scss
@@ -5,12 +5,13 @@
   max-height: 14.5rem;
   overflow: hidden;
   color: #fff;
-  font-size: 5rem;
+  font-size: 2.5rem;
   font-weight: $eapp-bold;
+  margin-bottom: 2rem;
 
-  @media screen and (max-width: 1100px) {
-    font-size: 4rem;
-  }
+  // @media screen and (max-width: 1100px) {
+  //   font-size: 4rem;
+  // }
 
   > .title-text {
     display: block;

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2515,6 +2515,7 @@ const en = {
   },
 
   address: {
+    label: 'This address is',
     options: {
       us: {
         label: 'In the<br>United States'
@@ -3178,7 +3179,8 @@ const en = {
           }
         },
         reprimand: {
-          para: 'For this employment, in the last seven (7) years have you received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as a violation of security policy?',
+          label: 'For this employment, in the last seven (7) years have you received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as a violation of security policy?',
+          append: 'Do you have another instance of discipline or a warning to provide?',
           description: {
             label: 'Provide the reason(s) for being warned, reprimanded, suspended or disciplined'
           },

--- a/src/config/navigation.js
+++ b/src/config/navigation.js
@@ -131,6 +131,15 @@ const navigation = [
       { name: 'Diagnoses', url: 'diagnoses' },
       { name: 'Existing Conditions', url: 'conditions', hiddenFunc: hideExistingConditions }
     ]
+  },
+  {
+    title: 'Design guideline',
+    name: 'Design guideline',
+    url: 'design',
+    hidden: true,
+    subsections: [
+      { name: 'Headings', url: 'headings' }
+    ]
   }
 ]
 

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -7,22 +7,34 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h2 {
-  font-size: 4rem;
+  font-size: 2.75rem;
   margin-top: 0;
   margin-bottom: 0.5rem;
-
-  @media screen and (max-width: 1100px) {
-    font-size: 3rem;
-  }
-
 }
 
 h3 {
-  font-size: 2.3rem;
+  font-size: 1.85rem;
+  margin-top: 1.5rem;
+  line-height: 1.7;
+}
 
-  @media screen and (max-width: 1100px) {
-    font-size: 1.8rem;
-  }
+h4 {
+  font-size: 1.7rem;
+  line-height: 1.7;
+}
+
+h5 {
+  font-size: 1.6rem;
+  line-height: 1.6;
+}
+
+h6 {
+  font-size: 1.5rem;
+  line-height: 1.7;
+}
+
+ul {
+  margin-top: 0;
 }
 
 /* design needs a touch more line height than standards */
@@ -74,7 +86,7 @@ a:focus {
         width: 100%;
         max-width: 106rem;
         min-width: 70rem;
-        margin: 0 auto;
+        margin: 0 auto 2rem auto;
       }
     }
   }

--- a/src/validators/employment.js
+++ b/src/validators/employment.js
@@ -1,8 +1,8 @@
 import DateRangeValidator from './daterange'
-import { daysAgo, today } from '../components/Section/History/dateranges'
-import { validNotApplicable, validGenericTextfield, validPhoneNumber, validGenericMonthYear, validDateField, withinSevenYears } from './helpers'
 import AddressValidator from './address'
 import ReferenceValidator from './reference'
+import { validNotApplicable, validGenericTextfield, validPhoneNumber, validGenericMonthYear,
+         validDateField, withinSevenYears, BranchCollection } from './helpers'
 
 export default class EmploymentValidator {
   constructor (state, props) {
@@ -46,25 +46,22 @@ export default class EmploymentValidator {
     if (!this.additional) {
       return false
     }
-    if (!(this.additional.HasAdditionalActivity === 'No' || this.additional.HasAdditionalActivity === 'Yes')) {
+
+    const branchValidator = new BranchCollection(this.additional.List)
+    if (!branchValidator.validKeyValues()) {
       return false
     }
 
-    if (this.additional.HasAdditionalActivity === 'Yes') {
-      if (!this.additional.List || this.additional.List.length === 0) {
-        return false
-      }
-
-      for (const activity of this.additional.List) {
-        let valid = validGenericTextfield(activity.Position) &&
-          validGenericTextfield(activity.Supervisor) &&
-          new DateRangeValidator(activity.DatesEmployed).isValid()
-        if (!valid) {
-          return false
-        }
-      }
+    if (branchValidator.hasNo()) {
+      return true
     }
-    return true
+
+    return branchValidator.each(item => {
+      console.log('item', item)
+      return validGenericTextfield(item.Position) &&
+        validGenericTextfield(item.Supervisor) &&
+        new DateRangeValidator(item.DatesEmployed).isValid()
+    })
   }
 
   validTelephone () {
@@ -168,14 +165,14 @@ export default class EmploymentValidator {
       case 'NationalGuard':
       case 'USPHS':
         return this.validDates() &&
-          this.validTitle() &&
-          this.validAssignedDuty() &&
-          this.validStatus() &&
-          this.validAddress() &&
-          this.validTelephone() &&
-          this.validSupervisor() &&
-          this.validReasonLeft() &&
-          this.validReprimand()
+        this.validTitle() &&
+        this.validAssignedDuty() &&
+        this.validStatus() &&
+        this.validAddress() &&
+        this.validTelephone() &&
+        this.validSupervisor() &&
+        this.validReasonLeft() &&
+        this.validReprimand()
 
       // Other Federal employment, State Government, Federal Contractor, Non-government employment, or Other
       case 'OtherFederal':
@@ -184,34 +181,34 @@ export default class EmploymentValidator {
       case 'NonGovernment':
       case 'Other':
         return this.validDates() &&
-          this.validTitle() &&
-          this.validEmployment() &&
-          this.validStatus() &&
-          this.validAddress() &&
-          this.validTelephone() &&
-          this.validSupervisor() &&
-          this.validAdditionalActivity() &&
-          this.validReasonLeft() &&
-          this.validReprimand()
+        this.validTitle() &&
+        this.validEmployment() &&
+        this.validStatus() &&
+        this.validAddress() &&
+        this.validTelephone() &&
+        this.validSupervisor() &&
+        this.validAdditionalActivity() &&
+        this.validReasonLeft() &&
+        this.validReprimand()
 
       // Self employment
       case 'SelfEmployment':
         return this.validDates() &&
-          this.validTitle() &&
-          this.validEmployment() &&
-          this.validStatus() &&
-          this.validAddress() &&
-          this.validPhysicalAddress() &&
-          this.validTelephone() &&
-          this.validReference() &&
-          this.validReasonLeft() &&
-          this.validReprimand()
+        this.validTitle() &&
+        this.validEmployment() &&
+        this.validStatus() &&
+        this.validAddress() &&
+        this.validPhysicalAddress() &&
+        this.validTelephone() &&
+        this.validReference() &&
+        this.validReasonLeft() &&
+        this.validReprimand()
 
       // Unemployment
       case 'Unemployment':
         return this.validDates() &&
-          this.validReference() &&
-          this.validReasonLeft()
+        this.validReference() &&
+        this.validReasonLeft()
       default:
         return false
     }

--- a/src/validators/employment.test.js
+++ b/src/validators/employment.test.js
@@ -233,8 +233,7 @@ describe('Employment component validation', function () {
             zipcode: '22202'
           },
           Additional: {
-            HasAdditionalActivity: 'No',
-            List: []
+            List: [{ Has: 'No' }]
           },
           Telephone: {
             noNumber: '',
@@ -394,9 +393,9 @@ describe('Employment component validation', function () {
             ]
           },
           Additional: {
-            HasAdditionalActivity: 'Yes',
             List: [
               {
+                Has: 'Yes',
                 Position: {
                   value: 'Dev1'
                 },
@@ -638,8 +637,7 @@ describe('Employment component validation', function () {
             value: 'SelfEmployed'
           },
           Additional: {
-            HasAdditionalActivity: 'Yes',
-            List: []
+            List: [{ Has: 'Yes' }]
           }
         },
         expected: false
@@ -650,9 +648,9 @@ describe('Employment component validation', function () {
             value: 'SelfEmployed'
           },
           Additional: {
-            HasAdditionalActivity: 'Yes',
             List: [
               {
+                Has: 'Yes',
                 Position: {
                   value: 'Dev1'
                 },
@@ -680,9 +678,9 @@ describe('Employment component validation', function () {
             value: 'SelfEmployed'
           },
           Additional: {
-            HasAdditionalActivity: 'Yes',
             List: [
               {
+                Has: 'Yes',
                 Position: {
                   value: ''
                 },
@@ -710,9 +708,9 @@ describe('Employment component validation', function () {
             value: 'SelfEmployed'
           },
           Additional: {
-            HasAdditionalActivity: 'Foo',
             List: [
               {
+                Has: 'Foo',
                 Position: {
                   value: ''
                 },

--- a/src/validators/history.test.js
+++ b/src/validators/history.test.js
@@ -38,8 +38,7 @@ describe('Employment component validation', function () {
                   zipcode: '22202'
                 },
                 Additional: {
-                  HasAdditionalActivity: 'No',
-                  List: []
+                  List: [{ Has: 'No' }]
                 },
                 Telephone: {
                   noNumber: '',

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -151,7 +151,7 @@ select {
     // Block style radio and checkboxes that are NOT toggles
     &.no-toggle {
       display: block;
-      margin-bottom: 1.2rem;
+      margin-bottom: 0;
       margin-right: 1.6rem;
       text-align: center;
       background: transparent;


### PR DESCRIPTION
Issue: #1053 

## Font size adjustments

 - H2: 2.75rem
 - H3: 1.85rem
 - H4: 1.7rem
 - H5: 1.6rem
 - H6: 1.5rem

## Toggle error icon in history section

During last sprint review it was noted to make the error icon visibility coincide with the incomplete error message visibility.

## Conversion of accordion-within-accordion in employment section

During review a situation where an accordion was within another accordion was found in the employment history section. This has been converted to a `BranchCollection`

## Margins and padding

 - H2's within accordion items have an additional `margin-top` applied
 - `Field` components have a `margin-bottom` adjusted to **7rem**
 - `NotApplicable`'s used of **or** has padding adjusted
 - `Telephone` extensions have a separator with additional whitespace while bringing the telephone type down closer to the inputs
 - Navigation buttons were shrunk and had additional padding applied

## New "design" navigation to experiment with font sizes and white-space in the browser

In an effort to provide a __playground__ for designers to test new styles with comprehensive sample set we created the blank form with various components which once deployed can be found at:

```
https://eqip-prototype-staging.fr.cloud.gov/#/form/design/
```