### PR TITLE
Show address alt dismiss when no suggestions found

### DIFF
--- a/src/components/Form/Address/Address.jsx
+++ b/src/components/Form/Address/Address.jsx
@@ -411,7 +411,7 @@ export default class Address extends ValidationElement {
   }
 
   dismissAlternative () {
-    if (this.state.geocodeErrorCode === 'error.geocode.defaultAddress') {
+    if (!this.state.suggestions || this.state.suggestions.length === 0) {
       return i18n.t('suggestions.address.alternate')
     }
 


### PR DESCRIPTION
The alternative dismiss hyperlink for address suggestions is now turned on for **any** time there are **no suggestions** found.