### PR TITLE
Align the arrow for "need more" sections due to font-size adjustments

### DIFF
--- a/src/components/Section/Legal/Police/Offense.jsx
+++ b/src/components/Section/Legal/Police/Offense.jsx
@@ -233,8 +233,10 @@ export default class Offense extends ValidationElement {
 
         <Show when={this.state.WasCited === 'Yes'}>
           <div>
-            <h3 className="more title">{i18n.t('legal.police.heading.needmore')}</h3>
-            <Svg src="img/date-down-arrow.svg" className="more arrow" />
+            <Field title={i18n.t('legal.police.heading.needmore')}
+                   className="more title">
+              <Svg src="img/date-down-arrow.svg" className="more arrow" />
+            </Field>
 
             <h2>{i18n.t('legal.police.heading.citedagency')}</h2>
             <Field title={i18n.t('legal.police.heading.citedby')}
@@ -288,8 +290,10 @@ export default class Offense extends ValidationElement {
 
         <Show when={this.state.WasCharged === 'Yes'}>
           <div>
-            <h3 className="more title">{i18n.t('legal.police.heading.needmore')}</h3>
-            <Svg src="img/date-down-arrow.svg" className="more arrow" />
+            <Field title={i18n.t('legal.police.heading.needmore')}
+                   className="more title">
+              <Svg src="img/date-down-arrow.svg" className="more arrow" />
+            </Field>
 
             <h2>{i18n.t('legal.police.heading.courtinfo')}</h2>
             <Field title={i18n.t('legal.police.heading.courtname')}
@@ -415,9 +419,9 @@ export default class Offense extends ValidationElement {
                     {i18n.t('legal.police.heading.awaitingTrial')}
                   </div>
                 </Branch>
-            <Field title={i18n.t('legal.police.heading.awaitingTrialExplanation')}
-                   titleSize="label"
-                   adjustFor="labels">
+                <Field title={i18n.t('legal.police.heading.awaitingTrialExplanation')}
+                       titleSize="label"
+                       adjustFor="labels">
                   <Textarea
                     className="awaiting-trial-explanation"
                     {...this.state.AwaitingTrialExplanation}

--- a/src/components/Section/Legal/Police/Offense.scss
+++ b/src/components/Section/Legal/Police/Offense.scss
@@ -20,9 +20,7 @@
   }
 
   .more.arrow {
-    text-align: center;
     height: 8rem;
-    width: 100%;
-    margin: 0 auto 2rem auto;
+    margin-left: 25.25rem;
   }
 }

--- a/src/components/Section/Psychological/Order.jsx
+++ b/src/components/Section/Psychological/Order.jsx
@@ -103,8 +103,10 @@ export default class Order extends ValidationElement {
                           onUpdate={this.updateAppeals}
                           >
 
-          <h3 className="more title">{i18n.t(`psychological.${prefix}.heading.needMore`)}</h3>
-          <Svg src="img/date-down-arrow.svg" className="more arrow" />
+          <Field title={i18n.t(`psychological.${prefix}.heading.needMore`)}
+                 className="more title">
+            <Svg src="img/date-down-arrow.svg" className="more arrow" />
+          </Field>
 
           <Field title={i18n.t(`psychological.${prefix}.heading.appealCourtName`)}>
             <Text name="CourtName"

--- a/src/components/Section/Psychological/Order.scss
+++ b/src/components/Section/Psychological/Order.scss
@@ -1,21 +1,12 @@
 @import 'eqip-colors';
 
 .order {
-  .courtname,
-  .disposition {
-    width: 92%;
-    max-width: 64rem;
-    display: inline-block;
-  }
-
   .more.title {
     color: $eapp-blue-dark;
   }
 
   .more.arrow {
-    text-align: center;
     height: 8rem;
-    width: 100%;
-    margin: 0 auto 2rem auto;
+    margin-left: 25.25rem;
   }
 }

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -458,8 +458,10 @@ export default class Relative extends ValidationElement {
                               onUpdate={this.updateAliases}
                               onValidate={this.props.onValidate}>
               <div>
-                <h3 className="more title">{i18n.t('relationships.relatives.heading.needmore')}</h3>
-                <Svg src="img/date-down-arrow.svg" className="more arrow" />
+                <Field title={i18n.t('relationships.relatives.heading.needmore')}
+                      className="more title">
+                  <Svg src="img/date-down-arrow.svg" className="more arrow" />
+                </Field>
                 <Alias name="Item" bind={true} />
               </div>
             </BranchCollection>

--- a/src/components/Section/Relationships/Relatives/Relative.scss
+++ b/src/components/Section/Relationships/Relatives/Relative.scss
@@ -82,10 +82,8 @@
   }
 
   .more.arrow {
-    text-align: center;
     height: 8rem;
-    width: 100%;
-    margin: 0 auto 2rem auto;
+    margin-left: 25.25rem;
   }
 
   .help-icon-employer-address {


### PR DESCRIPTION
Wrapped these elements within the `Field` structure so it utilizes the same amount of space available to other components. The `margin-left` was derived with some rough math

```
margin_left = (maximum_field_width / 2) - (h3_character_width - svg_width)
```

to be

```
25 ≈ (64 / 2) - (18 - 11)
```

## Before

![original-arrow](https://cloud.githubusercontent.com/assets/697855/25625034/54575842-2f29-11e7-8706-0a138b2807c1.png)

## After

![new-arrow](https://cloud.githubusercontent.com/assets/697855/25625040/57b48a5a-2f29-11e7-8bd9-3e9aaba84ec2.png)
