### PR TITLE
Allow zero value on Number

### DIFF
--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -2,13 +2,12 @@ import React from 'react'
 import ValidationElement from '../ValidationElement'
 import Generic from '../Generic'
 
-const trimLeadingZero = (num) => {
-  if (isNaN(num)) {
+export const trimLeadingZero = (num) => {
+  if (isNaN(num) || num === '') {
     return ''
   }
 
-  const i = parseInt(`0${num}`, 10)
-  return i === 0 ? '' : '' + i
+  return '' + parseInt(`0${num}`, 10)
 }
 
 export default class Number extends ValidationElement {

--- a/src/components/Form/Number/Number.test.jsx
+++ b/src/components/Form/Number/Number.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import Number from './Number'
+import Number, { trimLeadingZero } from './Number'
 
 describe('The number component', () => {
   it('renders appropriately with an error', () => {
@@ -121,5 +121,18 @@ describe('The number component', () => {
     const component = mount(<Number {...expected} />)
     component.find('input').simulate('change', { target: { value: '100a' } })
     expect(component.find({ type: 'text', value: expected.value }).length).toEqual(1)
+  })
+
+  it('trims zeroes appropriately', () => {
+    const tests = [
+      { given: '0', expected: '0' },
+      { given: '', expected: '' },
+      { given: '100', expected: '100' },
+      { given: '010', expected: '10' }
+    ]
+
+    tests.forEach(test => {
+      expect(trimLeadingZero(test.given)).toBe(test.expected)
+    })
   })
 })


### PR DESCRIPTION
Issue: #1151 

Our `trimLeadingZero()` function was not allowing the value of `0` to be entered and was returning and empty string instead. Refactored and test cases added.