### PR TITLE
Accordion updates per feedback

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { i18n } from '../../../config'
 import ValidationElement from '../ValidationElement'
+import Branch from '../Branch'
 import { findPosition } from '../../../middleware/history'
 
 export const openState = (item = {}, initial = false) => {
@@ -42,6 +43,7 @@ export default class Accordion extends ValidationElement {
     this.update = this.update.bind(this)
     this.add = this.add.bind(this)
     this.updateChild = this.updateChild.bind(this)
+    this.updateAddendum = this.updateAddendum.bind(this)
     this.summary = this.summary.bind(this)
     this.details = this.details.bind(this)
     this.content = this.content.bind(this)
@@ -133,9 +135,12 @@ export default class Accordion extends ValidationElement {
   /**
    * Send the updated list of items back to the parent component.
    */
-  update (items) {
+  update (items, branch) {
     if (this.props.onUpdate) {
-      this.props.onUpdate(items)
+      this.props.onUpdate({
+        branch: branch,
+        items: items
+      })
     }
   }
 
@@ -151,7 +156,7 @@ export default class Accordion extends ValidationElement {
       return x
     })
 
-    this.update(items)
+    this.update(items, this.props.branch)
     this.setState({ initial: false, scrollToId: '' })
   }
 
@@ -174,7 +179,7 @@ export default class Accordion extends ValidationElement {
 
     const item = this.newItem()
     items = items.concat([item])
-    this.update(items)
+    this.update(items, '')
     this.setState({ initial: false, scrollToId: item.uuid })
   }
 
@@ -192,7 +197,7 @@ export default class Accordion extends ValidationElement {
         items.push(this.newItem())
       }
 
-      this.update(items)
+      this.update(items, '')
       this.setState({ initial: false, scrollToId: '' })
     }
   }
@@ -204,7 +209,19 @@ export default class Accordion extends ValidationElement {
     let items = [...this.props.items]
     const index = items.findIndex(x => x.uuid === item.uuid)
     items[index][prop] = value
-    this.update(items)
+    this.update(items, this.props.branch)
+  }
+
+  /**
+   * Update the accordion addendum branch value.
+   */
+  updateAddendum (value) {
+    if (value === 'Yes') {
+      this.add()
+      return
+    }
+
+    this.update(this.props.item, value)
   }
 
   /**
@@ -311,6 +328,22 @@ export default class Accordion extends ValidationElement {
   }
 
   /**
+   * The append button is only displayed if there is no addendum.
+   */
+  appendButton () {
+    if (this.props.appendTitle || this.props.appendMessage) {
+      return null
+    }
+
+    return (
+      <button className="add usa-button-outline" onClick={this.add}>
+        {this.props.appendLabel}
+        <i className="fa fa-plus-circle"></i>
+      </button>
+    )
+  }
+
+  /**
    * Render the accordion addendum notice
    */
   addendum () {
@@ -318,28 +351,18 @@ export default class Accordion extends ValidationElement {
       return null
     }
 
-    let title = null
-    if (this.props.appendTitle) {
-      title = <h3>{this.props.appendTitle}</h3>
-    }
-
-    let message = null
-    if (this.props.appendMessage) {
-      message = this.props.appendMessage
-    }
-
+    // TODO: Add `value` and `onUpdate`
     const klassAppend = `addendum ${this.props.appendClass}`.trim()
     return (
-      <div className={klassAppend}>
-        {title}
-        {message}
-        <div>
-          <button className="add usa-button-outline" onClick={this.add}>
-            <span>{this.props.appendLabel}</span>
-            <i className="fa fa-plus-circle"></i>
-          </button>
-        </div>
-      </div>
+      <Branch label={this.props.appendTitle}
+              labelSize="h3"
+              className={klassAppend}
+              help={this.props.appendHelp}
+              value={this.props.branch}
+              onUpdate={this.updateAddendum}
+              onValidate={this.props.onValidate}>
+        {this.props.appendMessage}
+      </Branch>
     )
   }
 
@@ -367,10 +390,7 @@ export default class Accordion extends ValidationElement {
             {this.content()}
           </div>
 
-          <button className="add usa-button-outline" onClick={this.add}>
-            {this.props.appendLabel}
-            <i className="fa fa-plus-circle"></i>
-          </button>
+          {this.appendButton()}
         </div>
 
         {this.addendum()}
@@ -385,9 +405,11 @@ Accordion.defaultProps = {
   minimum: 1,
   defaultState: true,
   items: [],
+  branch: '',
   className: '',
   appendTitle: '',
-  appendMessage: '',
+  appendMessage: null,
+  appendHelp: null,
   appendClass: '',
   appendLabel: i18n.t('collection.append'),
   openLabel: i18n.t('collection.open'),

--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -251,7 +251,7 @@ export default class Accordion extends ValidationElement {
       return
     }
 
-    this.update(this.props.item, value)
+    this.update(this.props.items, value)
   }
 
   /**

--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -27,7 +27,7 @@
 
 .accordion {
   background-color: #e5e5e5;
-  padding: 0 5rem;
+  padding: 0 5rem 5rem 5rem;
   margin: 0 -17.5%;
 
   @media screen and (max-width: 1380px) {
@@ -108,6 +108,8 @@
         cursor: pointer;
         text-decoration: none;
         margin-bottom: 2.2rem;
+        width: 6rem;
+        float: right;
 
         span {
           border-bottom: 1px dashed $eapp-blue;
@@ -299,7 +301,7 @@ button.usa-button-outline {
   border-radius: 5px;
   padding: 1.7rem 2.3rem 1.7rem 2.3rem;
   background: #fff;
-  margin: 3.4rem 10%;
+  margin: 3.4rem 10% -1.6rem 10%;
 
   &:hover {
     color: #1a4c88;

--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -148,7 +148,6 @@
   .summary {
     display: table;
     width: 100%;
-    text-transform: capitalize;
 
     .left, .right {
       display: table-cell;

--- a/src/components/Form/Accordion/Accordion.test.jsx
+++ b/src/components/Form/Accordion/Accordion.test.jsx
@@ -8,7 +8,7 @@ describe('The accordion component', () => {
     let items = []
     const expected = {
       minimum: 0,
-      onUpdate: (x) => { items = x }
+      onUpdate: (x) => { items = x.items }
     }
     const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)
     expect(component.find('.accordion').length).toEqual(1)
@@ -19,7 +19,7 @@ describe('The accordion component', () => {
     let items = []
     const expected = {
       minimum: 2,
-      onUpdate: (x) => { items = x }
+      onUpdate: (x) => { items = x.items }
     }
     const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)
     expect(component.find('.accordion').length).toEqual(1)
@@ -35,7 +35,7 @@ describe('The accordion component', () => {
       minimum: 1,
       items: items,
       timeout: 0,
-      onUpdate: (x) => { items = x }
+      onUpdate: (x) => { items = x.items }
     }
     const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)
     component.find('button.add').simulate('click')
@@ -75,7 +75,7 @@ describe('The accordion component', () => {
       summary: (item, index) => {
         return (<div className="table">Item {index}</div>)
       },
-      onUpdate: (x) => { items = x }
+      onUpdate: (x) => { items = x.items }
     }
     const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)
     expect(items.length).toEqual(2)
@@ -129,7 +129,7 @@ describe('The accordion component', () => {
         { uuid: '3', open: false },
         { uuid: '4', open: false }
       ],
-      onUpdate: (x) => { items = x }
+      onUpdate: (x) => { items = x.items }
     }
 
     const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)
@@ -146,7 +146,7 @@ describe('The accordion component', () => {
     const expected = {
       minimum: 1,
       items: items,
-      onUpdate: (x) => { items = x }
+      onUpdate: (x) => { items = x.items }
     }
 
     const component = mount(<Accordion {...expected}><Text name="mytext" bind={true} /></Accordion>)
@@ -165,7 +165,7 @@ describe('The accordion component', () => {
     const expected = {
       minimum: 1,
       items: items,
-      onUpdate: (x) => { items = x },
+      onUpdate: (x) => { items = x.items },
       customSummary: (item, index) => { return <div className="custom-summary"></div> }
     }
     const component = mount(<Accordion {...expected}><Text name="mytext" bind={true} /></Accordion>)
@@ -180,7 +180,7 @@ describe('The accordion component', () => {
     const expected = {
       minimum: 1,
       items: items,
-      onUpdate: (x) => { items = x },
+      onUpdate: (x) => { items = x.items },
       customDetails: (item, index) => { return <div className="custom-details"></div> }
     }
     const component = mount(<Accordion {...expected}><Text name="mytext" bind={true} /></Accordion>)
@@ -195,7 +195,7 @@ describe('The accordion component', () => {
     const expected = {
       minimum: 1,
       items: items,
-      onUpdate: (x) => { items = x },
+      onUpdate: (x) => { items = x.items },
       summary: (item, index, initial) => { return <span className="summary-props">Properties</span> },
       customSummary: (item, index, initial, callback) => { return callback() },
       customDetails: (item, index, initial, callback) => { return callback() }

--- a/src/components/Section/Citizenship/Multiple/Multiple.jsx
+++ b/src/components/Section/Citizenship/Multiple/Multiple.jsx
@@ -140,7 +140,6 @@ export default class Multiple extends ValidationElement {
                      summary={this.summaryCitizenships}
                      description={i18n.t('citizenship.multiple.collection.citizenship.summary.title')}
                      appendTitle={i18n.t('citizenship.multiple.collection.citizenship.appendTitle')}
-                     appendMessage={i18n.m('citizenship.multiple.collection.citizenship.appendMessage')}
                      appendLabel={i18n.t('citizenship.multiple.collection.citizenship.append')}>
             <CitizenshipItem name="Item" bind={true} />
           </Accordion>

--- a/src/components/Section/Citizenship/Multiple/Multiple.jsx
+++ b/src/components/Section/Citizenship/Multiple/Multiple.jsx
@@ -25,6 +25,7 @@ export default class Multiple extends ValidationElement {
     this.state = {
       HasMultiple: props.HasMultiple,
       Citizenships: props.Citizenships,
+      CitizenshipsBranch: props.CitizenshipsBranch,
       Passports: props.Passports,
       errorCodes: []
     }
@@ -77,7 +78,8 @@ export default class Multiple extends ValidationElement {
   }
 
   updateCitizenships (values) {
-    this.onUpdate('Citizenships', values)
+    this.onUpdate('Citizenships', values.items)
+    this.onUpdate('CitizenshipsBranch', values.branch)
   }
 
   updatePassports (values) {
@@ -132,6 +134,7 @@ export default class Multiple extends ValidationElement {
         <Show when={this.state.HasMultiple === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.Citizenships}
+                     branch={this.state.CitizenshipsBranch}
                      onUpdate={this.updateCitizenships}
                      onValidate={this.handleValidation}
                      summary={this.summaryCitizenships}
@@ -160,5 +163,6 @@ export default class Multiple extends ValidationElement {
 Multiple.defaultProps = {
   HasMultiple: '',
   Citizenships: [],
+  CitizenshipsBranch: '',
   Passports: []
 }

--- a/src/components/Section/Citizenship/Multiple/PassportItem.jsx
+++ b/src/components/Section/Citizenship/Multiple/PassportItem.jsx
@@ -66,7 +66,7 @@ export default class PassportItem extends ValidationElement {
   }
 
   updateCountries (values) {
-    this.onUpdate('Countries', values)
+    this.onUpdate('Countries', values.items)
   }
 
   summary (item, index) {

--- a/src/components/Section/Design/Headings/Headings.jsx
+++ b/src/components/Section/Design/Headings/Headings.jsx
@@ -15,8 +15,8 @@ export default class Headings extends ValidationElement {
     this.updateList = this.updateList.bind(this)
   }
 
-  updateList (items) {
-    this.setState({ List: items })
+  updateList (values) {
+    this.setState({ List: values.items })
   }
 
   summary (item, index) {

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
@@ -99,7 +99,6 @@ export default class Bankruptcies extends ValidationElement {
             summary={this.summary}
             description={i18n.t('financial.bankruptcy.collection.summary.title')}
             appendTitle={i18n.t('financial.bankruptcy.collection.summary.appendTitle')}
-            appendMessage={i18n.m('financial.bankruptcy.collection.summary.appendMessage')}
             appendLabel={i18n.t('financial.bankruptcy.collection.append')}>
             <Bankruptcy name="Bankruptcy"
               bind={true} />

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
@@ -21,6 +21,7 @@ export default class Bankruptcies extends ValidationElement {
     if (this.props.onUpdate) {
       this.props.onUpdate({
         List: this.props.List,
+        ListBranch: this.props.ListBranch,
         HasBankruptcy: this.props.HasBankruptcy,
         [field]: values
       })
@@ -28,7 +29,8 @@ export default class Bankruptcies extends ValidationElement {
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateHasBankrupty (values) {
@@ -91,6 +93,7 @@ export default class Bankruptcies extends ValidationElement {
         <Show when={this.props.HasBankruptcy === 'Yes'}>
           <Accordion minimum="1"
             items={this.props.List}
+            branch={this.props.ListBranch}
             onUpdate={this.updateList}
             onValidate={this.handleValidation}
             summary={this.summary}

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
@@ -17,24 +17,33 @@ export default class Bankruptcies extends ValidationElement {
     this.summary = this.summary.bind(this)
   }
 
-  update (field, values) {
+  update (queue) {
     if (this.props.onUpdate) {
-      this.props.onUpdate({
+      let obj = {
         List: this.props.List,
         ListBranch: this.props.ListBranch,
-        HasBankruptcy: this.props.HasBankruptcy,
-        [field]: values
-      })
+        HasBankruptcy: this.props.HasBankruptcy
+      }
+
+      for (const q of queue) {
+        obj = { ...obj, [q.name]: q.value }
+      }
+
+      this.props.onUpdate(obj)
     }
   }
 
   updateList (values) {
-    this.update('List', values.items)
-    this.update('ListBranch', values.branch)
+    this.update([
+      { name: 'List', value: values.items },
+      { name: 'ListBranch', value: values.branch }
+    ])
   }
 
   updateHasBankrupty (values) {
-    this.update('HasBankruptcy', values)
+    this.update([
+      { name: 'HasBankruptcy', value: values }
+    ])
   }
 
   /**
@@ -85,26 +94,32 @@ export default class Bankruptcies extends ValidationElement {
     return (
       <div className="bankruptcies">
         <Branch name="has_bankruptcydebt"
-          className="bankruptcy-branch"
-          value={this.props.HasBankruptcy}
-          help="financial.bankruptcy.help"
-          onUpdate={this.updateHasBankrupty}>
+                className="bankruptcy-branch"
+                value={this.props.HasBankruptcy}
+                help="financial.bankruptcy.help"
+                onUpdate={this.updateHasBankrupty}>
         </Branch>
         <Show when={this.props.HasBankruptcy === 'Yes'}>
           <Accordion minimum="1"
-            items={this.props.List}
-            branch={this.props.ListBranch}
-            onUpdate={this.updateList}
-            onValidate={this.handleValidation}
-            summary={this.summary}
-            description={i18n.t('financial.bankruptcy.collection.summary.title')}
-            appendTitle={i18n.t('financial.bankruptcy.collection.summary.appendTitle')}
-            appendLabel={i18n.t('financial.bankruptcy.collection.append')}>
+                     items={this.props.List}
+                     branch={this.props.ListBranch}
+                     onUpdate={this.updateList}
+                     onValidate={this.handleValidation}
+                     summary={this.summary}
+                     description={i18n.t('financial.bankruptcy.collection.summary.title')}
+                     appendTitle={i18n.t('financial.bankruptcy.collection.summary.appendTitle')}
+                     appendLabel={i18n.t('financial.bankruptcy.collection.append')}>
             <Bankruptcy name="Bankruptcy"
-              bind={true} />
+                        bind={true} />
           </Accordion>
         </Show>
       </div>
     )
   }
+}
+
+Bankruptcies.defaultProps = {
+  List: [],
+  ListBranch: '',
+  HasBankruptcy: ''
 }

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.test.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.test.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Bankruptcies from './Bankruptcies'
 
-
 describe('The bankruptcy component', () => {
   it('no error on empty', () => {
     const expected = {
@@ -81,6 +80,6 @@ describe('The bankruptcy component', () => {
 
     const component = mount(<Bankruptcies {...expected} />)
     component.find('.courtnumber input[name="CourtNumber"]').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(4)
   })
 })

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.test.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.test.jsx
@@ -80,6 +80,6 @@ describe('The bankruptcy component', () => {
 
     const component = mount(<Bankruptcies {...expected} />)
     component.find('.courtnumber input[name="CourtNumber"]').simulate('change')
-    expect(updates).toBe(4)
+    expect(updates).toBe(2)
   })
 })

--- a/src/components/Section/Financial/Card/Card.jsx
+++ b/src/components/Section/Financial/Card/Card.jsx
@@ -10,6 +10,7 @@ export default class Card extends ValidationElement {
     this.state = {
       HasCardAbuse: props.HasCardAbuse,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -63,11 +64,12 @@ export default class Card extends ValidationElement {
    * Dispatch callback initiated from the collection to notify of any new
    * updates to the items.
    */
-  updateList (collection) {
-    this.setState({ List: collection }, () => {
+  updateList (values) {
+    this.setState({ List: values.items, ListBranch: values.branch }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,
+          ListBranch: this.state.ListBranch,
           HasCardAbuse: this.state.HasCardAbuse
         })
       }
@@ -108,6 +110,7 @@ export default class Card extends ValidationElement {
         <Show when={this.state.HasCardAbuse === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -189,5 +192,6 @@ export default class Card extends ValidationElement {
 
 Card.defaultProps = {
   HasCardAbuse: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Financial/Card/Card.jsx
+++ b/src/components/Section/Financial/Card/Card.jsx
@@ -116,7 +116,6 @@ export default class Card extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('financial.card.collection.summary.title')}
                      appendTitle={i18n.t('financial.card.collection.appendTitle')}
-                     appendMessage={i18n.m('financial.card.collection.appendMessage')}
                      appendLabel={i18n.t('financial.card.collection.append')}>
 
             <Field title={i18n.t('financial.card.heading.agency')}

--- a/src/components/Section/Financial/Card/Card.jsx
+++ b/src/components/Section/Financial/Card/Card.jsx
@@ -55,7 +55,10 @@ export default class Card extends ValidationElement {
    */
   updateBranch (val, event) {
     this.setState({ HasCardAbuse: val }, () => {
-      this.updateList(val === 'No' ? [] : this.state.List)
+      this.updateList({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Financial/Credit/Credit.jsx
+++ b/src/components/Section/Financial/Credit/Credit.jsx
@@ -10,6 +10,7 @@ export default class Credit extends ValidationElement {
     this.state = {
       HasCreditCounseling: props.HasCreditCounseling,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -63,11 +64,12 @@ export default class Credit extends ValidationElement {
    * Dispatch callback initiated from the collection to notify of any new
    * updates to the items.
    */
-  updateList (collection) {
-    this.setState({ List: collection }, () => {
+  updateList (values) {
+    this.setState({ List: values.items, ListBranch: values.branch }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,
+          ListBranch: this.state.ListBranch,
           HasCreditCounseling: this.state.HasCreditCounseling
         })
       }
@@ -101,6 +103,7 @@ export default class Credit extends ValidationElement {
         <Show when={this.state.HasCreditCounseling === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -159,5 +162,6 @@ export default class Credit extends ValidationElement {
 
 Credit.defaultProps = {
   HasCreditCounseling: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Financial/Credit/Credit.jsx
+++ b/src/components/Section/Financial/Credit/Credit.jsx
@@ -109,7 +109,6 @@ export default class Credit extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('financial.credit.collection.summary.title')}
                      appendTitle={i18n.t('financial.credit.collection.appendTitle')}
-                     appendMessage={i18n.m('financial.credit.collection.appendMessage')}
                      appendLabel={i18n.t('financial.credit.collection.append')}>
 
             <Field title={i18n.t('financial.credit.heading.explanation')}

--- a/src/components/Section/Financial/Credit/Credit.jsx
+++ b/src/components/Section/Financial/Credit/Credit.jsx
@@ -55,7 +55,10 @@ export default class Credit extends ValidationElement {
    */
   updateBranch (val, event) {
     this.setState({ HasCreditCounseling: val }, () => {
-      this.updateList(val === 'No' ? [] : this.state.List)
+      this.updateList({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Financial/Delinquent/Delinquent.jsx
+++ b/src/components/Section/Financial/Delinquent/Delinquent.jsx
@@ -11,6 +11,7 @@ export default class Delinquent extends ValidationElement {
     this.state = {
       HasDelinquent: props.HasDelinquent,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -64,11 +65,12 @@ export default class Delinquent extends ValidationElement {
    * Dispatch callback initiated from the collection to notify of any new
    * updates to the items.
    */
-  updateList (collection) {
-    this.setState({ List: collection }, () => {
+  updateList (values) {
+    this.setState({ List: values.items, ListBranch: values.branch }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,
+          ListBranch: this.state.ListBranch,
           HasDelinquent: this.state.HasDelinquent
         })
       }
@@ -126,6 +128,7 @@ export default class Delinquent extends ValidationElement {
         <Show when={this.state.HasDelinquent === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -263,5 +266,6 @@ export default class Delinquent extends ValidationElement {
 
 Delinquent.defaultProps = {
   HasDelinquent: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Financial/Delinquent/Delinquent.jsx
+++ b/src/components/Section/Financial/Delinquent/Delinquent.jsx
@@ -110,8 +110,6 @@ export default class Delinquent extends ValidationElement {
           <li>{i18n.m('financial.delinquent.para.lien')}</li>
           <li>{i18n.m('financial.delinquent.para.federal')}</li>
         </ul>
-
-        {i18n.m('financial.delinquent.collection.appendMessage')}
       </div>
     )
   }

--- a/src/components/Section/Financial/Delinquent/Delinquent.jsx
+++ b/src/components/Section/Financial/Delinquent/Delinquent.jsx
@@ -56,7 +56,10 @@ export default class Delinquent extends ValidationElement {
    */
   updateBranch (val, event) {
     this.setState({ HasDelinquent: val }, () => {
-      this.updateList(val === 'No' ? [] : this.state.List)
+      this.updateList({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Financial/Gambling/Gambling.jsx
+++ b/src/components/Section/Financial/Gambling/Gambling.jsx
@@ -58,7 +58,10 @@ export default class Gambling extends ValidationElement {
    */
   onUpdate (val, event) {
     this.setState({ HasGamblingDebt: val }, () => {
-      this.myDispatch(val === 'No' ? [] : this.state.List)
+      this.myDispatch({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Financial/Gambling/Gambling.jsx
+++ b/src/components/Section/Financial/Gambling/Gambling.jsx
@@ -138,8 +138,7 @@ export default class Gambling extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('financial.gambling.collection.summary.title')}
                      appendLabel={i18n.t('financial.gambling.collection.append')}
-                     appendTitle={i18n.t('financial.gambling.collection.appendTitle')}
-                     appendMessage={i18n.m('financial.gambling.collection.appendMessage')}>
+                     appendTitle={i18n.t('financial.gambling.collection.appendTitle')}>
             <Field title={i18n.t('financial.gambling.heading.dates')}
                    help="financial.gambling.help.dates"
                    adjustFor="daterange">

--- a/src/components/Section/Financial/Gambling/Gambling.jsx
+++ b/src/components/Section/Financial/Gambling/Gambling.jsx
@@ -8,6 +8,7 @@ export default class Gambling extends ValidationElement {
     super(props)
     this.state = {
       List: props.List || [],
+      ListBranch: props.ListBranch || [],
       HasGamblingDebt: props.HasGamblingDebt,
       errorCodes: []
     }
@@ -66,11 +67,12 @@ export default class Gambling extends ValidationElement {
    * Dispatch callback initiated from the collection to notify of any new
    * updates to the items.
    */
-  myDispatch (collection) {
-    this.setState({ List: collection }, () => {
+  myDispatch (values) {
+    this.setState({ List: values.items, ListBranch: values.branch }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,
+          ListBranch: this.state.ListBranch,
           HasGamblingDebt: this.state.HasGamblingDebt
         })
       }
@@ -130,6 +132,7 @@ export default class Gambling extends ValidationElement {
         <Show when={this.state.HasGamblingDebt === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.myDispatch}
                      onValidate={this.handleValidation}
                      summary={this.summary}

--- a/src/components/Section/Financial/Gambling/Gambling.test.jsx
+++ b/src/components/Section/Financial/Gambling/Gambling.test.jsx
@@ -71,7 +71,7 @@ describe('The gambling component', () => {
     component.find({type: 'radio', name: 'has_gamblingdebt', value: 'Yes'}).simulate('change')
     expect(component.find('.details').length).toBeGreaterThan(0)
 
-    component.find('button.add').at(0).simulate('click')
+    component.find('.addendum .yes input').simulate('click')
     expect(component.find('.row.open').length).toBe(0)
   })
 

--- a/src/components/Section/Financial/Nonpayment/Nonpayment.jsx
+++ b/src/components/Section/Financial/Nonpayment/Nonpayment.jsx
@@ -11,6 +11,7 @@ export default class Nonpayment extends ValidationElement {
     this.state = {
       HasNonpayment: props.HasNonpayment,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -64,11 +65,12 @@ export default class Nonpayment extends ValidationElement {
    * Dispatch callback initiated from the collection to notify of any new
    * updates to the items.
    */
-  updateList (collection) {
-    this.setState({ List: collection }, () => {
+  updateList (values) {
+    this.setState({ List: values.items, ListBranch: values.branch }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,
+          ListBranch: this.state.ListBranch,
           HasNonpayment: this.state.HasNonpayment
         })
       }
@@ -130,6 +132,7 @@ export default class Nonpayment extends ValidationElement {
         <Show when={this.state.HasNonpayment === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -250,5 +253,6 @@ export default class Nonpayment extends ValidationElement {
 
 Nonpayment.defaultProps = {
   HasNonpayment: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Financial/Nonpayment/Nonpayment.jsx
+++ b/src/components/Section/Financial/Nonpayment/Nonpayment.jsx
@@ -114,8 +114,6 @@ export default class Nonpayment extends ValidationElement {
           <li>{i18n.m('financial.nonpayment.para.delinquent')}</li>
           <li>{i18n.m('financial.nonpayment.para.any')}</li>
         </ul>
-
-        {i18n.m('financial.nonpayment.collection.appendMessage')}
       </div>
     )
   }

--- a/src/components/Section/Financial/Nonpayment/Nonpayment.jsx
+++ b/src/components/Section/Financial/Nonpayment/Nonpayment.jsx
@@ -56,7 +56,10 @@ export default class Nonpayment extends ValidationElement {
    */
   updateBranch (val, event) {
     this.setState({ HasNonpayment: val }, () => {
-      this.updateList(val === 'No' ? [] : this.state.List)
+      this.updateList({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Financial/Taxes/Taxes.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.jsx
@@ -56,7 +56,10 @@ export default class Taxes extends ValidationElement {
    */
   updateBranch (val, event) {
     this.setState({ HasTaxes: val }, () => {
-      this.updateList(val === 'No' ? [] : this.state.List)
+      this.updateList({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Financial/Taxes/Taxes.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.jsx
@@ -11,6 +11,7 @@ export default class Taxes extends ValidationElement {
     this.state = {
       HasTaxes: props.HasTaxes,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -64,11 +65,12 @@ export default class Taxes extends ValidationElement {
    * Dispatch callback initiated from the collection to notify of any new
    * updates to the items.
    */
-  updateList (collection) {
-    this.setState({ List: collection }, () => {
+  updateList (values) {
+    this.setState({ List: values.items, ListBranch: values.branch }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,
+          ListBranch: this.state.ListBranch,
           HasTaxes: this.state.HasTaxes
         })
       }
@@ -104,6 +106,7 @@ export default class Taxes extends ValidationElement {
         <Show when={this.state.HasTaxes === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -217,5 +220,6 @@ export default class Taxes extends ValidationElement {
 
 Taxes.defaultProps = {
   HasTaxes: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Financial/Taxes/Taxes.jsx
+++ b/src/components/Section/Financial/Taxes/Taxes.jsx
@@ -112,7 +112,6 @@ export default class Taxes extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('financial.taxes.collection.summary.title')}
                      appendTitle={i18n.t('financial.taxes.collection.appendTitle')}
-                     appendMessage={i18n.m('financial.taxes.collection.appendMessage')}
                      appendLabel={i18n.t('financial.taxes.collection.append')}>
 
             <Field title={i18n.t('financial.taxes.heading.failure')}

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
@@ -81,8 +81,8 @@ export default class BenefitActivity extends ValidationElement {
                      defaultState={this.props.defaultState}
                      items={this.props.List}
                      branch={this.props.ListBranch}
-                     onUpdate={this.updateList}
                      summary={this.summary}
+                     onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      description={i18n.t('foreign.activities.benefit.collection.description')}
                      appendTitle={i18n.t('foreign.activities.benefit.collection.appendTitle')}

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
@@ -23,13 +23,15 @@ export default class BenefitActivity extends ValidationElement {
       this.props.onUpdate({
         HasBenefits: this.props.HasBenefits,
         List: this.props.List,
+        ListBranch: this.props.ListBranch,
         [field]: values
       })
     }
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateHasBenefits (values) {
@@ -65,29 +67,30 @@ export default class BenefitActivity extends ValidationElement {
     return (
       <div className="benefit-activity">
         <Branch name="has_benefit"
-          help="foreign.activities.benefit.help.benefit"
-          className="has-benefits"
-          label={i18n.t('foreign.activities.benefit.heading.title')}
-          labelSize="h3"
-          value={this.props.HasBenefits}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateHasBenefits}>
+                help="foreign.activities.benefit.help.benefit"
+                className="has-benefits"
+                label={i18n.t('foreign.activities.benefit.heading.title')}
+                labelSize="h3"
+                value={this.props.HasBenefits}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateHasBenefits}>
         </Branch>
 
         <Show when={this.props.HasBenefits === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.props.List}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('foreign.activities.benefit.collection.description')}
-            appendTitle={i18n.t('foreign.activities.benefit.collection.appendTitle')}
-            appendMessage={i18n.m('foreign.activities.benefit.collection.appendMessage')}
-            appendLabel={i18n.t('foreign.activities.benefit.collection.appendLabel')}>
+                     defaultState={this.props.defaultState}
+                     items={this.props.List}
+                     branch={this.props.ListBranch}
+                     onUpdate={this.updateList}
+                     summary={this.summary}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('foreign.activities.benefit.collection.description')}
+                     appendTitle={i18n.t('foreign.activities.benefit.collection.appendTitle')}
+                     appendMessage={i18n.m('foreign.activities.benefit.collection.appendMessage')}
+                     appendLabel={i18n.t('foreign.activities.benefit.collection.appendLabel')}>
             <Benefit name="Benefit"
-              bind={true}
-            />
+                     bind={true}
+                     />
           </Accordion>
         </Show>
       </div>
@@ -99,6 +102,7 @@ BenefitActivity.defaultProps = {
   name: 'benefit',
   HasBenefits: '',
   List: [],
+  ListBranch: '',
   defaultState: true
 }
 

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
@@ -86,7 +86,6 @@ export default class BenefitActivity extends ValidationElement {
                      onValidate={this.handleValidation}
                      description={i18n.t('foreign.activities.benefit.collection.description')}
                      appendTitle={i18n.t('foreign.activities.benefit.collection.appendTitle')}
-                     appendMessage={i18n.m('foreign.activities.benefit.collection.appendMessage')}
                      appendLabel={i18n.t('foreign.activities.benefit.collection.appendLabel')}>
             <Benefit name="Benefit"
                      bind={true}

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.jsx
@@ -18,24 +18,33 @@ export default class BenefitActivity extends ValidationElement {
     this.isValid = this.isValid.bind(this)
   }
 
-  update (field, values) {
+  update (queue) {
     if (this.props.onUpdate) {
-      this.props.onUpdate({
-        HasBenefits: this.props.HasBenefits,
+      let obj = {
         List: this.props.List,
         ListBranch: this.props.ListBranch,
-        [field]: values
-      })
+        HasBenefits: this.props.HasBenefits
+      }
+
+      for (const q of queue) {
+        obj = { ...obj, [q.name]: q.value }
+      }
+
+      this.props.onUpdate(obj)
     }
   }
 
   updateList (values) {
-    this.update('List', values.items)
-    this.update('ListBranch', values.branch)
+    this.update([
+      { name: 'List', value: values.items },
+      { name: 'ListBranch', value: values.branch }
+    ])
   }
 
   updateHasBenefits (values) {
-    this.update('HasBenefits', values)
+    this.update([
+      { name: 'HasBenefits', value: values }
+    ])
   }
 
   isValid () {

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.test.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.test.jsx
@@ -55,7 +55,7 @@ describe('The BenefitActivity component', () => {
     const component = mount(<BenefitActivity {...expected} />)
     expect(component.find('.benefit-activity').length).toBe(1)
     component.find('.benefit-frequency input').first().simulate('change')
-    expect(updates).toBe(2 * 2)
+    expect(updates).toBe(2)
   })
 
   it('Renders summary based on benefit', () => {

--- a/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.test.jsx
+++ b/src/components/Section/Foreign/Activities/BenefitActivity/BenefitActivity.test.jsx
@@ -55,8 +55,7 @@ describe('The BenefitActivity component', () => {
     const component = mount(<BenefitActivity {...expected} />)
     expect(component.find('.benefit-activity').length).toBe(1)
     component.find('.benefit-frequency input').first().simulate('change')
-
-    expect(updates).toBe(2)
+    expect(updates).toBe(2 * 2)
   })
 
   it('Renders summary based on benefit', () => {

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
@@ -18,24 +18,33 @@ export default class DirectActivity extends ValidationElement {
     this.isValid = this.isValid.bind(this)
   }
 
-  update (field, values) {
+  update (queue) {
     if (this.props.onUpdate) {
-      this.props.onUpdate({
+      let obj = {
         HasInterests: this.props.HasInterests,
         List: this.props.List,
-        ListBranch: this.props.ListBranch,
-        [field]: values
-      })
+        ListBranch: this.props.ListBranch
+      }
+
+      for (const q of queue) {
+        obj = { ...obj, [q.name]: q.value }
+      }
+
+      this.props.onUpdate(obj)
     }
   }
 
   updateList (values) {
-    this.update('List', values.items)
-    this.update('ListBranch', values.branch)
+    this.update([
+      { name: 'List', value: values.items },
+      { name: 'ListBranch', value: values.branch }
+    ])
   }
 
   updateHasInterests (values) {
-    this.update('HasInterests', values)
+    this.update([
+      { name: 'HasInterests', value: values }
+    ])
   }
 
   isValid () {

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
@@ -87,28 +87,28 @@ export default class DirectActivity extends ValidationElement {
     return (
       <div className="direct">
         <Branch name="has_interests"
-          label={<h3>{i18n.t('foreign.activities.direct.heading.title')}</h3>}
-          labelSize="h3"
-          value={this.props.HasInterests}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateHasInterests}>
+                label={<h3>{i18n.t('foreign.activities.direct.heading.title')}</h3>}
+                labelSize="h3"
+                value={this.props.HasInterests}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateHasInterests}>
           {i18n.m('foreign.activities.direct.para.intro')}
         </Branch>
 
         <Show when={this.props.HasInterests === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.props.List}
-            items={this.props.ListBranch}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('foreign.activities.direct.collection.description')}
-            appendTitle={i18n.t('foreign.activities.direct.collection.appendTitle')}
-            appendLabel={i18n.t('foreign.activities.direct.collection.appendLabel')}>
+                     defaultState={this.props.defaultState}
+                     items={this.props.List}
+                     branch={this.props.ListBranch}
+                     summary={this.summary}
+                     onUpdate={this.updateList}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('foreign.activities.direct.collection.description')}
+                     appendTitle={i18n.t('foreign.activities.direct.collection.appendTitle')}
+                     appendLabel={i18n.t('foreign.activities.direct.collection.appendLabel')}>
             <DirectInterest name="DirectInterest"
-              bind={true}
-            />
+                            bind={true}
+                            />
           </Accordion>
         </Show>
       </div>

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
@@ -23,13 +23,15 @@ export default class DirectActivity extends ValidationElement {
       this.props.onUpdate({
         HasInterests: this.props.HasInterests,
         List: this.props.List,
+        ListBranch: this.props.ListBranch,
         [field]: values
       })
     }
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateHasInterests (values) {
@@ -97,6 +99,7 @@ export default class DirectActivity extends ValidationElement {
           <Accordion minimum="1"
             defaultState={this.props.defaultState}
             items={this.props.List}
+            items={this.props.ListBranch}
             onUpdate={this.updateList}
             summary={this.summary}
             onValidate={this.handleValidation}
@@ -118,5 +121,6 @@ DirectActivity.defaultProps = {
   name: 'direct',
   HasInterests: '',
   List: [],
+  ListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
@@ -105,7 +105,6 @@ export default class DirectActivity extends ValidationElement {
             onValidate={this.handleValidation}
             description={i18n.t('foreign.activities.direct.collection.description')}
             appendTitle={i18n.t('foreign.activities.direct.collection.appendTitle')}
-            appendMessage={i18n.m('foreign.activities.direct.collection.appendMessage')}
             appendLabel={i18n.t('foreign.activities.direct.collection.appendLabel')}>
             <DirectInterest name="DirectInterest"
               bind={true}

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.test.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.test.jsx
@@ -102,7 +102,8 @@ describe('The DirectActivity component', () => {
             }
           }
         }
-      ]
+      ],
+      ListBranch: 'No'
     }
     const component = mount(<DirectActivity {...expected} />)
     expect(component.find('.accordion').length).toBe(1)

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
@@ -23,13 +23,15 @@ export default class IndirectActivity extends ValidationElement {
       this.props.onUpdate({
         HasInterests: this.props.HasInterests,
         List: this.props.List,
+        ListBranch: this.props.ListBranch,
         [field]: values
       })
     }
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateHasInterests (values) {
@@ -87,27 +89,28 @@ export default class IndirectActivity extends ValidationElement {
     return (
       <div className="indirect">
         <Branch name="has_interests"
-          label={i18n.t('foreign.activities.indirect.heading.title')}
-          labelSize="h3"
-          value={this.props.HasInterests}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateHasInterests}>
+                label={i18n.t('foreign.activities.indirect.heading.title')}
+                labelSize="h3"
+                value={this.props.HasInterests}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateHasInterests}>
         </Branch>
 
         <Show when={this.props.HasInterests === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.props.List}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('foreign.activities.indirect.collection.description')}
-            appendTitle={i18n.t('foreign.activities.indirect.collection.appendTitle')}
-            appendMessage={i18n.m('foreign.activities.indirect.collection.appendMessage')}
-            appendLabel={i18n.t('foreign.activities.indirect.collection.appendLabel')}>
+                     defaultState={this.props.defaultState}
+                     items={this.props.List}
+                     branch={this.props.ListBranch}
+                     summary={this.summary}
+                     onUpdate={this.updateList}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('foreign.activities.indirect.collection.description')}
+                     appendTitle={i18n.t('foreign.activities.indirect.collection.appendTitle')}
+                     appendMessage={i18n.m('foreign.activities.indirect.collection.appendMessage')}
+                     appendLabel={i18n.t('foreign.activities.indirect.collection.appendLabel')}>
             <IndirectInterest name="IndirectInterest"
-              bind={true}
-            />
+                              bind={true}
+                              />
           </Accordion>
         </Show>
       </div>
@@ -119,5 +122,6 @@ IndirectActivity.defaultProps = {
   name: 'indirect',
   HasInterests: '',
   List: [],
+  ListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
@@ -18,24 +18,33 @@ export default class IndirectActivity extends ValidationElement {
     this.isValid = this.isValid.bind(this)
   }
 
-  update (field, values) {
+  update (queue) {
     if (this.props.onUpdate) {
-      this.props.onUpdate({
-        HasInterests: this.props.HasInterests,
+      let obj = {
         List: this.props.List,
         ListBranch: this.props.ListBranch,
-        [field]: values
-      })
+        HasInterests: this.props.HasInterests
+      }
+
+      for (const q of queue) {
+        obj = { ...obj, [q.name]: q.value }
+      }
+
+      this.props.onUpdate(obj)
     }
   }
 
   updateList (values) {
-    this.update('List', values.items)
-    this.update('ListBranch', values.branch)
+    this.update([
+      { name: 'List', value: values.items },
+      { name: 'ListBranch', value: values.branch }
+    ])
   }
 
   updateHasInterests (values) {
-    this.update('HasInterests', values)
+    this.update([
+      { name: 'HasInterests', value: values }
+    ])
   }
 
   isValid () {

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
@@ -106,7 +106,6 @@ export default class IndirectActivity extends ValidationElement {
                      onValidate={this.handleValidation}
                      description={i18n.t('foreign.activities.indirect.collection.description')}
                      appendTitle={i18n.t('foreign.activities.indirect.collection.appendTitle')}
-                     appendMessage={i18n.m('foreign.activities.indirect.collection.appendMessage')}
                      appendLabel={i18n.t('foreign.activities.indirect.collection.appendLabel')}>
             <IndirectInterest name="IndirectInterest"
                               bind={true}

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.test.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.test.jsx
@@ -118,7 +118,8 @@ describe('The IndirectActivity component', () => {
             }
           }
         }
-      ]
+      ],
+      ListBranch: 'No'
     }
     const component = mount(<IndirectActivity {...expected} />)
     expect(component.find('.accordion').length).toBe(1)

--- a/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
+++ b/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
@@ -19,24 +19,33 @@ export default class RealEstateActivity extends ValidationElement {
     this.isValid = this.isValid.bind(this)
   }
 
-  update (field, values) {
+  update (queue) {
     if (this.props.onUpdate) {
-      this.props.onUpdate({
-        HasInterests: this.props.HasInterests,
+      let obj = {
         List: this.props.List,
         ListBranch: this.props.ListBranch,
-        [field]: values
-      })
+        HasInterests: this.props.HasInterests
+      }
+
+      for (const q of queue) {
+        obj = { ...obj, [q.name]: q.value }
+      }
+
+      this.props.onUpdate(obj)
     }
   }
 
   updateList (values) {
-    this.update('List', values.items)
-    this.update('ListBranch', values.branch)
+    this.update([
+      { name: 'List', value: values.items },
+      { name: 'ListBranch', value: values.branch }
+    ])
   }
 
   updateHasInterests (values) {
-    this.update('HasInterests', values)
+    this.update([
+      { name: 'HasInterests', value: values }
+    ])
   }
 
   isValid () {
@@ -68,7 +77,7 @@ export default class RealEstateActivity extends ValidationElement {
 
     const summary = [who, address].reduce((prev, next) => {
       if (prev && next) {
-        return prev + ' - ' + next
+        return <span>{prev} - {next}</span>
       }
       return prev
     })

--- a/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
+++ b/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
@@ -88,27 +88,27 @@ export default class RealEstateActivity extends ValidationElement {
     return (
       <div className="realestate">
         <Branch name="has_interests"
-          label={i18n.t('foreign.activities.realestate.heading.title')}
-          labelSize="h3"
-          value={this.props.HasInterests}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateHasInterests}>
+                label={i18n.t('foreign.activities.realestate.heading.title')}
+                labelSize="h3"
+                value={this.props.HasInterests}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateHasInterests}>
         </Branch>
 
         <Show when={this.props.HasInterests === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.props.List}
-            branch={this.props.ListBranch}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('foreign.activities.realestate.collection.description')}
-            appendTitle={i18n.t('foreign.activities.realestate.collection.appendTitle')}
-            appendLabel={i18n.t('foreign.activities.realestate.collection.appendLabel')}>
+                     defaultState={this.props.defaultState}
+                     items={this.props.List}
+                     branch={this.props.ListBranch}
+                     summary={this.summary}
+                     onUpdate={this.updateList}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('foreign.activities.realestate.collection.description')}
+                     appendTitle={i18n.t('foreign.activities.realestate.collection.appendTitle')}
+                     appendLabel={i18n.t('foreign.activities.realestate.collection.appendLabel')}>
             <RealEstateInterest name="RealEstateInterest"
-              bind={true}
-            />
+                                bind={true}
+                                />
           </Accordion>
         </Show>
       </div>

--- a/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
+++ b/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
@@ -24,13 +24,15 @@ export default class RealEstateActivity extends ValidationElement {
       this.props.onUpdate({
         HasInterests: this.props.HasInterests,
         List: this.props.List,
+        ListBranch: this.props.ListBranch,
         [field]: values
       })
     }
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateHasInterests (values) {
@@ -97,6 +99,7 @@ export default class RealEstateActivity extends ValidationElement {
           <Accordion minimum="1"
             defaultState={this.props.defaultState}
             items={this.props.List}
+            branch={this.props.ListBranch}
             onUpdate={this.updateList}
             summary={this.summary}
             onValidate={this.handleValidation}
@@ -118,5 +121,6 @@ RealEstateActivity.defaultProps = {
   name: 'realestate',
   HasInterests: '',
   List: [],
+  ListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
+++ b/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.jsx
@@ -105,7 +105,6 @@ export default class RealEstateActivity extends ValidationElement {
             onValidate={this.handleValidation}
             description={i18n.t('foreign.activities.realestate.collection.description')}
             appendTitle={i18n.t('foreign.activities.realestate.collection.appendTitle')}
-            appendMessage={i18n.m('foreign.activities.realestate.collection.appendMessage')}
             appendLabel={i18n.t('foreign.activities.realestate.collection.appendLabel')}>
             <RealEstateInterest name="RealEstateInterest"
               bind={true}

--- a/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.test.jsx
+++ b/src/components/Section/Foreign/Activities/RealEstateActivity/RealEstateActivity.test.jsx
@@ -152,7 +152,8 @@ describe('The RealEstateActivity component', () => {
             }
           }
         }
-      ]
+      ],
+      ListBranch: 'No'
     }
     const component = mount(<RealEstateActivity {...expected} />)
     expect(component.find('.accordion').length).toBe(1)

--- a/src/components/Section/Foreign/Activities/Support.jsx
+++ b/src/components/Section/Foreign/Activities/Support.jsx
@@ -12,6 +12,7 @@ export default class Support extends ValidationElement {
     this.state = {
       HasForeignSupport: props.HasForeignSupport,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -27,7 +28,8 @@ export default class Support extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasForeignSupport: this.state.HasForeignSupport,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
@@ -37,8 +39,9 @@ export default class Support extends ValidationElement {
     this.onUpdate('HasForeignSupport', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -92,6 +95,7 @@ export default class Support extends ValidationElement {
         <Show when={this.state.HasForeignSupport === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -169,5 +173,6 @@ export default class Support extends ValidationElement {
 Support.defaultProps = {
   name: 'Support',
   HasForeignSupport: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Foreign/Activities/Support.jsx
+++ b/src/components/Section/Foreign/Activities/Support.jsx
@@ -101,7 +101,6 @@ export default class Support extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('foreign.activities.support.collection.summary.title')}
                      appendTitle={i18n.t('foreign.activities.support.collection.appendTitle')}
-                     appendMessage={i18n.m('foreign.activities.support.collection.appendMessage')}
                      appendLabel={i18n.t('foreign.activities.support.collection.append')}>
             <h3>{i18n.t('foreign.activities.support.heading.name')}</h3>
             <Name name="Name"

--- a/src/components/Section/Foreign/Activities/Support.test.jsx
+++ b/src/components/Section/Foreign/Activities/Support.test.jsx
@@ -23,7 +23,7 @@ describe('The foreign activities support component', () => {
     }
     const component = mount(<Support {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 
@@ -35,8 +35,8 @@ describe('The foreign activities support component', () => {
       onValidate: () => { validated = true }
     }
     const component = mount(<Support {...expected} />)
-    component.find('.branch .yes input').simulate('change')
-    component.find('.branch .yes input').simulate('blur')
+    component.find('.branch .yes input').at(0).simulate('change')
+    component.find('.branch .yes input').at(0).simulate('blur')
     expect(validated).toBe(true)
   })
 
@@ -55,6 +55,6 @@ describe('The foreign activities support component', () => {
     component.find('.foreign-activities-support-amount input').simulate('change')
     component.find('.foreign-activities-support-frequency input').simulate('change')
     component.find('.foreign-activities-support-citizenship input').simulate('change')
-    expect(updates).toBe(6)
+    expect(updates).toBe(6 * 2)
   })
 })

--- a/src/components/Section/Foreign/Business/Advice.jsx
+++ b/src/components/Section/Foreign/Business/Advice.jsx
@@ -11,6 +11,7 @@ export default class Advice extends ValidationElement {
     this.state = {
       HasForeignAdvice: props.HasForeignAdvice,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -25,7 +26,8 @@ export default class Advice extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasForeignAdvice: this.state.HasForeignAdvice,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
@@ -35,8 +37,9 @@ export default class Advice extends ValidationElement {
     this.onUpdate('HasForeignAdvice', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -96,6 +99,7 @@ export default class Advice extends ValidationElement {
         <Show when={this.state.HasForeignAdvice === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -159,5 +163,6 @@ export default class Advice extends ValidationElement {
 Advice.defaultProps = {
   name: 'Advice',
   HasForeignAdvice: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Foreign/Business/Advice.test.jsx
+++ b/src/components/Section/Foreign/Business/Advice.test.jsx
@@ -23,7 +23,7 @@ describe('The foreign business advice component', () => {
     }
     const component = mount(<Advice {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 
@@ -55,6 +55,6 @@ describe('The foreign business advice component', () => {
     component.find('.advice-country input').simulate('change')
     component.find('.advice-dates .to .day input').simulate('change')
     component.find('.advice-compensation textarea').simulate('change')
-    expect(updates).toBe(6)
+    expect(updates).toBe(6 * 2)
   })
 })

--- a/src/components/Section/Foreign/Business/Advice.test.jsx
+++ b/src/components/Section/Foreign/Business/Advice.test.jsx
@@ -35,8 +35,8 @@ describe('The foreign business advice component', () => {
       onValidate: () => { validated = true }
     }
     const component = mount(<Advice {...expected} />)
-    component.find('.branch .yes input').simulate('change')
-    component.find('.branch .yes input').simulate('blur')
+    component.find('.branch .yes input').at(0).simulate('change')
+    component.find('.branch .yes input').at(0).simulate('blur')
     expect(validated).toBe(true)
   })
 

--- a/src/components/Section/Foreign/Business/Conferences.jsx
+++ b/src/components/Section/Foreign/Business/Conferences.jsx
@@ -13,6 +13,7 @@ export default class Conferences extends ValidationElement {
     this.state = {
       HasForeignConferences: props.HasForeignConferences,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -37,8 +38,9 @@ export default class Conferences extends ValidationElement {
     this.onUpdate('HasForeignConferences', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -99,6 +101,7 @@ export default class Conferences extends ValidationElement {
         <Show when={this.state.HasForeignConferences === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -168,5 +171,6 @@ export default class Conferences extends ValidationElement {
 Conferences.defaultProps = {
   name: 'Conferences',
   HasForeignConferences: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Foreign/Business/Conferences.test.jsx
+++ b/src/components/Section/Foreign/Business/Conferences.test.jsx
@@ -23,7 +23,7 @@ describe('The foreign business conferences component', () => {
     }
     const component = mount(<Conferences {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 
@@ -57,6 +57,6 @@ describe('The foreign business conferences component', () => {
     component.find('.conferences-purpose textarea').simulate('change')
     component.find('.has-foreign-contacts .yes input').simulate('change')
     component.find('.conferences-explanation textarea').simulate('change')
-    expect(updates).toBe(8)
+    expect(updates).toBe(8 * 16)
   })
 })

--- a/src/components/Section/Foreign/Business/Conferences.test.jsx
+++ b/src/components/Section/Foreign/Business/Conferences.test.jsx
@@ -57,6 +57,6 @@ describe('The foreign business conferences component', () => {
     component.find('.conferences-purpose textarea').simulate('change')
     component.find('.has-foreign-contacts .yes input').simulate('change')
     component.find('.conferences-explanation textarea').simulate('change')
-    expect(updates).toBe(8 * 16)
+    expect(updates).toBe(8 * 2)
   })
 })

--- a/src/components/Section/Foreign/Business/Employment.jsx
+++ b/src/components/Section/Foreign/Business/Employment.jsx
@@ -105,7 +105,6 @@ export default class Employment extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('foreign.business.employment.collection.summary.title')}
                      appendTitle={i18n.t('foreign.business.employment.collection.appendTitle')}
-                     appendMessage={i18n.m('foreign.business.employment.collection.appendMessage')}
                      appendLabel={i18n.t('foreign.business.employment.collection.append')}>
             <JobOffer name="Item" bind={true} />
           </Accordion>

--- a/src/components/Section/Foreign/Business/Employment.jsx
+++ b/src/components/Section/Foreign/Business/Employment.jsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { i18n } from '../../../../config'
 import { DateSummary } from '../../../Summary'
 import { ForeignBusinessEmploymentValidator } from '../../../../validators'
-import { ValidationElement, Branch, Show, Accordion, Field,
-         Address, Textarea, Name, DateControl } from '../../../Form'
+import { ValidationElement, Branch, Show, Accordion } from '../../../Form'
 import JobOffer from './JobOffer'
 
 export default class Employment extends ValidationElement {
@@ -13,6 +12,7 @@ export default class Employment extends ValidationElement {
     this.state = {
       HasForeignEmployment: props.HasForeignEmployment,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -27,7 +27,8 @@ export default class Employment extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasForeignEmployment: this.state.HasForeignEmployment,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
@@ -37,8 +38,9 @@ export default class Employment extends ValidationElement {
     this.onUpdate('HasForeignEmployment', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -97,6 +99,7 @@ export default class Employment extends ValidationElement {
         <Show when={this.state.HasForeignEmployment === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}

--- a/src/components/Section/Foreign/Business/Employment.test.jsx
+++ b/src/components/Section/Foreign/Business/Employment.test.jsx
@@ -23,7 +23,7 @@ describe('The foreign business employment component', () => {
     }
     const component = mount(<Employment {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 
@@ -55,6 +55,6 @@ describe('The foreign business employment component', () => {
     component.find('.employment-address .mailing input').simulate('change')
     component.find('.employment-accepted .yes input').simulate('change')
     component.find('.employment-explanation textarea').simulate('change')
-    expect(updates).toBe(7)
+    expect(updates).toBe(7 * 2)
   })
 })

--- a/src/components/Section/Foreign/Business/Family.jsx
+++ b/src/components/Section/Foreign/Business/Family.jsx
@@ -11,6 +11,7 @@ export default class Family extends ValidationElement {
     this.state = {
       HasForeignFamily: props.HasForeignFamily,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -25,7 +26,8 @@ export default class Family extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasForeignFamily: this.state.HasForeignFamily,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
@@ -35,8 +37,9 @@ export default class Family extends ValidationElement {
     this.onUpdate('HasForeignFamily', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -96,6 +99,7 @@ export default class Family extends ValidationElement {
         <Show when={this.state.HasForeignFamily === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -151,5 +155,6 @@ export default class Family extends ValidationElement {
 Family.defaultProps = {
   name: 'Family',
   HasForeignFamily: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Foreign/Business/Family.test.jsx
+++ b/src/components/Section/Foreign/Business/Family.test.jsx
@@ -23,7 +23,7 @@ describe('The foreign business family component', () => {
     }
     const component = mount(<Family {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 
@@ -35,8 +35,8 @@ describe('The foreign business family component', () => {
       onValidate: () => { validated = true }
     }
     const component = mount(<Family {...expected} />)
-    component.find('.branch .yes input').simulate('change')
-    component.find('.branch .yes input').simulate('blur')
+    component.find('.branch .yes input').at(0).simulate('change')
+    component.find('.branch .yes input').at(0).simulate('blur')
     expect(validated).toBe(true)
   })
 
@@ -54,6 +54,6 @@ describe('The foreign business family component', () => {
     component.find('.family-country input').simulate('change')
     component.find('.family-date .day input').simulate('change')
     component.find('.family-circumstances textarea').simulate('change')
-    expect(updates).toBe(5)
+    expect(updates).toBe(5 * 2)
   })
 })

--- a/src/components/Section/Foreign/Business/JobOffer.test.jsx
+++ b/src/components/Section/Foreign/Business/JobOffer.test.jsx
@@ -18,6 +18,6 @@ describe('The foreign business job offer component', () => {
     component.find('.employment-address .mailing input').simulate('change')
     component.find('.employment-accepted .yes input').simulate('change')
     component.find('.employment-explanation textarea').simulate('change')
-    expect(updates).toBe(16)
+    expect(updates).toBe(14)
   })
 })

--- a/src/components/Section/Foreign/Business/JobOffer.test.jsx
+++ b/src/components/Section/Foreign/Business/JobOffer.test.jsx
@@ -18,6 +18,6 @@ describe('The foreign business job offer component', () => {
     component.find('.employment-address .mailing input').simulate('change')
     component.find('.employment-accepted .yes input').simulate('change')
     component.find('.employment-explanation textarea').simulate('change')
-    expect(updates).toBe(7)
+    expect(updates).toBe(16)
   })
 })

--- a/src/components/Section/Foreign/Business/Ventures.jsx
+++ b/src/components/Section/Foreign/Business/Ventures.jsx
@@ -12,6 +12,7 @@ export default class Ventures extends ValidationElement {
     this.state = {
       HasForeignVentures: props.HasForeignVentures,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -26,7 +27,8 @@ export default class Ventures extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasForeignVentures: this.state.HasForeignVentures,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
@@ -36,8 +38,9 @@ export default class Ventures extends ValidationElement {
     this.onUpdate('HasForeignVentures', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -99,6 +102,7 @@ export default class Ventures extends ValidationElement {
         <Show when={this.state.HasForeignVentures === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -204,5 +208,6 @@ export default class Ventures extends ValidationElement {
 Ventures.defaultProps = {
   name: 'Ventures',
   HasForeignVentures: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Foreign/Business/Ventures.test.jsx
+++ b/src/components/Section/Foreign/Business/Ventures.test.jsx
@@ -23,7 +23,7 @@ describe('The foreign business ventures component', () => {
     }
     const component = mount(<Ventures {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 
@@ -35,8 +35,8 @@ describe('The foreign business ventures component', () => {
       onValidate: () => { validated = true }
     }
     const component = mount(<Ventures {...expected} />)
-    component.find('.branch .yes input').simulate('change')
-    component.find('.branch .yes input').simulate('blur')
+    component.find('.branch .yes input').at(0).simulate('change')
+    component.find('.branch .yes input').at(0).simulate('blur')
     expect(validated).toBe(true)
   })
 
@@ -59,6 +59,6 @@ describe('The foreign business ventures component', () => {
     component.find('.ventures-position input').simulate('change')
     component.find('.ventures-service input').simulate('change')
     component.find('.ventures-compensation textarea').simulate('change')
-    expect(updates).toBe(10)
+    expect(updates).toBe(10 * 2)
   })
 })

--- a/src/components/Section/Foreign/Contacts/Contacts.jsx
+++ b/src/components/Section/Foreign/Contacts/Contacts.jsx
@@ -11,6 +11,7 @@ export default class Contacts extends ValidationElement {
     this.state = {
       HasForeignContacts: props.HasForeignContacts,
       List: props.List,
+      ListBranch: props.ListBranch,
       error: false,
       valid: false,
       errorCodes: []
@@ -25,7 +26,8 @@ export default class Contacts extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasForeignContacts: this.state.HasForeignContacts,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
@@ -35,8 +37,9 @@ export default class Contacts extends ValidationElement {
     this.onUpdate('HasForeignContacts', value)
   }
 
-  updateList (items) {
-    this.onUpdate('List', items)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -94,6 +97,7 @@ export default class Contacts extends ValidationElement {
         <Show when={this.state.HasForeignContacts === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -111,5 +115,6 @@ export default class Contacts extends ValidationElement {
 
 Contacts.defaultProps = {
   HasForeignContacts: '',
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Foreign/Contacts/Contacts.test.jsx
+++ b/src/components/Section/Foreign/Contacts/Contacts.test.jsx
@@ -23,7 +23,7 @@ describe('The contacts component', () => {
     }
     const component = mount(<Contacts {...expected} />)
     component.find('.branch .yes input').simulate('change')
-    expect(updates).toBe(2)
+    expect(updates).toBe(3)
     expect(component.find('.accordion').length).toBe(1)
   })
 })

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -84,8 +84,8 @@ export default class Federal extends ValidationElement {
     this.handleValidation(event, null, null)
   }
 
-  updateCollection (collection) {
-    this.onUpdate('List', collection)
+  updateCollection (values) {
+    this.onUpdate('List', values.items)
   }
 
   /**

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -152,17 +152,17 @@ class History extends ValidationElement {
   }
 
   updateResidence (values) {
-    this.onUpdate('Residence', values)
+    this.onUpdate('Residence', values.items)
   }
 
   updateEmployment (values) {
-    this.onUpdate('Employment', values)
+    this.onUpdate('Employment', values.items)
   }
 
   updateEducation (values) {
     let education = this.props.Education || {}
     education.List = values.items
-    this.onUpdate('Education', education)
+    this.onUpdate('Education', education.items)
   }
 
   updateBranchAttendance (values) {

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -152,16 +152,16 @@ class History extends ValidationElement {
   }
 
   updateResidence (values) {
-    this.onUpdate('Residence', this.excludeGaps(values))
+    this.onUpdate('Residence', this.excludeGaps(values.items))
   }
 
   updateEmployment (values) {
-    this.onUpdate('Employment', this.excludeGaps(values))
+    this.onUpdate('Employment', this.excludeGaps(values.items))
   }
 
   updateEducation (values) {
     let education = this.props.Education || {}
-    education.List = values
+    education.List = values.items
     this.onUpdate('Education', education)
   }
 

--- a/src/components/Section/History/summaries.jsx
+++ b/src/components/Section/History/summaries.jsx
@@ -64,7 +64,7 @@ export const ResidenceSummary = (item, errors, open) => {
       <span className="index">
         {i18n.t('history.residence.collection.summary.item')}:
       </span>
-      <span className="employer"><strong>{address}</strong></span>
+      <span className="employer title-case"><strong>{address}</strong></span>
       <span className="dates"><strong>{dates}</strong></span>
     </span>
   )
@@ -80,7 +80,7 @@ const PersonSummary = (item, errors) => {
   return (
     <span>
       <span className="index">{i18n.t('history.residence.collection.summary.item2')}: </span>
-      <span><strong>{name}</strong></span>
+      <span className="title-case"><strong>{name}</strong></span>
     </span>
   )
 }

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
@@ -32,12 +32,12 @@ export default class ContactInformation extends ValidationElement {
     this.handleUpdate('Emails', collection)
   }
 
-  contactDispatch (field, collection) {
-    this.handleUpdate(field, collection)
+  contactDispatch (field, values) {
+    this.handleUpdate(field, values)
   }
 
   handleUpdate (field, values) {
-    this.setState({ [field]: values }, () => {
+    this.setState({ [field]: values.items }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           Emails: this.state.Emails,

--- a/src/components/Section/Identification/OtherNames/OtherNames.jsx
+++ b/src/components/Section/Identification/OtherNames/OtherNames.jsx
@@ -48,7 +48,10 @@ export default class OtherNames extends ValidationElement {
 
   onUpdate (val, event) {
     this.setState({ HasOtherNames: val }, () => {
-      this.myDispatch(val === 'No' ? [] : this.state.List)
+      this.myDispatch({
+        items: val === 'No' ? [] : this.state.List,
+        branch: ''
+      })
       this.handleValidation(event, null, null)
     })
   }

--- a/src/components/Section/Identification/OtherNames/OtherNames.jsx
+++ b/src/components/Section/Identification/OtherNames/OtherNames.jsx
@@ -53,8 +53,8 @@ export default class OtherNames extends ValidationElement {
     })
   }
 
-  myDispatch (collection) {
-    this.setState({ List: collection }, () => {
+  myDispatch (values) {
+    this.setState({ List: values.items }, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           List: this.state.List,

--- a/src/components/Section/Legal/Police/Police.jsx
+++ b/src/components/Section/Legal/Police/Police.jsx
@@ -36,6 +36,7 @@ export default class Police extends ValidationElement {
       List: props.List,
       ListBranch: props.ListBranch,
       OtherOffenses: props.OtherOffenses,
+      OtherOffensesBranch: props.OtherOffensesBranch,
       DomesticViolence: props.DomesticViolence,
       errorCodes: []
     }

--- a/src/components/Section/Legal/Police/Police.jsx
+++ b/src/components/Section/Legal/Police/Police.jsx
@@ -34,6 +34,7 @@ export default class Police extends ValidationElement {
       HasOtherFirearms: props.HasOtherFirearms,
       HasOtherAlcohol: props.HasOtherAlcohol,
       List: props.List,
+      ListBranch: props.ListBranch,
       OtherOffenses: props.OtherOffenses,
       DomesticViolence: props.DomesticViolence,
       errorCodes: []
@@ -104,12 +105,14 @@ export default class Police extends ValidationElement {
     })
   }
 
-  updateList (collection) {
-    this.onUpdate('List', collection)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
-  updateOtherOffenses (value) {
-    this.onUpdate('OtherOffenses', value, () => {
+  updateOtherOffenses (values) {
+    this.onUpdate('OtherOffensesBranch', values.branch)
+    this.onUpdate('OtherOffenses', values.items, () => {
       this.checkToClear()
     })
   }
@@ -285,6 +288,7 @@ export default class Police extends ValidationElement {
         <Show when={this.hasOffenses()}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}
@@ -347,6 +351,7 @@ export default class Police extends ValidationElement {
         <Show when={this.hasOtherOffenses()}>
           <Accordion minimum="1"
                      items={this.state.OtherOffenses}
+                     branch={this.state.OtherOffensesBranch}
                      onUpdate={this.updateOtherOffenses}
                      onValidate={this.handleValidation}
                      summary={this.summary}

--- a/src/components/Section/Military/Disciplinary/Disciplinary.jsx
+++ b/src/components/Section/Military/Disciplinary/Disciplinary.jsx
@@ -22,6 +22,7 @@ export default class Disciplinary extends ValidationElement {
     this.state = {
       HasDisciplinary: props.HasDisciplinary,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -45,8 +46,9 @@ export default class Disciplinary extends ValidationElement {
     }
   }
 
-  updateList (collection) {
-    this.onUpdate('List', collection)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -119,6 +121,7 @@ export default class Disciplinary extends ValidationElement {
         <Show when={this.state.HasDisciplinary === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}

--- a/src/components/Section/Military/Foreign/ForeignService.jsx
+++ b/src/components/Section/Military/Foreign/ForeignService.jsx
@@ -269,7 +269,6 @@ export default class ForeignService extends ValidationElement {
                        summary={this.summary}
                        description={i18n.t('military.foreign.collection.contacts.summary.title')}
                        appendTitle={i18n.t('military.foreign.collection.contacts.appendTitle')}
-                       appendMessage={i18n.m('military.foreign.collection.contacts.appendMessage')}
                        appendLabel={i18n.t('military.foreign.collection.contacts.append')}>
               <ForeignContact name="Item"
                               bind={true}

--- a/src/components/Section/Military/Foreign/ForeignService.jsx
+++ b/src/components/Section/Military/Foreign/ForeignService.jsx
@@ -29,7 +29,8 @@ export default class ForeignService extends ValidationElement {
       Circumstances: props.Circumstances,
       ReasonLeft: props.ReasonLeft,
       MaintainsContact: props.MaintainsContact,
-      List: props.List
+      List: props.List,
+      ListBranch: props.ListBranch
     }
 
     this.onUpdate = this.onUpdate.bind(this)
@@ -92,8 +93,9 @@ export default class ForeignService extends ValidationElement {
     }
   }
 
-  updateList (value) {
-    this.onUpdate('List', value)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -261,6 +263,7 @@ export default class ForeignService extends ValidationElement {
             <Accordion minimum="1"
                        className="foreign-contacts-collection"
                        items={this.state.List}
+                       branch={this.state.ListBranch}
                        onUpdate={this.updateList}
                        onValidate={this.props.onValidate}
                        summary={this.summary}

--- a/src/components/Section/Military/Foreign/ForeignService.jsx
+++ b/src/components/Section/Military/Foreign/ForeignService.jsx
@@ -90,6 +90,7 @@ export default class ForeignService extends ValidationElement {
     // If there is no history clear out any previously entered data
     if (value === 'No') {
       this.onUpdate('List', [])
+      this.onUpdate('ListBranch', '')
     }
   }
 

--- a/src/components/Section/Military/History/History.jsx
+++ b/src/components/Section/Military/History/History.jsx
@@ -23,6 +23,7 @@ export default class History extends ValidationElement {
     this.state = {
       HasServed: props.HasServed,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -46,8 +47,9 @@ export default class History extends ValidationElement {
     }
   }
 
-  updateList (collection) {
-    this.onUpdate('List', collection)
+  updateList (values) {
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -117,6 +119,7 @@ export default class History extends ValidationElement {
         <Show when={this.state.HasServed === 'Yes'}>
           <Accordion minimum="1"
                      items={this.state.List}
+                     branch={this.state.ListBranch}
                      onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      summary={this.summary}

--- a/src/components/Section/Military/History/History.jsx
+++ b/src/components/Section/Military/History/History.jsx
@@ -125,7 +125,6 @@ export default class History extends ValidationElement {
                      summary={this.summary}
                      description={i18n.t('military.history.collection.summary.title')}
                      appendTitle={i18n.t('military.history.collection.appendTitle')}
-                     appendMessage={i18n.m('military.history.collection.appendMessage')}
                      appendLabel={i18n.t('military.history.collection.append')}>
             <MilitaryService name="Item"
                              bind={true}

--- a/src/components/Section/Psychological/Competence/Competence.jsx
+++ b/src/components/Section/Psychological/Competence/Competence.jsx
@@ -11,6 +11,7 @@ export default class Competence extends ValidationElement {
     this.state = {
       IsIncompetent: props.IsIncompetent,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -25,14 +26,16 @@ export default class Competence extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           IsIncompetent: this.state.IsIncompetent,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateIsIncompentent (values) {
@@ -90,6 +93,7 @@ export default class Competence extends ValidationElement {
           <Accordion minimum="1"
             defaultState={this.props.defaultState}
             items={this.state.List}
+            branch={this.state.ListBranch}
             onUpdate={this.updateList}
             summary={this.summary}
             onValidate={this.handleValidation}
@@ -109,6 +113,8 @@ export default class Competence extends ValidationElement {
 }
 
 Competence.defaultProps = {
+  IsIncompetent: '',
   List: [],
+  ListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Psychological/Competence/Competence.jsx
+++ b/src/components/Section/Psychological/Competence/Competence.jsx
@@ -99,7 +99,6 @@ export default class Competence extends ValidationElement {
             onValidate={this.handleValidation}
             description={i18n.t('psychological.competence.collection.description')}
             appendTitle={i18n.t('psychological.competence.collection.appendTitle')}
-            appendMessage={i18n.m('psychological.competence.collection.appendMessage')}
             appendLabel={i18n.t('psychological.competence.collection.appendLabel')}>
             <Order name="Competence"
               ApplicantBirthDate={this.props.ApplicantBirthDate}

--- a/src/components/Section/Psychological/Competence/Competence.jsx
+++ b/src/components/Section/Psychological/Competence/Competence.jsx
@@ -84,26 +84,26 @@ export default class Competence extends ValidationElement {
       <div className="competence">
         <h2>{i18n.t('psychological.heading.competence')}</h2>
         <Branch name="is_incompetent"
-          value={this.state.IsIncompetent}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateIsIncompentent}>
+                value={this.state.IsIncompetent}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateIsIncompentent}>
         </Branch>
 
         <Show when={this.state.IsIncompetent === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.state.List}
-            branch={this.state.ListBranch}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('psychological.competence.collection.description')}
-            appendTitle={i18n.t('psychological.competence.collection.appendTitle')}
-            appendLabel={i18n.t('psychological.competence.collection.appendLabel')}>
+                     defaultState={this.props.defaultState}
+                     items={this.state.List}
+                     branch={this.state.ListBranch}
+                     summary={this.summary}
+                     onUpdate={this.updateList}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('psychological.competence.collection.description')}
+                     appendTitle={i18n.t('psychological.competence.collection.appendTitle')}
+                     appendLabel={i18n.t('psychological.competence.collection.appendLabel')}>
             <Order name="Competence"
-              ApplicantBirthDate={this.props.ApplicantBirthDate}
-              prefix="competence"
-              bind={true} />
+                   ApplicantBirthDate={this.props.ApplicantBirthDate}
+                   prefix="competence"
+                   bind={true} />
           </Accordion>
         </Show>
       </div>

--- a/src/components/Section/Psychological/Competence/Competence.test.jsx
+++ b/src/components/Section/Psychological/Competence/Competence.test.jsx
@@ -14,6 +14,6 @@ describe('The Competence component', () => {
     const component = mount(<Competence onUpdate={onUpdate} />)
     component.find('.competence .yes input').simulate('change')
     component.find('input[name="CourtName"]').simulate('change')
-    expect(updates).toBe(3)
+    expect(updates).toBe(5)
   })
 })

--- a/src/components/Section/Psychological/Consultation/Consultation.jsx
+++ b/src/components/Section/Psychological/Consultation/Consultation.jsx
@@ -103,7 +103,6 @@ export default class Consultation extends ValidationElement {
             onValidate={this.handleValidation}
             description={i18n.t('psychological.consultation.collection.description')}
             appendTitle={i18n.t('psychological.consultation.collection.appendTitle')}
-            appendMessage={i18n.m('psychological.consultation.collection.appendMessage')}
             appendLabel={i18n.t('psychological.consultation.collection.appendLabel')}>
             <Order
               name="Consultation"

--- a/src/components/Section/Psychological/Consultation/Consultation.jsx
+++ b/src/components/Section/Psychological/Consultation/Consultation.jsx
@@ -11,6 +11,7 @@ export default class Consultation extends ValidationElement {
     this.state = {
       Consulted: props.Consulted,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -26,14 +27,16 @@ export default class Consultation extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           Consulted: this.state.Consulted,
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('List', values.branch)
   }
 
   updateConsulted (values) {
@@ -94,6 +97,7 @@ export default class Consultation extends ValidationElement {
           <Accordion minimum="1"
             defaultState={this.props.defaultState}
             items={this.state.List}
+            branch={this.state.ListBranch}
             onUpdate={this.updateList}
             summary={this.summary}
             onValidate={this.handleValidation}
@@ -114,6 +118,8 @@ export default class Consultation extends ValidationElement {
 }
 
 Consultation.defaultProps = {
+  Consulted: '',
   List: [],
+  ListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Psychological/Consultation/Consultation.jsx
+++ b/src/components/Section/Psychological/Consultation/Consultation.jsx
@@ -36,7 +36,7 @@ export default class Consultation extends ValidationElement {
 
   updateList (values) {
     this.update('List', values.items)
-    this.update('List', values.branch)
+    this.update('ListBranch', values.branch)
   }
 
   updateConsulted (values) {
@@ -88,27 +88,26 @@ export default class Consultation extends ValidationElement {
         <h2>{i18n.t('psychological.heading.consultation')}</h2>
         { i18n.m('psychological.heading.consultation2') }
         <Branch name="is_incompetent"
-          value={this.state.Consulted}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateConsulted}>
+                value={this.state.Consulted}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateConsulted}>
         </Branch>
 
         <Show when={this.state.Consulted === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.state.List}
-            branch={this.state.ListBranch}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('psychological.consultation.collection.description')}
-            appendTitle={i18n.t('psychological.consultation.collection.appendTitle')}
-            appendLabel={i18n.t('psychological.consultation.collection.appendLabel')}>
-            <Order
-              name="Consultation"
-              prefix="consultation"
-              ApplicantBirthDate={this.props.ApplicantBirthDate}
-              bind={true} />
+                     defaultState={this.props.defaultState}
+                     items={this.state.List}
+                     branch={this.state.ListBranch}
+                     summary={this.summary}
+                     onUpdate={this.updateList}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('psychological.consultation.collection.description')}
+                     appendTitle={i18n.t('psychological.consultation.collection.appendTitle')}
+                     appendLabel={i18n.t('psychological.consultation.collection.appendLabel')}>
+            <Order name="Consultation"
+                   prefix="consultation"
+                   ApplicantBirthDate={this.props.ApplicantBirthDate}
+                   bind={true} />
           </Accordion>
         </Show>
       </div>

--- a/src/components/Section/Psychological/Consultation/Consultation.test.jsx
+++ b/src/components/Section/Psychological/Consultation/Consultation.test.jsx
@@ -14,6 +14,6 @@ describe('The Consultation component', () => {
     const component = mount(<Consultation onUpdate={onUpdate} />)
     component.find('.consultation .yes input').simulate('change')
     component.find('input[name="CourtName"]').simulate('change')
-    expect(updates).toBe(3)
+    expect(updates).toBe(5)
   })
 })

--- a/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
@@ -180,7 +180,6 @@ export default class Diagnoses extends ValidationElement {
                          summary={this.treatmentSummary}
                          onValidate={this.handleValidation}
                          appendTitle={i18n.t('psychological.diagnoses.treatment.collection.appendTitle')}
-                         appendMessage={i18n.m('psychological.diagnoses.treatment.collection.appendMessage')}
                          appendLabel={i18n.t('psychological.diagnoses.treatment.collection.appendLabel')}>
                 <Treatment name="Treatment"
                            prefix="diagnoses.professional"

--- a/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
@@ -15,7 +15,9 @@ export default class Diagnoses extends ValidationElement {
       DidNotConsult: props.DidNotConsult,
       InTreatment: props.InTreatment,
       DiagnosisList: props.DiagnosisList,
+      DiagnosisListBranch: props.DiagnosisListBranch,
       TreatmentList: props.TreatmentList,
+      TreatmentListBranch: props.TreatmentListBranch,
       errorCodes: []
     }
 
@@ -36,18 +38,22 @@ export default class Diagnoses extends ValidationElement {
           DidNotConsult: this.state.DidNotConsult,
           InTreatment: this.state.InTreatment,
           DiagnosisList: this.state.DiagnosisList,
-          TreatmentList: this.state.TreatmentList
+          DiagnosisListBranch: this.state.DiagnosisListBranch,
+          TreatmentList: this.state.TreatmentList,
+          TreatmentListBranch: this.state.TreatmentListBranch
         })
       }
     })
   }
 
   updateDiagnosisList (values) {
-    this.update('DiagnosisList', values)
+    this.update('DiagnosisList', values.items)
+    this.update('DiagnosisListBranch', values.branch)
   }
 
   updateTreatmentList (values) {
-    this.update('TreatmentList', values)
+    this.update('TreatmentList', values.items)
+    this.update('TreatmentListBranch', values.branch)
   }
 
   updateDiagnosed (values) {
@@ -122,61 +128,63 @@ export default class Diagnoses extends ValidationElement {
         <Field title={i18n.t('psychological.diagnoses.heading.diagnoses')}>
           <p>{i18n.t('psychological.diagnoses.heading.examples')}</p>
           <Branch name="diagnosed"
-            className="diagnosed"
-            value={this.state.Diagnosed}
-            onValidate={this.handleValidation}
-            onUpdate={this.updateDiagnosed}>
+                  className="diagnosed"
+                  value={this.state.Diagnosed}
+                  onValidate={this.handleValidation}
+                  onUpdate={this.updateDiagnosed}>
           </Branch>
         </Field>
         <Show when={this.state.Diagnosed === 'Yes'}>
           <div>
             <Accordion minimum="1"
-              className="diagnosis-collection"
-              defaultState={this.props.defaultState}
-              items={this.state.DiagnosisList}
-              onUpdate={this.updateDiagnosisList}
-              summary={this.summary}
-              onValidate={this.handleValidation}
-              description={i18n.t('psychological.diagnoses.collection.description')}
-              appendTitle={i18n.t('psychological.diagnoses.collection.appendTitle')}
-              appendMessage={i18n.m('psychological.diagnoses.collection.appendMessage')}
-              appendLabel={i18n.t('psychological.diagnoses.collection.appendLabel')}>
+                       className="diagnosis-collection"
+                       defaultState={this.props.defaultState}
+                       items={this.state.DiagnosisList}
+                       branch={this.state.DiagnosisListBranch}
+                       onUpdate={this.updateDiagnosisList}
+                       summary={this.summary}
+                       onValidate={this.handleValidation}
+                       description={i18n.t('psychological.diagnoses.collection.description')}
+                       appendTitle={i18n.t('psychological.diagnoses.collection.appendTitle')}
+                       appendMessage={i18n.m('psychological.diagnoses.collection.appendMessage')}
+                       appendLabel={i18n.t('psychological.diagnoses.collection.appendLabel')}>
               <Diagnosis name="Diagnosis"
-                ApplicantBirthDate={this.props.ApplicantBirthDate}
-                bind={true} />
+                         ApplicantBirthDate={this.props.ApplicantBirthDate}
+                         bind={true} />
             </Accordion>
 
             <h3>{i18n.t('psychological.diagnoses.heading.didNotConsult')}</h3>
             <Branch name="didNotConsult"
-              className="didnotconsult"
-              value={this.state.DidNotConsult}
-              help="psychological.diagnoses.help.didNotConsult"
-              onValidate={this.handleValidation}
-              onUpdate={this.updateDidNotConsult}>
+                    className="didnotconsult"
+                    value={this.state.DidNotConsult}
+                    help="psychological.diagnoses.help.didNotConsult"
+                    onValidate={this.handleValidation}
+                    onUpdate={this.updateDidNotConsult}>
             </Branch>
 
             <h3>{i18n.t('psychological.diagnoses.heading.inTreatment')}</h3>
             <Branch name="inTreatment"
-              className="intreatment"
-              value={this.state.InTreatment}
-              help="psychological.diagnoses.help.inTreatment"
-              onValidate={this.handleValidation}
-              onUpdate={this.updateInTreatment}>
+                    className="intreatment"
+                    value={this.state.InTreatment}
+                    help="psychological.diagnoses.help.inTreatment"
+                    onValidate={this.handleValidation}
+                    onUpdate={this.updateInTreatment}>
             </Branch>
 
             <Show when={this.state.InTreatment === 'Yes'}>
               <Accordion minimum="1"
-                defaultState={this.props.defaultState}
-                items={this.state.TreatmentList}
-                onUpdate={this.updateTreatmentList}
-                summary={this.treatmentSummary}
-                onValidate={this.handleValidation}
-                appendTitle={i18n.t('psychological.diagnoses.treatment.collection.appendTitle')}
-                appendMessage={i18n.m('psychological.diagnoses.treatment.collection.appendMessage')}
-                appendLabel={i18n.t('psychological.diagnoses.treatment.collection.appendLabel')}>
+                         defaultState={this.props.defaultState}
+                         items={this.state.TreatmentList}
+                         branch={this.state.TreatmentListBranch}
+                         onUpdate={this.updateTreatmentList}
+                         summary={this.treatmentSummary}
+                         onValidate={this.handleValidation}
+                         appendTitle={i18n.t('psychological.diagnoses.treatment.collection.appendTitle')}
+                         appendMessage={i18n.m('psychological.diagnoses.treatment.collection.appendMessage')}
+                         appendLabel={i18n.t('psychological.diagnoses.treatment.collection.appendLabel')}>
                 <Treatment name="Treatment"
-                  prefix="diagnoses.professional"
-                  bind={true} />
+                           prefix="diagnoses.professional"
+                           bind={true} />
               </Accordion>
             </Show>
           </div>
@@ -190,6 +198,8 @@ export default class Diagnoses extends ValidationElement {
 Diagnoses.defaultProps = {
   List: [],
   DiagnosisList: [],
+  DiagnosisListBranch: '',
   TreatmentList: [],
+  TreatmentListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Psychological/Diagnoses/Diagnoses.test.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnoses.test.jsx
@@ -15,6 +15,6 @@ describe('The Diagnoses component', () => {
     component.find('.diagnosed .yes input').simulate('change')
     component.find('.didnotconsult .yes input').simulate('change')
     component.find('.intreatment .yes input').simulate('change')
-    expect(updates).toBe(5)
+    expect(updates).toBe(7)
   })
 })

--- a/src/components/Section/Psychological/ExistingConditions/ExistingConditions.jsx
+++ b/src/components/Section/Psychological/ExistingConditions/ExistingConditions.jsx
@@ -14,6 +14,7 @@ export default class ExistingConditions extends ValidationElement {
       ReceivedTreatment: props.ReceivedTreatment,
       Explanation: props.Explanation,
       TreatmentList: props.TreatmentList,
+      TreatmentListBranch: props.TreatmentListBranch,
       DidNotFollow: props.DidNotFollow,
       DidNotFollowExplanation: props.DidNotFollowExplanation,
       errorCodes: []
@@ -53,7 +54,8 @@ export default class ExistingConditions extends ValidationElement {
   }
 
   updateTreatmentList (values) {
-    this.update('TreatmentList', values)
+    this.update('TreatmentList', values.items)
+    this.update('TreatmentListBranch', values.branch)
   }
 
   updateDidNotFollow (values) {
@@ -126,74 +128,75 @@ export default class ExistingConditions extends ValidationElement {
             <Field adjustFor="button">
               <RadioGroup className="treatment-list option-list" selectedValue={this.state.ReceivedTreatment}>
                 <Radio name="treatment"
-                  className="treatment yes"
-                  label={i18n.t('psychological.existingConditions.receivedTreatment.label.yes')}
-                  value="Yes"
-                  onUpdate={this.updateReceivedTreatment}
-                  onValidate={this.handleValidation}
-                />
+                       className="treatment yes"
+                       label={i18n.t('psychological.existingConditions.receivedTreatment.label.yes')}
+                       value="Yes"
+                       onUpdate={this.updateReceivedTreatment}
+                       onValidate={this.handleValidation}
+                       />
                 <Radio name="treatment"
-                  className="treatment no"
-                  label={i18n.t('psychological.existingConditions.receivedTreatment.label.no')}
-                  value="No"
-                  onUpdate={this.updateReceivedTreatment}
-                  onValidate={this.handleValidation}
-                />
+                       className="treatment no"
+                       label={i18n.t('psychological.existingConditions.receivedTreatment.label.no')}
+                       value="No"
+                       onUpdate={this.updateReceivedTreatment}
+                       onValidate={this.handleValidation}
+                       />
                 <Radio name="treatment"
-                  className="treatment decline"
-                  label={i18n.t('psychological.existingConditions.receivedTreatment.label.decline')}
-                  value="Decline"
-                  onUpdate={this.updateReceivedTreatment}
-                  onValidate={this.handleValidation}
-                />
+                       className="treatment decline"
+                       label={i18n.t('psychological.existingConditions.receivedTreatment.label.decline')}
+                       value="Decline"
+                       onUpdate={this.updateReceivedTreatment}
+                       onValidate={this.handleValidation}
+                       />
               </RadioGroup>
             </Field>
 
             <Show when={this.state.ReceivedTreatment === 'No'}>
               <Field title={i18n.t(`psychological.existingConditions.heading.explanation`)}>
                 <Textarea name="Explanation"
-                  className="explanation"
-                  {...this.props.Explanation}
-                  onUpdate={this.updateExplanation}
-                  onValidate={this.handleValidation}
-                />
+                          className="explanation"
+                          {...this.props.Explanation}
+                          onUpdate={this.updateExplanation}
+                          onValidate={this.handleValidation}
+                          />
               </Field>
             </Show>
 
             <Show when={this.state.ReceivedTreatment === 'Yes'}>
               <Accordion minimum="1"
-                defaultState={this.props.defaultState}
-                items={this.state.TreatmentList}
-                onUpdate={this.updateTreatmentList}
-                summary={this.summary}
-                onValidate={this.handleValidation}
-                description={i18n.t('psychological.existingConditions.treatment.collection.description')}
-                appendTitle={i18n.t('psychological.existingConditions.treatment.collection.appendTitle')}
-                appendMessage={i18n.m('psychological.existingConditions.treatment.collection.appendMessage')}
-                appendLabel={i18n.t('psychological.existingConditions.treatment.collection.appendLabel')}>
+                         defaultState={this.props.defaultState}
+                         items={this.state.TreatmentList}
+                         branch={this.state.TreatmentListBranch}
+                         onUpdate={this.updateTreatmentList}
+                         summary={this.summary}
+                         onValidate={this.handleValidation}
+                         description={i18n.t('psychological.existingConditions.treatment.collection.description')}
+                         appendTitle={i18n.t('psychological.existingConditions.treatment.collection.appendTitle')}
+                         appendMessage={i18n.m('psychological.existingConditions.treatment.collection.appendMessage')}
+                         appendLabel={i18n.t('psychological.existingConditions.treatment.collection.appendLabel')}>
                 <Diagnosis name="Diagnosis"
-                  ApplicantBirthDate={this.props.ApplicantBirthDate}
-                  prefix="existingConditions.diagnosis"
-                  bind={true} />
+                           ApplicantBirthDate={this.props.ApplicantBirthDate}
+                           prefix="existingConditions.diagnosis"
+                           bind={true} />
               </Accordion>
             </Show>
 
             <h3>{i18n.t('psychological.existingConditions.heading.didNotFollow')}</h3>
             <Branch name="didNotFollow"
-              className="eapp-field-wrap didnotfollow"
-              value={this.state.DidNotFollow}
-              onValidate={this.handleValidation}
-              onUpdate={this.updateDidNotFollow}>
+                    className="eapp-field-wrap didnotfollow"
+                    value={this.state.DidNotFollow}
+                    onValidate={this.handleValidation}
+                    onUpdate={this.updateDidNotFollow}>
             </Branch>
 
             <Show when={this.state.DidNotFollow === 'Yes'}>
               <Field title={i18n.t(`psychological.existingConditions.heading.didNotFollowExplanation`)}>
                 <Textarea name="DidNotFollowExplanation"
-                  className="explanation"
-                  {...this.props.DidNotFollowExplanation}
-                  onUpdate={this.updateDidNotFollowExplanation}
-                  onValidate={this.handleValidation}
-                />
+                          className="explanation"
+                          {...this.props.DidNotFollowExplanation}
+                          onUpdate={this.updateDidNotFollowExplanation}
+                          onValidate={this.handleValidation}
+                          />
               </Field>
             </Show>
           </div>
@@ -205,5 +208,6 @@ export default class ExistingConditions extends ValidationElement {
 
 ExistingConditions.defaultProps = {
   TreatmentList: [],
+  TreatmentListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Psychological/ExistingConditions/ExistingConditions.jsx
+++ b/src/components/Section/Psychological/ExistingConditions/ExistingConditions.jsx
@@ -172,7 +172,6 @@ export default class ExistingConditions extends ValidationElement {
                          onValidate={this.handleValidation}
                          description={i18n.t('psychological.existingConditions.treatment.collection.description')}
                          appendTitle={i18n.t('psychological.existingConditions.treatment.collection.appendTitle')}
-                         appendMessage={i18n.m('psychological.existingConditions.treatment.collection.appendMessage')}
                          appendLabel={i18n.t('psychological.existingConditions.treatment.collection.appendLabel')}>
                 <Diagnosis name="Diagnosis"
                            ApplicantBirthDate={this.props.ApplicantBirthDate}

--- a/src/components/Section/Psychological/ExistingConditions/ExistingConditions.test.jsx
+++ b/src/components/Section/Psychological/ExistingConditions/ExistingConditions.test.jsx
@@ -21,7 +21,7 @@ describe('The ExistingConditions component', () => {
     component.find({type: 'radio', name: 'treatment', value: 'Yes'}).simulate('click')
     component.find('input#Condition').simulate('change')
 
-    expect(updates).toBe(8)
+    expect(updates).toBe(10)
   })
 
   it('Selects no to everything', () => {

--- a/src/components/Section/Psychological/Hospitalizations/Hospitalizations.jsx
+++ b/src/components/Section/Psychological/Hospitalizations/Hospitalizations.jsx
@@ -95,8 +95,8 @@ export default class Hospitalizations extends ValidationElement {
                      defaultState={this.props.defaultState}
                      items={this.state.List}
                      branch={this.state.ListBranch}
-                     onUpdate={this.updateList}
                      summary={this.summary}
+                     onUpdate={this.updateList}
                      onValidate={this.handleValidation}
                      description={i18n.t('psychological.hospitalization.collection.description')}
                      appendTitle={i18n.t('psychological.hospitalization.collection.appendTitle')}

--- a/src/components/Section/Psychological/Hospitalizations/Hospitalizations.jsx
+++ b/src/components/Section/Psychological/Hospitalizations/Hospitalizations.jsx
@@ -12,6 +12,7 @@ export default class Hospitalizations extends ValidationElement {
     this.state = {
       Hospitalized: props.Hospitalized,
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -33,7 +34,8 @@ export default class Hospitalizations extends ValidationElement {
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   updateHospitalized (values) {
@@ -83,26 +85,27 @@ export default class Hospitalizations extends ValidationElement {
       <div className="hospitalizations">
         <h2>{i18n.t('psychological.heading.hospitalization')}</h2>
         <Branch name="hospitalized"
-          value={this.state.Hospitalized}
-          onValidate={this.handleValidation}
-          onUpdate={this.updateHospitalized}>
+                value={this.state.Hospitalized}
+                onValidate={this.handleValidation}
+                onUpdate={this.updateHospitalized}>
         </Branch>
 
         <Show when={this.state.Hospitalized === 'Yes'}>
           <Accordion minimum="1"
-            defaultState={this.props.defaultState}
-            items={this.state.List}
-            onUpdate={this.updateList}
-            summary={this.summary}
-            onValidate={this.handleValidation}
-            description={i18n.t('psychological.hospitalization.collection.description')}
-            appendTitle={i18n.t('psychological.hospitalization.collection.appendTitle')}
-            appendMessage={i18n.m('psychological.hospitalization.collection.appendMessage')}
-            appendLabel={i18n.t('psychological.hospitalization.collection.appendLabel')}>
+                     defaultState={this.props.defaultState}
+                     items={this.state.List}
+                     branch={this.state.ListBranch}
+                     onUpdate={this.updateList}
+                     summary={this.summary}
+                     onValidate={this.handleValidation}
+                     description={i18n.t('psychological.hospitalization.collection.description')}
+                     appendTitle={i18n.t('psychological.hospitalization.collection.appendTitle')}
+                     appendMessage={i18n.m('psychological.hospitalization.collection.appendMessage')}
+                     appendLabel={i18n.t('psychological.hospitalization.collection.appendLabel')}>
             <Hospitalization name="Hospitalization"
-              ApplicantBirthDate={this.props.ApplicantBirthDate}
-              bind={true}
-            />
+                             ApplicantBirthDate={this.props.ApplicantBirthDate}
+                             bind={true}
+                             />
           </Accordion>
 
         </Show>
@@ -113,5 +116,6 @@ export default class Hospitalizations extends ValidationElement {
 
 Hospitalization.defaultProps = {
   List: [],
+  ListBranch: '',
   defaultState: true
 }

--- a/src/components/Section/Psychological/Hospitalizations/Hospitalizations.jsx
+++ b/src/components/Section/Psychological/Hospitalizations/Hospitalizations.jsx
@@ -100,7 +100,6 @@ export default class Hospitalizations extends ValidationElement {
                      onValidate={this.handleValidation}
                      description={i18n.t('psychological.hospitalization.collection.description')}
                      appendTitle={i18n.t('psychological.hospitalization.collection.appendTitle')}
-                     appendMessage={i18n.m('psychological.hospitalization.collection.appendMessage')}
                      appendLabel={i18n.t('psychological.hospitalization.collection.appendLabel')}>
             <Hospitalization name="Hospitalization"
                              ApplicantBirthDate={this.props.ApplicantBirthDate}

--- a/src/components/Section/Psychological/Hospitalizations/Hospitalizations.test.jsx
+++ b/src/components/Section/Psychological/Hospitalizations/Hospitalizations.test.jsx
@@ -17,7 +17,7 @@ describe('The Hospitalizations component', () => {
     component.find({type: 'radio', value: 'Voluntary'}).simulate('change')
     component.find('textarea#Explanation').simulate('change', { target: { value: 'Testing' } })
     component.find('input#Facility').simulate('change', { target: { value: 'Testing' } })
-    expect(updates).toBe(5)
+    expect(updates).toBe(9)
   })
 
   it('Loads data', () => {
@@ -25,7 +25,7 @@ describe('The Hospitalizations component', () => {
     const onUpdate = () => { updates++ }
     const component = mount(<Hospitalizations onUpdate={onUpdate} List={List} Hospitalized={'Yes'} />)
     component.find('input#Facility').simulate('change', { target: { value: 'Testing' } })
-    expect(updates).toBe(2)
+    expect(updates).toBe(4)
   })
 })
 

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -13,6 +13,7 @@ export default class People extends ValidationElement {
 
     this.state = {
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -25,14 +26,16 @@ export default class People extends ValidationElement {
     this.setState({[field]: values}, () => {
       if (this.props.onUpdate) {
         this.props.onUpdate({
-          List: this.state.List
+          List: this.state.List,
+          ListBranch: this.state.ListBranch
         })
       }
     })
   }
 
   updateList (values) {
-    this.update('List', values)
+    this.update('List', values.items)
+    this.update('ListBranch', values.branch)
   }
 
   isValid () {
@@ -59,8 +62,8 @@ export default class People extends ValidationElement {
     const o = (item || {}).Person || {}
     const date = dateRangeFormat(o.KnownDates)
     const name = o.Name
-      ? `${o.Name.first || ''} ${o.Name.middle || ''} ${o.Name.last || ''} ${date}`.trim()
-      : i18n.t('relationships.people.person.collection.summary.unknown')
+          ? `${o.Name.first || ''} ${o.Name.middle || ''} ${o.Name.last || ''} ${date}`.trim()
+          : i18n.t('relationships.people.person.collection.summary.unknown')
     const type = i18n.t('relationships.people.person.collection.itemType')
 
     return (
@@ -93,11 +96,11 @@ export default class People extends ValidationElement {
 
         <div className="summaryprogress progress">
           <SummaryProgress className="people-summary"
-            List={this.peopleSummaryList}
-            title={i18n.t('relationships.people.summaryProgress.title')}
-            unit={i18n.t('relationships.people.summaryProgress.unit')}
-            total={7}
-          >
+                           List={this.peopleSummaryList}
+                           title={i18n.t('relationships.people.summaryProgress.title')}
+                           unit={i18n.t('relationships.people.summaryProgress.unit')}
+                           total={7}
+                           >
             <div className="summary-icon">
               <Svg src="img/people-who-know-you.svg" />
             </div>
@@ -108,13 +111,14 @@ export default class People extends ValidationElement {
         </div>
 
         <Accordion minimum="1"
-          items={this.state.List}
-          onUpdate={this.updateList}
-          summary={this.summary}
-          onValidate={this.handleValidation}
-          appendTitle={i18n.t('relationships.people.person.collection.appendTitle')}
-          appendMessage={i18n.m('relationships.people.person.collection.appendMessage')}
-          appendLabel={i18n.t('relationships.people.person.collection.appendLabel')}>
+                   items={this.state.List}
+                   branch={this.state.ListBranch}
+                   onUpdate={this.updateList}
+                   summary={this.summary}
+                   onValidate={this.handleValidation}
+                   appendTitle={i18n.t('relationships.people.person.collection.appendTitle')}
+                   appendMessage={i18n.m('relationships.people.person.collection.appendMessage')}
+                   appendLabel={i18n.t('relationships.people.person.collection.appendLabel')}>
           <Person name="Person" bind={true} />
         </Accordion>
       </div>
@@ -123,5 +127,6 @@ export default class People extends ValidationElement {
 }
 
 People.defaultProps = {
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -117,7 +117,6 @@ export default class People extends ValidationElement {
                    summary={this.summary}
                    onValidate={this.handleValidation}
                    appendTitle={i18n.t('relationships.people.person.collection.appendTitle')}
-                   appendMessage={i18n.m('relationships.people.person.collection.appendMessage')}
                    appendLabel={i18n.t('relationships.people.person.collection.appendLabel')}>
           <Person name="Person" bind={true} />
         </Accordion>

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -113,8 +113,8 @@ export default class People extends ValidationElement {
         <Accordion minimum="1"
                    items={this.state.List}
                    branch={this.state.ListBranch}
-                   onUpdate={this.updateList}
                    summary={this.summary}
+                   onUpdate={this.updateList}
                    onValidate={this.handleValidation}
                    appendTitle={i18n.t('relationships.people.person.collection.appendTitle')}
                    appendLabel={i18n.t('relationships.people.person.collection.appendLabel')}>

--- a/src/components/Section/Relationships/People/People.test.jsx
+++ b/src/components/Section/Relationships/People/People.test.jsx
@@ -35,6 +35,6 @@ describe('The relative alias component', () => {
     component.find('.relationships input[name="relationship-other"]').simulate('change')
     component.find('.relationship-other input').simulate('change')
     component.find('.relationships input[name="relationship-other"]').simulate('change')
-    expect(updates).toBe(13)
+    expect(updates).toBe(13 * 2)
   })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -409,8 +409,8 @@ export default class CivilUnion extends ValidationElement {
                        items={this.state.DivorcedList}
                        branch={this.state.DivorcedListBranch}
                        onUpdate={this.updateDivorcedList}
-                       summary={this.divorceSummary}
                        onValidate={this.handleValidation}
+                       summary={this.divorceSummary}
                        description={i18n.t('relationships.civilUnion.divorce.collection.description')}
                        appendTitle={i18n.t('relationships.civilUnion.divorce.collection.appendTitle')}
                        appendLabel={i18n.t('relationships.civilUnion.divorce.collection.appendLabel')}>

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -28,6 +28,7 @@ export default class CivilUnion extends ValidationElement {
       AddressSeparatedNotApplicable: props.AddressSeparatedNotApplicable,
       Divorced: props.Divorced,
       DivorcedList: props.DivorcedList,
+      DivorcedListBranch: props.DivorcedListBranch,
       UseCurrentAddress: props.UseCurrentAddress,
       errorCodes: []
     }
@@ -78,6 +79,7 @@ export default class CivilUnion extends ValidationElement {
           AddressSeparatedNotApplicable: this.state.AddressSeparatedNotApplicable,
           Divorced: this.state.Divorced,
           DivorcedList: this.state.DivorcedList,
+          DivorcedListBranch: this.state.DivorcedListBranch,
           UseCurrentAddress: this.state.UseCurrentAddress
         })
       }
@@ -165,7 +167,8 @@ export default class CivilUnion extends ValidationElement {
   }
 
   updateDivorcedList (values) {
-    this.update('DivorcedList', values)
+    this.update('DivorcedList', values.items)
+    this.update('DivorcedListBranch', values.branch)
   }
 
   updateUseCurrentAddress (cb) {
@@ -203,8 +206,8 @@ export default class CivilUnion extends ValidationElement {
     const date = (o.DateDivorced || {}).date ? `${o.DateDivorced.month}/${o.DateDivorced.year}` : ''
     const status = o.Status || ''
     const name = o.Name
-      ? `${o.Name.first || ''} ${o.Name.middle || ''} ${o.Name.last || ''}`.trim()
-      : i18n.t('relationships.relatives.collection.summary.unknown')
+          ? `${o.Name.first || ''} ${o.Name.middle || ''} ${o.Name.last || ''}`.trim()
+          : i18n.t('relationships.relatives.collection.summary.unknown')
     return (
       <span>
         <span className="index">{itemType}</span>
@@ -404,6 +407,7 @@ export default class CivilUnion extends ValidationElement {
           <Show when={this.state.Divorced === 'Yes'}>
             <Accordion minimum="1"
                        items={this.state.DivorcedList}
+                       branch={this.state.DivorcedListBranch}
                        onUpdate={this.updateDivorcedList}
                        summary={this.divorceSummary}
                        onValidate={this.handleValidation}
@@ -423,5 +427,25 @@ export default class CivilUnion extends ValidationElement {
 }
 
 CivilUnion.defaultProps = {
-  List: []
+  Name: {},
+  Birthdate: {},
+  BirthPlace: {},
+  ForeignBornDocument: {},
+  SSN: {},
+  OtherName: {},
+  OtherNameMaiden: {},
+  OtherNameNotApplicable: {},
+  DatesUsed: {},
+  EnteredCivilUnion: {},
+  Address: {},
+  Telephone: {},
+  Email: {},
+  Separated: '',
+  DateSeparated: {},
+  AddressSeparated: {},
+  AddressSeparatedNotApplicable: {},
+  Divorced: '',
+  DivorcedList: [],
+  DivorcedListBranch: '',
+  UseCurrentAddress: false
 }

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -413,7 +413,6 @@ export default class CivilUnion extends ValidationElement {
                        onValidate={this.handleValidation}
                        description={i18n.t('relationships.civilUnion.divorce.collection.description')}
                        appendTitle={i18n.t('relationships.civilUnion.divorce.collection.appendTitle')}
-                       appendMessage={i18n.m('relationships.civilUnion.divorce.collection.appendMessage')}
                        appendLabel={i18n.t('relationships.civilUnion.divorce.collection.appendLabel')}>
               <Divorce name="Divorce"
                        bind={true}

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -45,7 +45,7 @@ describe('The cohabitant component', () => {
     component.find('.dateseparated input#month').simulate('change', { target: { value: '12' } })
     component.find('.address-separated input#address').simulate('change')
     component.find('.address-separated input[name="OtherNameNotApplicable"]').simulate('change')
-    expect(updates).toBe(25)
+    expect(updates).toBe(26)
   })
 
   it('renders current address', () => {

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitants.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitants.jsx
@@ -11,6 +11,7 @@ export default class Cohabitants extends ValidationElement {
     this.state = {
       HasCohabitant: props.HasCohabitant,
       CohabitantList: props.CohabitantList,
+      CohabitantListBranch: props.CohabitantListBranch,
       errorCodes: []
     }
 
@@ -24,7 +25,8 @@ export default class Cohabitants extends ValidationElement {
       if (this.props.onUpdate) {
         this.props.onUpdate({
           HasCohabitant: this.state.HasCohabitant,
-          CohabitantList: this.state.CohabitantList
+          CohabitantList: this.state.CohabitantList,
+          CohabitantListBranch: this.state.CohabitantListBranch
         })
       }
     })
@@ -39,7 +41,8 @@ export default class Cohabitants extends ValidationElement {
   }
 
   updateCohabitantList (values) {
-    this.update('CohabitantList', values)
+    this.update('CohabitantList', values.items)
+    this.update('CohabitantListBranch', values.branch)
   }
 
   summary (item, index) {
@@ -89,6 +92,7 @@ export default class Cohabitants extends ValidationElement {
         <Show when={this.state.HasCohabitant === 'Yes'}>
           <Accordion minimum="1"
             items={this.state.CohabitantList}
+            branch={this.state.CohabitantListBranch}
             onUpdate={this.updateCohabitantList}
             summary={this.summary}
             onValidate={this.handleValidation}
@@ -105,6 +109,7 @@ export default class Cohabitants extends ValidationElement {
 }
 
 Cohabitants.defaultProps = {
-  List: []
+  HasCohabitant: '',
+  CohabitantList: [],
+  CohabitantListBranch: ''
 }
-

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitants.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitants.jsx
@@ -93,8 +93,8 @@ export default class Cohabitants extends ValidationElement {
           <Accordion minimum="1"
             items={this.state.CohabitantList}
             branch={this.state.CohabitantListBranch}
-            onUpdate={this.updateCohabitantList}
             summary={this.summary}
+            onUpdate={this.updateCohabitantList}
             onValidate={this.handleValidation}
             description={i18n.t('relationships.cohabitant.collection.description')}
             appendTitle={i18n.t('relationships.cohabitant.collection.appendTitle')}

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitants.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitants.jsx
@@ -98,7 +98,6 @@ export default class Cohabitants extends ValidationElement {
             onValidate={this.handleValidation}
             description={i18n.t('relationships.cohabitant.collection.description')}
             appendTitle={i18n.t('relationships.cohabitant.collection.appendTitle')}
-            appendMessage={i18n.m('relationships.cohabitant.collection.appendMessage')}
             appendLabel={i18n.t('relationships.cohabitant.collection.appendLabel')}>
             <Cohabitant name="Cohabitant" spouse={this.props.spouse} bind={true} />
           </Accordion>

--- a/src/components/Section/Relationships/RelationshipStatus/Cohabitants.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Cohabitants.test.jsx
@@ -23,6 +23,6 @@ describe('The cohabitants component', () => {
     expect(component.find('.cohabitants').length).toEqual(1)
     component.find('.has-cohabitant .yes input').simulate('change')
     component.find('.has-cohabitant .no input').simulate('change')
-    expect(updates).toBe(3)
+    expect(updates).toBe(4)
   })
 })

--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -107,13 +107,14 @@ export default class Relatives extends ValidationElement {
         {i18n.m('relationships.relatives.para.opportunity')}
 
         <Accordion minimum="1"
-                    items={this.state.List}
-                    branch={this.state.ListBranch}
-                    onUpdate={this.updateList}
-                    summary={this.summary}
-                    description={i18n.t('relationships.relatives.collection.summary.title')}
-                    appendTitle={i18n.t('relationships.relatives.collection.appendTitle')}
-                    appendLabel={i18n.t('relationships.relatives.collection.append')}>
+                   items={this.state.List}
+                   branch={this.state.ListBranch}
+                   onUpdate={this.updateList}
+                   onValidate={this.handleValidation}
+                   summary={this.summary}
+                   description={i18n.t('relationships.relatives.collection.summary.title')}
+                   appendTitle={i18n.t('relationships.relatives.collection.appendTitle')}
+                   appendLabel={i18n.t('relationships.relatives.collection.append')}>
           <Relative name="Item"
                     bind={true}
                     />

--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -21,6 +21,7 @@ export default class Relatives extends ValidationElement {
     super(props)
     this.state = {
       List: props.List,
+      ListBranch: props.ListBranch,
       errorCodes: []
     }
 
@@ -39,7 +40,8 @@ export default class Relatives extends ValidationElement {
   }
 
   updateList (values) {
-    this.onUpdate('List', values)
+    this.onUpdate('List', values.items)
+    this.onUpdate('ListBranch', values.branch)
   }
 
   /**
@@ -106,6 +108,7 @@ export default class Relatives extends ValidationElement {
 
         <Accordion minimum="1"
                     items={this.state.List}
+                    branch={this.state.ListBranch}
                     onUpdate={this.updateList}
                     summary={this.summary}
                     description={i18n.t('relationships.relatives.collection.summary.title')}
@@ -122,5 +125,6 @@ export default class Relatives extends ValidationElement {
 }
 
 Relatives.defaultProps = {
-  List: []
+  List: [],
+  ListBranch: ''
 }

--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -113,7 +113,6 @@ export default class Relatives extends ValidationElement {
                     summary={this.summary}
                     description={i18n.t('relationships.relatives.collection.summary.title')}
                     appendTitle={i18n.t('relationships.relatives.collection.appendTitle')}
-                    appendMessage={i18n.m('relationships.relatives.collection.appendMessage')}
                     appendLabel={i18n.t('relationships.relatives.collection.append')}>
           <Relative name="Item"
                     bind={true}

--- a/src/components/Summary/AddressSummary.js
+++ b/src/components/Summary/AddressSummary.js
@@ -16,14 +16,11 @@ export const AddressSummary = (props, unknown) => {
     address2 = `${(props.city || '').toLowerCase()}, ${(props.country || '').toLowerCase()}`.trim()
   }
 
-  let address = ''
   if (address1.length === 0 || address2.length === 1) {
-    address = unknown
-  } else {
-    address = `${address1.toLowerCase()}, ${address2}`.trim()
+    return unknown
   }
 
   return (
-    <span className="title-case">{address}</span>
+    <span className="title-case">{`${address1.toLowerCase()}, ${address2}`.trim()}</span>
   )
 }

--- a/src/components/Summary/AddressSummary.js
+++ b/src/components/Summary/AddressSummary.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export const AddressSummary = (props, unknown) => {
   if (!props) {
     return unknown
@@ -21,5 +23,7 @@ export const AddressSummary = (props, unknown) => {
     address = `${address1.toLowerCase()}, ${address2}`.trim()
   }
 
-  return address
+  return (
+    <span className="title-case">{address}</span>
+  )
 }

--- a/src/components/Summary/AddressSummary.test.js
+++ b/src/components/Summary/AddressSummary.test.js
@@ -15,7 +15,7 @@ describe('The address summary', () => {
   })
 
   it('display United States address', () => {
-    const expected = '123 some rd, springfield, IL 12345'
+    const expected = <span className="title-case">123 some rd, springfield, IL 12345</span>
     const item = {
       addressType: 'United States',
       address: '123 Some Rd',
@@ -24,11 +24,11 @@ describe('The address summary', () => {
       zipcode: '12345'
     }
     const summary = AddressSummary(item, 'Unknown')
-    expect(summary).toBe(expected)
+    expect(summary).toEqual(expected)
   })
 
   it('display APO/FPO address', () => {
-    const expected = '123 some rd, FPO, AA 12345'
+    const expected = <span className="title-case">123 some rd, FPO, AA 12345</span>
     const item = {
       addressType: 'APOFPO',
       address: '123 Some Rd',
@@ -37,11 +37,11 @@ describe('The address summary', () => {
       zipcode: '12345'
     }
     const summary = AddressSummary(item, 'Unknown')
-    expect(summary).toBe(expected)
+    expect(summary).toEqual(expected)
   })
 
   it('display international address', () => {
-    const expected = '123 some rd, frankfurt, germany'
+    const expected = <span className="title-case">123 some rd, frankfurt, germany</span>
     const item = {
       addressType: 'International',
       address: '123 Some Rd',
@@ -49,6 +49,6 @@ describe('The address summary', () => {
       country: 'Germany'
     }
     const summary = AddressSummary(item, 'Unknown')
-    expect(summary).toBe(expected)
+    expect(summary).toEqual(expected)
   })
 })

--- a/src/components/Summary/NameSummary.js
+++ b/src/components/Summary/NameSummary.js
@@ -1,8 +1,12 @@
+import React from 'react'
+
 export const NameSummary = (props, unknown) => {
   if (!props) {
     return unknown
   }
 
   const name = `${props.first || ''} ${props.middle || ''} ${props.last || ''}`.trim()
-  return name.length > 0 ? name : unknown
+  return name.length > 0
+    ? <span className="title-case">{name}</span>
+    : unknown
 }

--- a/src/components/Summary/NameSummary.test.js
+++ b/src/components/Summary/NameSummary.test.js
@@ -11,24 +11,24 @@ describe('The name summary', () => {
   it('display only first name', () => {
     const item = { first: 'Bob', middle: '', last: '' }
     const summary = NameSummary(item, 'Unknown')
-    expect(summary).toBe('Bob')
+    expect(summary).toEqual(<span className="title-case">Bob</span>)
   })
 
   it('display only middle name', () => {
     const item = { first: '', middle: 'Joe', last: '' }
     const summary = NameSummary(item, 'Unknown')
-    expect(summary).toBe('Joe')
+    expect(summary).toEqual(<span className="title-case">Joe</span>)
   })
 
   it('display only last name', () => {
     const item = { first: '', middle: '', last: 'Smith' }
     const summary = NameSummary(item, 'Unknown')
-    expect(summary).toBe('Smith')
+    expect(summary).toEqual(<span className="title-case">Smith</span>)
   })
 
   it('display full name', () => {
     const item = { first: 'Bob', middle: 'Joe', last: 'Smith' }
     const summary = NameSummary(item, 'Unknown')
-    expect(summary).toBe('Bob Joe Smith')
+    expect(summary).toEqual(<span className="title-case">Bob Joe Smith</span>)
   })
 })

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -4870,8 +4870,8 @@ const en = {
           summary: 'Provide your direct financial interests here',
           description: 'Summary of financial interests',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendMessage: 'If yes use the button below to add another interest.',
-          appendLabel: 'Add another interest',
+          appendMessage: 'If yes use the button below to add another direct interest.',
+          appendLabel: 'Add another direct interest',
           itemType: 'Interest'
         },
         interest: {
@@ -4982,8 +4982,8 @@ const en = {
           summary: 'Provide your indirect financial interests here',
           description: 'Summary of financial interests',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendMessage: 'If yes use the button below to add another interest.',
-          appendLabel: 'Add another interest',
+          appendMessage: 'If yes use the button below to add another indirect interest.',
+          appendLabel: 'Add another indirect interest',
           itemType: 'Interest'
         },
         interest: {
@@ -5108,8 +5108,8 @@ const en = {
           summary: 'Provide your real estate financial interests here',
           description: 'Summary of financial interests',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendMessage: 'If yes use the button below to add another interest.',
-          appendLabel: 'Add another interest',
+          appendMessage: 'If yes use the button below to add another real estate interest.',
+          appendLabel: 'Add another real estate interest',
           itemType: 'Interest'
         },
         interest: {
@@ -5255,7 +5255,7 @@ const en = {
           },
           appendTitle: 'Have you additionally provided financial support for any foreign national?',
           appendMessage: [
-            'If yes use the button below to add another instance'
+            'If yes use the button below to add another instance.'
           ],
           append: 'Add another instance'
         }
@@ -5695,7 +5695,7 @@ const en = {
           appendTitle: 'Have you in the last seven (7) years provided advice or support to any other individual associated with a foreign business or other foreign organization that you have not previously listed as a former employer?',
           appendMessage: [
             'Answer **"No"** if all your advice or support was authorized pursuant to official U.S. Government business.',
-            'If yes use the button below to add another instance of advice/support'
+            'If yes use the button below to add another instance of advice/support.'
           ],
           append: 'Add another instance of advice/support'
         }
@@ -5751,9 +5751,9 @@ const en = {
           appendTitle: 'Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or any member of your immediate family in the last seven (7) years been asked to provide advice or serve as a consultant, even informally, by any other foreign government official or agency?',
           appendMessage: [
             'Answer **"No"** if all the advice or support was authorized pursuant to official U.S. Government business.',
-            'If yes use the button below to add another interest'
+            'If yes use the button below to add another instance of advice/support.'
           ],
-          append: 'Add another interest'
+          append: 'Add another instance of advice/support'
         }
       },
       employment: {
@@ -5806,7 +5806,7 @@ const en = {
           },
           appendTitle: 'Has any additional foreign national, in the last seven (7) years, offered you a job, asked you to work a consultant, or consider employment with them?',
           appendMessage: [
-            'If yes use the button below to add another job offer'
+            'If yes use the button below to add another job offer.'
           ],
           append: 'Add another job offer'
         }
@@ -5897,9 +5897,9 @@ const en = {
           appendTitle: 'Have you, in the last seven (7) years, been involved in any other type of business venture with a foreign national not described above?',
           appendMessage: [
             'Own, co-own, serve as a business consultant, provide financial support, etc.',
-            'If yes use the button below to add another interest'
+            'If yes use the button below to add another business venture.'
           ],
-          append: 'Add another interest'
+          append: 'Add another business venture'
         }
       },
       conferences: {

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2340,7 +2340,7 @@ const en = {
           }
         },
         collection: {
-          description: '',
+          description: 'Summary of divorcees',
           appendTitle: 'Do you have any additional person(s) from whom you are divorced/dissolved, annulled, or widowed to report?',
           appendLabel: 'Add another person',
           itemType: 'Person'
@@ -2495,7 +2495,7 @@ const en = {
         birthplace: 'Was this person born in the United States of America'
       },
       collection: {
-        description: '',
+        description: 'Summary of cohabitants',
         appendTitle: 'Do you have an additional cohabitant to report?',
         appendLabel: 'Add another cohabitant',
         itemType: 'Cohabitant'

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -996,8 +996,7 @@ const en = {
           debt: 'Debt'
         },
         append: 'Add another financial problem',
-        appendTitle: 'Have you EVER experienced additional financial problems due to gambling?',
-        appendMessage: 'If yes use the button below to add another financial problem'
+        appendTitle: 'Have you EVER experienced additional financial problems due to gambling?'
       },
       heading: {
         dates: 'Provide the date range of your financial problems due to gambling',
@@ -1052,8 +1051,7 @@ const en = {
           unknown: 'Provide your bankruptcy below',
           nodates: 'NA',
           chapter: 'Chapter',
-          appendTitle: 'In the last seven (7) years, have you filed any additional petitions under any chapter of the bankruptcy code?',
-          appendMessage: 'If yes use the button below to add another bankruptcy petition'
+          appendTitle: 'In the last seven (7) years, have you filed any additional petitions under any chapter of the bankruptcy code?'
         },
         append: 'Add another petition'
       },
@@ -1249,7 +1247,6 @@ const en = {
           item: 'Agency'
         },
         appendTitle: 'Are there any other instances in the last seven (7) years where you failed to file or pay Federal, state, or other taxes when required by law or ordinance?',
-        appendMessage: 'If yes use the button below to add another tax filing/payment issue',
         append: 'Add another tax filing/payment issue'
       }
     },
@@ -1313,7 +1310,6 @@ const en = {
           item: 'Employer'
         },
         appendTitle: 'Are there any other instances in the last seven (7) years where you have been counseled, warned, or disciplined for violating the term of agreement for a travel or credit card provided by your employer?',
-        appendMessage: 'If yes use the button below to add another card abuse/counseling issue',
         append: 'Add another card abuse/counseling issue'
       }
     },
@@ -1365,7 +1361,6 @@ const en = {
           item: 'Service'
         },
         appendTitle: 'Are you currently utilizing, or seeking assistance from any other credit counseling service or similar resource to resolve your financial difficulties?',
-        appendMessage: 'If yes use the button below to add another credit counseling entry',
         append: 'Add another credit counseling entry'
       }
     },
@@ -1475,7 +1470,6 @@ const en = {
           item: 'Service'
         },
         appendTitle: 'Other than previously listed, are there any other instances of the following occurrences?',
-        appendMessage: 'If yes use the button below to add another payment issue',
         append: 'Add another payment issue'
       }
     },
@@ -1576,7 +1570,6 @@ const en = {
           item: 'Service'
         },
         appendTitle: 'Other than previously listed, are there any other instances of the following occurrences?',
-        appendMessage: 'If yes use the button below to add another non-payment or excessive late payment',
         append: 'Add another non-payment or excessive late payment'
       }
     }
@@ -1841,7 +1834,6 @@ const en = {
             unknown: 'Provide citizenship details below'
           },
           appendTitle: 'Do you have an additional citizenship to provide?',
-          appendMessage: 'If yes use the button below to add another',
           append: 'Add another citizenship'
         },
         passport: {
@@ -1851,7 +1843,6 @@ const en = {
             unknown: 'Provide passport details below'
           },
           appendTitle: 'Do you have an additional foreign passport (or identity card) to report?',
-          appendMessage: 'If yes use the button below to add another foreign passport',
           append: 'Add another foreign passport'
         },
         travel: {
@@ -1986,7 +1977,6 @@ const en = {
           item: 'Relative'
         },
         appendTitle: 'Do you have an additional relative to enter?',
-        appendMessage: 'If **Yes** use the button below to add another',
         append: 'Add another relative'
       },
       heading: {
@@ -2352,7 +2342,6 @@ const en = {
         collection: {
           description: '',
           appendTitle: 'Do you have any additional person(s) from whom you are divorced/dissolved, annulled, or widowed to report?',
-          appendMessage: 'If yes please use the button below to add another person',
           appendLabel: 'Add another person',
           itemType: 'Person'
         },
@@ -2508,7 +2497,6 @@ const en = {
       collection: {
         description: '',
         appendTitle: 'Do you have an additional cohabitant to report?',
-        appendMessage: 'If yes please use the button below to add another cohabitant.',
         appendLabel: 'Add another cohabitant',
         itemType: 'Cohabitant'
       },
@@ -2661,7 +2649,6 @@ const en = {
             unknown: 'Provide the person\'s information below'
           },
           appendLabel: 'Add another person',
-          appendMessage: 'If yes use the button below to add another instance',
           appendTitle: 'Do you have an additional person who knows you well to list?',
           itemType: 'Person'
         }
@@ -2944,7 +2931,6 @@ const en = {
           unknown: 'Provide your military history below'
         },
         appendTitle: 'Do you have additional military service to report?',
-        appendMessage: 'If yes use the button below to add more',
         append: 'Add additional military history'
       }
     },
@@ -3111,7 +3097,6 @@ const en = {
             unknown: 'Provide foreign military contact below'
           },
           appendTitle: 'Do you have an additional foreign military service contact to report?',
-          appendMessage: 'If yes use the button below to add another contact',
           append: 'Add another contact'
         }
       }
@@ -4870,7 +4855,6 @@ const en = {
           summary: 'Provide your direct financial interests here',
           description: 'Summary of financial interests',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendMessage: 'If yes use the button below to add another direct interest.',
           appendLabel: 'Add another direct interest',
           itemType: 'Interest'
         },
@@ -4982,7 +4966,6 @@ const en = {
           summary: 'Provide your indirect financial interests here',
           description: 'Summary of financial interests',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendMessage: 'If yes use the button below to add another indirect interest.',
           appendLabel: 'Add another indirect interest',
           itemType: 'Interest'
         },
@@ -5108,7 +5091,6 @@ const en = {
           summary: 'Provide your real estate financial interests here',
           description: 'Summary of financial interests',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendMessage: 'If yes use the button below to add another real estate interest.',
           appendLabel: 'Add another real estate interest',
           itemType: 'Interest'
         },
@@ -5254,9 +5236,6 @@ const en = {
             unknown: 'Provide details of foreign financial support below'
           },
           appendTitle: 'Have you additionally provided financial support for any foreign national?',
-          appendMessage: [
-            'If yes use the button below to add another instance.'
-          ],
           append: 'Add another instance'
         }
       },
@@ -5299,7 +5278,6 @@ const en = {
           summary: 'Provide your financial benefits here',
           description: 'Summary of financial benefits',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children receive any additional benefits from a foreign country?',
-          appendMessage: 'If yes use the button below to add another benefit.',
           appendLabel: 'Add another benefit',
           itemType: 'Benefit'
         },
@@ -5633,8 +5611,7 @@ const en = {
         },
         appendTitle: 'Do you have, or have you had, close and/or continuing contact with any additional foreign national within the last seven (7) years with whom you, or your spouse, or cohabitant are bound by affection, influence, common interests, and/or obligation?',
         appendMessage: [
-          'Include associates as well as relatives, not previously listed in the relatives section.',
-          'If yes use the button below to add another association.'
+          'Include associates as well as relatives, not previously listed in the relatives section.'
         ],
         append: 'Add another association'
       }
@@ -5694,8 +5671,7 @@ const en = {
           },
           appendTitle: 'Have you in the last seven (7) years provided advice or support to any other individual associated with a foreign business or other foreign organization that you have not previously listed as a former employer?',
           appendMessage: [
-            'Answer **"No"** if all your advice or support was authorized pursuant to official U.S. Government business.',
-            'If yes use the button below to add another instance of advice/support.'
+            'Answer **"No"** if all your advice or support was authorized pursuant to official U.S. Government business.'
           ],
           append: 'Add another instance of advice/support'
         }
@@ -5750,8 +5726,7 @@ const en = {
           },
           appendTitle: 'Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or any member of your immediate family in the last seven (7) years been asked to provide advice or serve as a consultant, even informally, by any other foreign government official or agency?',
           appendMessage: [
-            'Answer **"No"** if all the advice or support was authorized pursuant to official U.S. Government business.',
-            'If yes use the button below to add another instance of advice/support.'
+            'Answer **"No"** if all the advice or support was authorized pursuant to official U.S. Government business.'
           ],
           append: 'Add another instance of advice/support'
         }
@@ -5805,9 +5780,6 @@ const en = {
             unknown: 'Provide details of foreign business job below'
           },
           appendTitle: 'Has any additional foreign national, in the last seven (7) years, offered you a job, asked you to work a consultant, or consider employment with them?',
-          appendMessage: [
-            'If yes use the button below to add another job offer.'
-          ],
           append: 'Add another job offer'
         }
       },
@@ -5896,8 +5868,7 @@ const en = {
           },
           appendTitle: 'Have you, in the last seven (7) years, been involved in any other type of business venture with a foreign national not described above?',
           appendMessage: [
-            'Own, co-own, serve as a business consultant, provide financial support, etc.',
-            'If yes use the button below to add another business venture.'
+            'Own, co-own, serve as a business consultant, provide financial support, etc.'
           ],
           append: 'Add another business venture'
         }
@@ -5975,8 +5946,7 @@ const en = {
           },
           appendTitle: 'Have you in the last seven (7) years, attended or participated in any additional conferences, trade shows, seminars, or meetings oustide the U.S.?',
           appendMessage: [
-            'Do not include those you attended or participated in on official business for the U.S. government.',
-            'If yes use the button below to add another event.'
+            'Do not include those you attended or participated in on official business for the U.S. government.'
           ],
           append: 'Add another event'
         }
@@ -6220,7 +6190,13 @@ const en = {
           unknown: 'Provide offense below'
         },
         appendTitle: 'Do you have any other offenses where any of the following has happened to you?',
-        appendMessage: '- **In the last seven (7) years** have you been issued a summons, citation, or ticket to appear in court in a criminal proceeding against you? (Do not check if all the citations involved traffic infractions where the fine was than $300 and did not include alcohol or drugs.)\n- **In the last seven (7) years** have you been arrested by any police officer, sheriff, marshal or any other type of law enforcement official?\n- **In the last seven (7) years** have you been charged with, convicted of, or sentenced for a crime in any court? (Include all qualifying charges, convictions or sentences in any federal, state, local, military, or non-U.S. court, even if previously listed on this form.)\n- **In the last seven (7) years** have you been or are you currently on probation or parole?\nAre you currently on trial or awaiting a trial on criminal charges?\n<p>If yes use the button below to add add another offense.</p>',
+        appendMessage: [
+          '- **In the last seven (7) years** have you been issued a summons, citation, or ticket to appear in court in a criminal proceeding against you? (Do not check if all the citations involved traffic infractions where the fine was than $300 and did not include alcohol or drugs.)',
+          '- **In the last seven (7) years** have you been arrested by any police officer, sheriff, marshal or any other type of law enforcement official?',
+          '- **In the last seven (7) years** have you been charged with, convicted of, or sentenced for a crime in any court? (Include all qualifying charges, convictions or sentences in any federal, state, local, military, or non-U.S. court, even if previously listed on this form.)',
+          '- **In the last seven (7) years** have you been or are you currently on probation or parole?',
+          'Are you currently on trial or awaiting a trial on criminal charges?'
+        ],
         append: 'Add another offense'
       }
     }
@@ -6419,7 +6395,6 @@ const en = {
         summaryCourtName: 'Provide your order details below',
         description: 'Summary of orders',
         appendTitle: 'Do you have an additional instance where a court or administrative agency EVER issued an order declaring you mentally incompetent?',
-        appendMessage: 'If yes, use the button below to add another instance',
         appendLabel: 'Add another order',
         itemType: 'Order'
       }
@@ -6475,7 +6450,6 @@ const en = {
         summaryCourtName: 'Provide your order details below',
         description: 'Summary of orders',
         appendTitle: 'Do you have an additional instance where a court or administrative agency EVER issued an order declaring you mentally incompetent?',
-        appendMessage: 'If yes, use the button below to add another instance',
         appendLabel: 'Add another order',
         itemType: 'Order'
       }
@@ -6497,7 +6471,6 @@ const en = {
         description: 'Summary of hospitalizations',
         summary: 'Provide your hospitalization details below',
         appendTitle: 'Do you have an additional instance where you have EVER been hospitalized for a mental health condition?',
-        appendMessage: 'If yes, use the button below to add another hospitalization',
         appendLabel: 'Add another hospitalization',
         itemType: 'Hospitalization'
       },
@@ -6617,7 +6590,7 @@ const en = {
         description: 'Summary of diagnoses',
         summary: 'Provide your diagnosis details below',
         appendTitle: 'Do you have an additional instance where you EVER had been diagnosed by a physician or other health professional (for example, a psychiatrist, psychologist, licensed clinical social worker, or nurse practitioner) with psychotic disorder, schizophrenia, schizoaffective disorder, delusional disorder, bipolar mood disorder, borderline personality disorder, or antisocial personality disorder?',
-        appendMessage: 'Health professional examples: a psychiatrist, psychologist, licensed clinical social worker, or nurse practitioner.\n\nIf yes, use the button below to add another hospitalization',
+        appendMessage: 'Health professional examples: a psychiatrist, psychologist, licensed clinical social worker, or nurse practitioner.',
         appendLabel: 'Add another diagnosis',
         itemType: 'Diagnosis'
       },
@@ -6649,7 +6622,6 @@ const en = {
           description: 'Summary of treatments',
           summary: 'Provide your treatment details below',
           appendTitle: 'Do you have an additional instance where you are currently in treatment?',
-          appendMessage: 'If yes, use the button below to add another treatment',
           appendLabel: 'Add another treatment',
           itemType: 'Treatment'
         }
@@ -6731,7 +6703,6 @@ const en = {
           description: 'Summary of treatments',
           summary: 'Provide your treatment details below',
           appendTitle: 'Do you have an additional instance where you ever received are you currently receiving counseling or treatment for that condition',
-          appendMessage: 'If yes, use the button below to add another instance',
           appendLabel: 'Add another treatment',
           itemType: 'Treatment'
         }

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -5088,11 +5088,11 @@ const en = {
           title: 'Have you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children EVER owned, or do you anticipate owning, or plan to purchase real estate in a foreign country?'
         },
         collection: {
-          summary: 'Provide your real estate financial interests here',
-          description: 'Summary of financial interests',
+          summary: 'Provide your real estate purchase here',
+          description: 'Summary of financial purchase',
           appendTitle: 'Do you, your spouse or legally recognized civil union/domestic partner, cohabitant, or dependent children have any additional foreign financial interests?',
-          appendLabel: 'Add another real estate interest',
-          itemType: 'Interest'
+          appendLabel: 'Add another real estate purchase',
+          itemType: 'Purchase'
         },
         interest: {
           para: {

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -208,6 +208,10 @@ a:focus {
   text-align: left;
 }
 
+.title-case {
+  text-transform: capitalize;
+}
+
 .no-gutter {
   margin-left: initial;
   margin-right: initial;

--- a/src/validators/bankruptcy.js
+++ b/src/validators/bankruptcy.js
@@ -9,6 +9,7 @@ export default class BankruptcyValidator {
   constructor (state, props) {
     this.hasBankruptcy = state.HasBankruptcy
     this.list = state.List
+    this.listBranch = state.ListBranch
   }
 
   /**
@@ -32,6 +33,10 @@ export default class BankruptcyValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/bankruptcy.test.js
+++ b/src/validators/bankruptcy.test.js
@@ -39,14 +39,16 @@ describe('Bankruptcy component validation', function () {
       {
         state: {
           HasBankruptcy: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasBankruptcy: 'No',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -97,7 +99,8 @@ describe('Bankruptcy component validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -147,7 +150,8 @@ describe('Bankruptcy component validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -160,7 +164,8 @@ describe('Bankruptcy component validation', function () {
                 PetitionType: 'Hello'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       }

--- a/src/validators/cardabuse.js
+++ b/src/validators/cardabuse.js
@@ -6,6 +6,7 @@ export default class CardAbuseValidator {
   constructor (state = {}, props = {}) {
     this.hasCardAbuse = state.HasCardAbuse
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validHasCardAbuse () {
@@ -26,6 +27,10 @@ export default class CardAbuseValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/cardabuse.test.js
+++ b/src/validators/cardabuse.test.js
@@ -209,21 +209,24 @@ describe('taxes component validation', function () {
       {
         state: {
           HasCardAbuse: 'No',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: true
       },
       {
         state: {
           HasCardAbuse: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
       {
         state: {
           HasCardAbuse: 'Yes',
-          List: [{}]
+          List: [{}],
+          ListBranch: ''
         },
         expected: false
       },
@@ -259,7 +262,8 @@ describe('taxes component validation', function () {
                 value: 'The description'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/citizenship-multiple.js
+++ b/src/validators/citizenship-multiple.js
@@ -7,6 +7,7 @@ export default class CitizenshipMultipleValidator {
   constructor (state = {}, props = {}) {
     this.hasMultiple = state.HasMultiple
     this.citizenships = state.Citizenships || []
+    this.citizenshipsBranch = state.CitizenshipsBranch
     this.passports = state.Passports || []
   }
 
@@ -20,6 +21,10 @@ export default class CitizenshipMultipleValidator {
     }
 
     if (this.citizenships.length === 0) {
+      return false
+    }
+
+    if (this.citizenshipsBranch !== 'No') {
       return false
     }
 

--- a/src/validators/citizenship-multiple.test.js
+++ b/src/validators/citizenship-multiple.test.js
@@ -431,7 +431,8 @@ describe('citizenship multiple component validation', function () {
               Item: {
               }
             }
-          ]
+          ],
+          CitizenshipsBranch: 'No'
         },
         expected: false
       },
@@ -464,7 +465,8 @@ describe('citizenship multiple component validation', function () {
                 }
               }
             }
-          ]
+          ],
+          CitizenshipsBranch: 'No'
         },
         expected: true
       }
@@ -656,6 +658,7 @@ describe('citizenship multiple component validation', function () {
               }
             }
           ],
+          CitizenshipsBranch: 'No',
           Passports: [
             {
               Has: 'Yes',

--- a/src/validators/civilunion.js
+++ b/src/validators/civilunion.js
@@ -25,6 +25,7 @@ export default class CivilUnionValidator {
     this.addressSeparatedNotApplicable = state.AddressSeparatedNotApplicable
     this.divorced = state.Divorced
     this.divorcedList = state.DivorcedList
+    this.divorcedListBranch = state.DivorcedListBranch
   }
 
   validOtherName () {
@@ -56,17 +57,25 @@ export default class CivilUnionValidator {
     if (!validBranch(this.divorced)) {
       return false
     }
+
     if (this.divorced === 'No') {
       return true
     }
+
     if (!this.divorcedList || !this.divorcedList.length) {
       return false
     }
+
+    if (this.divorcedListBranch !== 'No') {
+      return false
+    }
+
     for (let item of this.divorcedList) {
       if (!new DivorceValidator(item.Divorce).isValid()) {
         return false
       }
     }
+
     return true
   }
 

--- a/src/validators/civilunion.test.js
+++ b/src/validators/civilunion.test.js
@@ -18,14 +18,16 @@ describe('CivilUnion validation', function () {
       {
         state: {
           Divorced: 'Yes',
-          DivorcedList: []
+          DivorcedList: [],
+          DivorcedListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           Divorced: 'Yes',
-          DivorcedList: [{Divorce: {}}]
+          DivorcedList: [{Divorce: {}}],
+          DivorcedListBranch: 'No'
         },
         expected: false
       },
@@ -85,7 +87,8 @@ describe('CivilUnion validation', function () {
                 zipcode: '22202'
               }
             }
-          }]
+          }],
+          DivorcedListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/cohabitant.js
+++ b/src/validators/cohabitant.js
@@ -8,6 +8,7 @@ export default class CohabitantsValidator {
   constructor (state = {}) {
     this.hasCohabitant = state.HasCohabitant
     this.cohabitantList = state.CohabitantList || []
+    this.cohabitantListBranch = state.CohabitantListBranch
   }
 
   isValid () {
@@ -19,6 +20,10 @@ export default class CohabitantsValidator {
     }
 
     if (!this.cohabitantList.length) {
+      return false
+    }
+
+    if (this.cohabitantListBranch !== 'No') {
       return false
     }
 

--- a/src/validators/cohabitant.test.js
+++ b/src/validators/cohabitant.test.js
@@ -126,14 +126,16 @@ describe('Cohabitant validation', function () {
       {
         state: {
           HasCohabitant: 'Yes',
-          CohabitantList: []
+          CohabitantList: [],
+          CohabitantListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasCohabitant: 'Yes',
-          CohabitantList: [{Cohabitant: {}}]
+          CohabitantList: [{Cohabitant: {}}],
+          CohabitantListBranch: 'No'
         },
         expected: false
       },
@@ -201,7 +203,8 @@ describe('Cohabitant validation', function () {
                 }
               }
             }
-          ]
+          ],
+          CohabitantListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/competence.js
+++ b/src/validators/competence.js
@@ -3,6 +3,7 @@ import OrderValidator from './order'
 export default class CompetenceValidator {
   constructor (state = {}, props) {
     this.list = state.List || []
+    this.listBranch = state.ListBranch
     this.isIncompetent = state.IsIncompetent
   }
 
@@ -12,6 +13,10 @@ export default class CompetenceValidator {
 
   validList () {
     if (this.isIncompetent === 'Yes' && this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/competence.test.js
+++ b/src/validators/competence.test.js
@@ -31,13 +31,15 @@ describe('Competence validation', function () {
                 Appeals: [{ Has: 'No' }]
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           List: [],
+          ListBranch: 'No',
           IsIncompetent: 'Yes'
         },
         expected: false
@@ -45,6 +47,7 @@ describe('Competence validation', function () {
       {
         state: {
           List: [],
+          ListBranch: 'No',
           IsIncompetent: 'No'
         },
         expected: true
@@ -52,6 +55,7 @@ describe('Competence validation', function () {
       {
         state: {
           List: [],
+          ListBranch: 'No',
           IsIncompetent: 'Nope'
         },
         expected: false
@@ -82,7 +86,8 @@ describe('Competence validation', function () {
                 Appeals: [{ Has: 'No' }]
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       }

--- a/src/validators/consultation.js
+++ b/src/validators/consultation.js
@@ -3,6 +3,7 @@ import OrderValidator from './order'
 export default class ConsultationValidator {
   constructor (state = {}, props) {
     this.list = state.List || []
+    this.listBranch = state.ListBranch
     this.consulted = state.Consulted
   }
 
@@ -12,6 +13,10 @@ export default class ConsultationValidator {
 
   validList () {
     if (this.consulted === 'Yes' && this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/consultation.test.js
+++ b/src/validators/consultation.test.js
@@ -31,28 +31,32 @@ describe('Consultation validation', function () {
                 Appeals: [{ Has: 'No' }]
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           List: [],
-          Consulted: 'Yes'
+          Consulted: 'Yes',
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           List: [],
-          Consulted: 'No'
+          Consulted: 'No',
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           List: [],
-          Consulted: 'Nope'
+          Consulted: 'Nope',
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -82,7 +86,8 @@ describe('Consultation validation', function () {
                 Appeals: [{ Has: 'No' }]
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       }

--- a/src/validators/credit.js
+++ b/src/validators/credit.js
@@ -5,6 +5,7 @@ export default class CreditValidator {
   constructor (state = {}, props = {}) {
     this.hasCreditCounseling = state.HasCreditCounseling
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validHasCreditCounseling () {
@@ -25,6 +26,10 @@ export default class CreditValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/credit.test.js
+++ b/src/validators/credit.test.js
@@ -168,21 +168,24 @@ describe('credit component validation', function () {
       {
         state: {
           HasCreditCounseling: 'No',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           HasCreditCounseling: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasCreditCounseling: 'Yes',
-          List: [{}]
+          List: [{}],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -215,7 +218,8 @@ describe('credit component validation', function () {
                 value: 'The description'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/delinquent.js
+++ b/src/validators/delinquent.js
@@ -5,6 +5,7 @@ export default class DelinquentValidator {
   constructor (state = {}, props = {}) {
     this.hasDelinquent = state.HasDelinquent
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validHasDelinquent () {
@@ -25,6 +26,10 @@ export default class DelinquentValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/delinquent.test.js
+++ b/src/validators/delinquent.test.js
@@ -396,21 +396,24 @@ describe('delinquent component validation', function () {
       {
         state: {
           HasDelinquent: 'No',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           HasDelinquent: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasDelinquent: 'Yes',
-          List: [{}]
+          List: [{}],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -469,7 +472,8 @@ describe('delinquent component validation', function () {
                 value: 'The description'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/diagnoses.js
+++ b/src/validators/diagnoses.js
@@ -10,7 +10,9 @@ export default class DiagnosesValidator {
     this.didNotConsult = state.DidNotConsult
     this.inTreatment = state.InTreatment
     this.diagnosisList = state.DiagnosisList
+    this.diagnosisListBranch = state.DiagnosisListBranch
     this.treatmentList = state.TreatmentList
+    this.treatmentListBranch = state.TreatmentListBranch
   }
 
   validDiagnosisList () {
@@ -22,11 +24,16 @@ export default class DiagnosesValidator {
       return false
     }
 
+    if (this.diagnosisListBranch !== 'No') {
+      return false
+    }
+
     for (let item of this.diagnosisList) {
       if (!new DiagnosisValidator(item.Diagnosis).isValid()) {
         return false
       }
     }
+
     return true
   }
 
@@ -39,11 +46,16 @@ export default class DiagnosesValidator {
       return false
     }
 
+    if (this.treatmentListBranch !== 'No') {
+      return false
+    }
+
     for (let item of this.treatmentList) {
       if (!new TreatmentValidator(item.Treatment).isValid()) {
         return false
       }
     }
+
     return true
   }
 
@@ -62,4 +74,3 @@ export default class DiagnosesValidator {
       this.validTreatmentList()
   }
 }
-

--- a/src/validators/diagnoses.test.js
+++ b/src/validators/diagnoses.test.js
@@ -26,28 +26,32 @@ describe('Diagnoses validation', function () {
                 extension: ''
               }
             }
-          }]
+          }],
+          TreatmentListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           InTreatment: 'No',
-          TreatmentList: []
+          TreatmentList: [],
+          TreatmentListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           InTreatment: 'Yes',
-          TreatmentList: []
+          TreatmentList: [],
+          TreatmentListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           InTreatment: 'Yes',
-          TreatmentList: [{}]
+          TreatmentList: [{}],
+          TreatmentListBranch: 'No'
         },
         expected: false
       }
@@ -119,28 +123,32 @@ describe('Diagnoses validation', function () {
                 }
               }
             }
-          }]
+          }],
+          DiagnosisListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           Diagnosed: 'No',
-          DiagnosisList: []
+          DiagnosisList: [],
+          DiagnosisListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           Diagnosed: 'Yes',
-          DiagnosisList: []
+          DiagnosisList: [],
+          DiagnosisListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           Diagnosed: 'Yes',
-          DiagnosisList: [{}]
+          DiagnosisList: [{}],
+          DiagnosisListBranch: 'No'
         },
         expected: false
       }
@@ -158,7 +166,9 @@ describe('Diagnoses validation', function () {
           InTreatment: 'No',
           DidNotConsult: 'Yes',
           DiagnosisList: [],
-          TreatmentList: []
+          DiagnosisListBranch: 'No',
+          TreatmentList: [],
+          TreatmentListBranch: 'No'
         },
         expected: true
       }]

--- a/src/validators/existingconditions.js
+++ b/src/validators/existingconditions.js
@@ -7,6 +7,7 @@ export default class ExistingConditionsValidator {
     this.receivedTreatment = state.ReceivedTreatment
     this.explanation = state.Explanation
     this.treatmentList = state.TreatmentList || []
+    this.treatmentListBranch = state.TreatmentListBranch
     this.didNotFollow = state.DidNotFollow
     this.didNotFollowExplanation = state.DidNotFollowExplanation
     this.prefix = (props || {}).prefix
@@ -20,6 +21,7 @@ export default class ExistingConditionsValidator {
     if (this.receivedTreatment === 'No' && !validGenericTextfield(this.explanation)) {
       return false
     }
+
     return true
   }
 
@@ -27,9 +29,11 @@ export default class ExistingConditionsValidator {
     if (!validBranch(this.didNotFollow)) {
       return false
     }
+
     if (this.didNotFollow === 'Yes' && !validGenericTextfield(this.didNotFollowExplanation)) {
       return false
     }
+
     return true
   }
 
@@ -42,11 +46,16 @@ export default class ExistingConditionsValidator {
       return false
     }
 
+    if (this.treatmentListBranch !== 'No') {
+      return false
+    }
+
     for (let item of this.treatmentList) {
       if (!new DiagnosisValidator(item.Treatment, { prefix: this.prefix }).isValid()) {
         return false
       }
     }
+
     return true
   }
 

--- a/src/validators/existingconditions.test.js
+++ b/src/validators/existingconditions.test.js
@@ -145,7 +145,8 @@ describe('Diagnosis validation', function () {
                 }
               }
             }
-          ]
+          ],
+          TreatmentListBranch: 'No'
         },
         expected: true
       },
@@ -164,7 +165,8 @@ describe('Diagnosis validation', function () {
       {
         state: {
           ReceivedTreatment: 'Yes',
-          TreatmentList: [{Treatment: {}}]
+          TreatmentList: [{Treatment: {}}],
+          TreatmentListBranch: 'No'
         },
         expected: false
       }
@@ -244,7 +246,9 @@ describe('Diagnosis validation', function () {
                 }
               }
             }
-          ]},
+          ],
+          TreatmentListBranch: 'No'
+        },
         expected: true
       }
     ]

--- a/src/validators/foreignbenefitactivity.js
+++ b/src/validators/foreignbenefitactivity.js
@@ -5,6 +5,7 @@ export default class ForeignBenefitActivityValidator {
   constructor (state, props = {}) {
     this.hasBenefits = props.HasBenefits || ''
     this.list = props.List || []
+    this.listBranch = props.ListBranch
   }
 
   isValid () {
@@ -16,6 +17,10 @@ export default class ForeignBenefitActivityValidator {
     }
 
     if (this.hasBenefits === 'Yes' && !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/foreignbenefitactivity.test.js
+++ b/src/validators/foreignbenefitactivity.test.js
@@ -18,7 +18,8 @@ describe('Foreign RealEstate Activity validation', function () {
       {
         props: {
           HasBenefits: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
@@ -53,7 +54,8 @@ describe('Foreign RealEstate Activity validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignbusinessadvice.js
+++ b/src/validators/foreignbusinessadvice.js
@@ -6,6 +6,7 @@ export default class ForeignBusinessAdviceValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignAdvice = state.HasForeignAdvice
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -15,6 +16,10 @@ export default class ForeignBusinessAdviceValidator {
 
     if (this.hasForeignAdvice === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreignbusinessadvice.test.js
+++ b/src/validators/foreignbusinessadvice.test.js
@@ -135,7 +135,8 @@ describe('Foreign business advice component validation', function () {
       {
         state: {
           HasForeignAdvice: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -173,7 +174,8 @@ describe('Foreign business advice component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignbusinessconferences.js
+++ b/src/validators/foreignbusinessconferences.js
@@ -5,6 +5,7 @@ export default class ForeignBusinessConferencesValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignConferences = state.HasForeignConferences
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -14,6 +15,10 @@ export default class ForeignBusinessConferencesValidator {
 
     if (this.hasForeignConferences === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreignbusinessconferences.test.js
+++ b/src/validators/foreignbusinessconferences.test.js
@@ -225,7 +225,8 @@ describe('Foreign business conferences component validation', function () {
       {
         state: {
           HasForeignConferences: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
@@ -266,7 +267,8 @@ describe('Foreign business conferences component validation', function () {
                 ]
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignbusinessemployment.js
+++ b/src/validators/foreignbusinessemployment.js
@@ -6,6 +6,7 @@ export default class ForeignBusinessEmploymentValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignEmployment = state.HasForeignEmployment
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -15,6 +16,10 @@ export default class ForeignBusinessEmploymentValidator {
 
     if (this.hasForeignEmployment === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreignbusinessemployment.test.js
+++ b/src/validators/foreignbusinessemployment.test.js
@@ -148,7 +148,8 @@ describe('Foreign business employment component validation', function () {
       {
         state: {
           HasForeignEmployment: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -186,7 +187,8 @@ describe('Foreign business employment component validation', function () {
                 Accepted: 'No'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignbusinessfamily.js
+++ b/src/validators/foreignbusinessfamily.js
@@ -5,6 +5,7 @@ export default class ForeignBusinessFamilyValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignFamily = state.HasForeignFamily
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -14,6 +15,10 @@ export default class ForeignBusinessFamilyValidator {
 
     if (this.hasForeignFamily === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreignbusinessfamily.test.js
+++ b/src/validators/foreignbusinessfamily.test.js
@@ -132,7 +132,8 @@ describe('Foreign business family component validation', function () {
       {
         state: {
           HasForeignFamily: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -167,7 +168,8 @@ describe('Foreign business family component validation', function () {
                 value: 'this is the circumstances'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignbusinessventures.js
+++ b/src/validators/foreignbusinessventures.js
@@ -7,6 +7,7 @@ export default class ForeignBusinessVenturesValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignVentures = state.HasForeignVentures
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -16,6 +17,10 @@ export default class ForeignBusinessVenturesValidator {
 
     if (this.hasForeignVentures === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreignbusinessventures.test.js
+++ b/src/validators/foreignbusinessventures.test.js
@@ -282,7 +282,8 @@ describe('Foreign business ventures component validation', function () {
       {
         state: {
           HasForeignVentures: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -344,7 +345,8 @@ describe('Foreign business ventures component validation', function () {
                 value: 'this is the compensation'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreigncontacts.js
+++ b/src/validators/foreigncontacts.js
@@ -8,6 +8,7 @@ export default class ForeignContactsValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignContacts = state.HasForeignContacts
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -17,6 +18,10 @@ export default class ForeignContactsValidator {
 
     if (this.hasForeignContacts === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreigncontacts.test.js
+++ b/src/validators/foreigncontacts.test.js
@@ -656,7 +656,8 @@ describe('Foreign contacts component validation', function () {
                 HasAffiliations: 'No'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreigndirectactivity.js
+++ b/src/validators/foreigndirectactivity.js
@@ -5,6 +5,7 @@ export default class ForeignDirectActivityValidator {
   constructor (state, props = {}) {
     this.hasInterests = props.HasInterests || ''
     this.list = props.List || []
+    this.listBranch = props.ListBranch
   }
 
   isValid () {
@@ -16,6 +17,10 @@ export default class ForeignDirectActivityValidator {
     }
 
     if (this.hasInterests === 'Yes' && !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/foreigndirectactivity.test.js
+++ b/src/validators/foreigndirectactivity.test.js
@@ -18,7 +18,8 @@ describe('Foreign Direct Activity validation', function () {
       {
         props: {
           HasInterests: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
@@ -62,7 +63,8 @@ describe('Foreign Direct Activity validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignindirectactivity.js
+++ b/src/validators/foreignindirectactivity.js
@@ -5,6 +5,7 @@ export default class ForeignIndirectActivityValidator {
   constructor (state, props = {}) {
     this.hasInterests = props.HasInterests || ''
     this.list = props.List || []
+    this.listBranch = props.ListBranch
   }
 
   isValid () {
@@ -16,6 +17,10 @@ export default class ForeignIndirectActivityValidator {
     }
 
     if (this.hasInterests === 'Yes' && !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/foreignindirectactivity.test.js
+++ b/src/validators/foreignindirectactivity.test.js
@@ -18,7 +18,8 @@ describe('Foreign Indirect Activity validation', function () {
       {
         props: {
           HasInterests: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
@@ -71,7 +72,8 @@ describe('Foreign Indirect Activity validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignrealestateactivity.js
+++ b/src/validators/foreignrealestateactivity.js
@@ -5,6 +5,7 @@ export default class ForeignRealEstateActivityValidator {
   constructor (state, props = {}) {
     this.hasInterests = props.HasInterests || ''
     this.list = props.List || []
+    this.listBranch = props.ListBranch
   }
 
   isValid () {
@@ -16,6 +17,10 @@ export default class ForeignRealEstateActivityValidator {
     }
 
     if (this.hasInterests === 'Yes' && !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/foreignrealestateactivity.test.js
+++ b/src/validators/foreignrealestateactivity.test.js
@@ -18,7 +18,8 @@ describe('Foreign RealEstate Activity validation', function () {
       {
         props: {
           HasInterests: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -63,7 +64,8 @@ describe('Foreign RealEstate Activity validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/foreignsupport.js
+++ b/src/validators/foreignsupport.js
@@ -6,6 +6,7 @@ export default class ForeignActivitiesSupportValidator {
   constructor (state = {}, props = {}) {
     this.hasForeignSupport = state.HasForeignSupport
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validList () {
@@ -15,6 +16,10 @@ export default class ForeignActivitiesSupportValidator {
 
     if (this.hasForeignSupport === 'Yes') {
       if (!this.list || this.list.length === 0) {
+        return false
+      }
+
+      if (this.listBranch !== 'No') {
         return false
       }
 

--- a/src/validators/foreignsupport.test.js
+++ b/src/validators/foreignsupport.test.js
@@ -170,7 +170,8 @@ describe('Foreign activities support component validation', function () {
       {
         state: {
           HasForeignSupport: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
@@ -211,7 +212,8 @@ describe('Foreign activities support component validation', function () {
                 ]
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/gambling.js
+++ b/src/validators/gambling.js
@@ -3,7 +3,8 @@ import DateRangeValidator from './daterange'
 export default class GamblingValidator {
   constructor (state, props) {
     this.hasGamblingDebt = state.HasGamblingDebt
-    this.list = state.List
+    this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validHasGamblingDebt () {
@@ -27,6 +28,10 @@ export default class GamblingValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/gambling.test.js
+++ b/src/validators/gambling.test.js
@@ -211,7 +211,8 @@ describe('gambling debt component validation', function () {
       {
         state: {
           HasGamblingDebt: 'Foo',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -239,7 +240,8 @@ describe('gambling debt component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/gambling.test.js
+++ b/src/validators/gambling.test.js
@@ -66,7 +66,8 @@ describe('gambling debt component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -90,7 +91,8 @@ describe('gambling debt component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -118,7 +120,8 @@ describe('gambling debt component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -146,7 +149,8 @@ describe('gambling debt component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -174,21 +178,24 @@ describe('gambling debt component validation', function () {
                 present: false
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasGamblingDebt: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasGamblingDebt: 'Yes',
-          List: null
+          List: null,
+          ListBranch: 'No'
         },
         expected: false
       }

--- a/src/validators/hospitalization.js
+++ b/src/validators/hospitalization.js
@@ -5,11 +5,16 @@ import { validGenericTextfield } from './helpers'
 export default class HospitalizationsValidator {
   constructor (state = {}, props) {
     this.list = state.List || []
+    this.listBranch = state.ListBranch
     this.hospitalized = state.Hospitalized
   }
 
   validList () {
     if (this.hospitalized === 'Yes' && this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/hospitalization.test.js
+++ b/src/validators/hospitalization.test.js
@@ -90,44 +90,82 @@ describe('Hospitalization validation', function () {
       {
         state: {
           Hospitalized: 'Yes',
-          List: [{
-            Hospitalization: {
-              Facility: {
-                value: 'Place 1'
-              },
-              FacilityAddress: {
-                addressType: 'United States',
-                address: '1234 Some Rd',
-                city: 'Arlington',
-                state: 'Virginia',
-                zipcode: '22202'
-              },
-              TreatmentDate: {
-                from: {
-                  date: new Date('1/1/2010')
+          List: [
+            {
+              Hospitalization: {
+                Facility: {
+                  value: 'Place 1'
                 },
-                to: {
-                  date: new Date('1/1/2012')
+                FacilityAddress: {
+                  addressType: 'United States',
+                  address: '1234 Some Rd',
+                  city: 'Arlington',
+                  state: 'Virginia',
+                  zipcode: '22202'
                 },
-                present: false
-              },
-              Admission: 'Voluntary',
-              Explanation: {
-                value: 'Because I can'
+                TreatmentDate: {
+                  from: {
+                    date: new Date('1/1/2010')
+                  },
+                  to: {
+                    date: new Date('1/1/2012')
+                  },
+                  present: false
+                },
+                Admission: 'Voluntary',
+                Explanation: {
+                  value: 'Because I can'
+                }
               }
             }
-          }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           Hospitalized: 'Nope',
-          List: [{
-            Hospitalization: {
+          List: [
+            {
+              Hospitalization: {
+                Facility: {
+                  value: 'Place 1'
+                },
+                FacilityAddress: {
+                  addressType: 'United States',
+                  address: '1234 Some Rd',
+                  city: 'Arlington',
+                  state: 'Virginia',
+                  zipcode: '22202'
+                },
+                TreatmentDate: {
+                  from: {
+                    date: new Date('1/1/2010')
+                  },
+                  to: {
+                    date: new Date('1/1/2012')
+                  },
+                  present: false
+                },
+                Admission: 'Voluntary',
+                Explanation: {
+                  value: 'Because I can'
+                }
+              }
+            }
+          ],
+          ListBranch: ''
+        },
+        expected: false
+      },
+      {
+        state: {
+          Hospitalized: 'Yes',
+          List: [
+            {
               Facility: {
-                value: 'Place 1'
+                value: null
               },
               FacilityAddress: {
                 addressType: 'United States',
@@ -150,47 +188,16 @@ describe('Hospitalization validation', function () {
                 value: 'Because I can'
               }
             }
-          }
-          ]
+          ],
+          ListBranch: ''
         },
         expected: false
       },
       {
         state: {
           Hospitalized: 'Yes',
-          List: [{
-            Facility: {
-              value: null
-            },
-            FacilityAddress: {
-              addressType: 'United States',
-              address: '1234 Some Rd',
-              city: 'Arlington',
-              state: 'Virginia',
-              zipcode: '22202'
-            },
-            TreatmentDate: {
-              from: {
-                date: new Date('1/1/2010')
-              },
-              to: {
-                date: new Date('1/1/2012')
-              },
-              present: false
-            },
-            Admission: 'Voluntary',
-            Explanation: {
-              value: 'Because I can'
-            }
-          }
-          ]
-        },
-        expected: false
-      },
-      {
-        state: {
-          Hospitalized: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       }

--- a/src/validators/militarydisciplinary.js
+++ b/src/validators/militarydisciplinary.js
@@ -4,6 +4,7 @@ export default class MilitaryDisciplinaryValidator {
   constructor (state = {}, props = {}) {
     this.hasDisciplinary = state.HasDisciplinary
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validDisciplinary () {
@@ -16,6 +17,10 @@ export default class MilitaryDisciplinaryValidator {
     }
 
     if (this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/militarydisciplinary.test.js
+++ b/src/validators/militarydisciplinary.test.js
@@ -62,7 +62,8 @@ describe('Military disciplinary validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/militaryforeign.js
+++ b/src/validators/militaryforeign.js
@@ -46,7 +46,8 @@ export class ForeignServiceValidator {
     this.circumstances = state.Circumstances
     this.reasonLeft = state.ReasonLeft
     this.maintainsContact = state.MaintainsContact
-    this.list = state.List
+    this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validOrganization () {
@@ -92,6 +93,10 @@ export class ForeignServiceValidator {
     }
 
     if (this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/militaryforeign.test.js
+++ b/src/validators/militaryforeign.test.js
@@ -162,7 +162,8 @@ describe('Military foreign validation', function () {
                       }
                     }
                   }
-                ]
+                ],
+                ListBranch: 'No'
               }
             }
           ]
@@ -193,7 +194,8 @@ describe('Military foreign validation', function () {
       {
         state: {
           MaintainsContact: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -234,7 +236,8 @@ describe('Military foreign validation', function () {
                 value: 'Monthly'
               }
             }
-          }]
+          }],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/militaryforeign.test.js
+++ b/src/validators/militaryforeign.test.js
@@ -9,7 +9,8 @@ describe('Military foreign validation', function () {
             {
               Has: ''
             }
-          ]
+          ],
+          ListBranch: ''
         },
         expected: false
       },
@@ -19,7 +20,8 @@ describe('Military foreign validation', function () {
             {
               Has: 'No'
             }
-          ]
+          ],
+          ListBranch: ''
         },
         expected: true
       },
@@ -29,7 +31,8 @@ describe('Military foreign validation', function () {
             {
               Has: 'Yes'
             }
-          ]
+          ],
+          ListBranch: ''
         },
         expected: false
       }
@@ -48,7 +51,8 @@ describe('Military foreign validation', function () {
             {
               Has: 'Yes'
             }
-          ]
+          ],
+          ListBranch: ''
         },
         expected: false
       },

--- a/src/validators/militaryhistory.js
+++ b/src/validators/militaryhistory.js
@@ -5,6 +5,7 @@ export default class MilitaryHistoryValidator {
   constructor (state = {}, props = {}) {
     this.hasServed = state.HasServed
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validServed () {
@@ -17,6 +18,10 @@ export default class MilitaryHistoryValidator {
     }
 
     if (this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/militaryhistory.test.js
+++ b/src/validators/militaryhistory.test.js
@@ -58,7 +58,8 @@ describe('Military history validation', function () {
                 HasBeenDischarged: 'Yes'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -97,7 +98,8 @@ describe('Military history validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -130,7 +132,8 @@ describe('Military history validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -166,7 +169,8 @@ describe('Military history validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -192,7 +196,8 @@ describe('Military history validation', function () {
                 HasBeenDischarged: 'No'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       },
@@ -217,7 +222,8 @@ describe('Military history validation', function () {
                 HasBeenDischarged: 'No'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/nonpayment.js
+++ b/src/validators/nonpayment.js
@@ -4,6 +4,7 @@ export default class NonpaymentValidator {
   constructor (state = {}, props = {}) {
     this.hasNonpayment = state.HasNonpayment
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validHasNonpayment () {
@@ -24,6 +25,10 @@ export default class NonpaymentValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/nonpayment.test.js
+++ b/src/validators/nonpayment.test.js
@@ -344,21 +344,24 @@ describe('nonpayment component validation', function () {
       {
         state: {
           HasNonpayment: 'No',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: true
       },
       {
         state: {
           HasNonpayment: 'Yes',
-          List: []
+          List: [],
+          ListBranch: ''
         },
         expected: false
       },
       {
         state: {
           HasNonpayment: 'Yes',
-          List: [{}]
+          List: [{}],
+          ListBranch: ''
         },
         expected: false
       },
@@ -407,7 +410,8 @@ describe('nonpayment component validation', function () {
                 value: 'The description'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/people.js
+++ b/src/validators/people.js
@@ -6,16 +6,21 @@ import { validGenericTextfield, validPhoneNumber, validNotApplicable } from './h
 export default class PeopleValidator {
   constructor (state = {}) {
     this.people = state.List || []
+    this.listBranch = state.ListBranch
   }
 
+  // TODO: Determine if this is being used outside of this file
   validCount () {
     let count = 0
+
     for (let item of this.people) {
       if (!new PersonValidator(item.Person).isValid()) {
         continue
       }
+
       count++
     }
+
     return count
   }
 
@@ -23,11 +28,17 @@ export default class PeopleValidator {
     if (this.people.length < 1) {
       return false
     }
+
+    if (this.listBranch !== 'No') {
+      return false
+    }
+
     for (let item of this.people) {
       if (!new PersonValidator(item.Person).isValid()) {
         return false
       }
     }
+
     return true
   }
 }

--- a/src/validators/people.test.js
+++ b/src/validators/people.test.js
@@ -114,13 +114,15 @@ describe('Person validator', function () {
     const tests = [
       {
         state: {
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
-          List: [{ Person: {} }, { Person: {} }, { Person: {} }]
+          List: [{ Person: {} }, { Person: {} }, { Person: {} }],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -280,7 +282,8 @@ describe('Person validator', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }
@@ -295,7 +298,8 @@ describe('Person validator', function () {
     const tests = [
       {
         state: {
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: 0
       },
@@ -351,7 +355,8 @@ describe('Person validator', function () {
                 zipcode: '22202'
               }
             }
-          }]
+          }],
+          ListBranch: 'No'
         },
         expected: 1
       }

--- a/src/validators/police.js
+++ b/src/validators/police.js
@@ -10,7 +10,9 @@ export default class PoliceValidator {
     this.hasProbation = state.HasProbation
     this.hasTrial = state.HasTrial
     this.list = state.List || []
+    this.listBranch = state.ListBranch
     this.otherOffenses = state.OtherOffenses || []
+    this.otherOffensesBranch = state.OtherOffensesBranch
     this.domesticViolence = state.DomesticViolence || []
     this.hasOtherConviction = state.HasOtherConviction
     this.hasOtherFelony = state.HasOtherFelony
@@ -56,17 +58,28 @@ export default class PoliceValidator {
       return false
     }
 
+    if (this.listBranch !== 'No') {
+      return false
+    }
+
     for (const offense of this.list) {
       if (new OffenseValidator(offense.Item, null).isValid() !== true) {
         return false
       }
     }
 
-    for (const otherOffense of this.otherOffenses) {
-      if (new OtherOffenseValidator(otherOffense.Item, null).isValid() !== true) {
+    if (this.hasOtherOffenses()) {
+      if (this.otherOffensesBranch !== 'No') {
         return false
       }
+
+      for (const otherOffense of this.otherOffenses) {
+        if (new OtherOffenseValidator(otherOffense.Item, null).isValid() !== true) {
+          return false
+        }
+      }
     }
+
     return true
   }
 

--- a/src/validators/police.test.js
+++ b/src/validators/police.test.js
@@ -106,6 +106,7 @@ describe('Police record validation', function () {
           HasCharges: 'No',
           HasProbation: 'No',
           HasTrial: 'Yes',
+          ListBranch: 'No',
           List: [
             {
               Item: {
@@ -166,6 +167,7 @@ describe('Police record validation', function () {
           HasCharges: 'No',
           HasProbation: 'No',
           HasTrial: 'Yes',
+          ListBranch: 'No',
           List: [
             {
               Item: {
@@ -196,6 +198,7 @@ describe('Police record validation', function () {
           HasCharges: 'No',
           HasProbation: 'No',
           HasTrial: 'Yes',
+          ListBranch: 'No',
           List: [
             {
               Item: {
@@ -222,6 +225,7 @@ describe('Police record validation', function () {
               }
             }
           ],
+          OtherOffensesBranch: 'No',
           OtherOffenses: [
             {
               Item: {
@@ -325,6 +329,7 @@ describe('Police record validation', function () {
           HasCharges: 'No',
           HasProbation: 'No',
           HasTrial: 'Yes',
+          ListBranch: 'No',
           List: [
             {
               Item: {
@@ -351,6 +356,7 @@ describe('Police record validation', function () {
               }
             }
           ],
+          OtherOffensesBranch: 'No',
           OtherOffenses: [
             {
               Item: {

--- a/src/validators/police.test.js
+++ b/src/validators/police.test.js
@@ -49,7 +49,8 @@ describe('Police record validation', function () {
           HasCharges: null,
           HasProbation: null,
           HasTrial: null,
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -61,6 +62,7 @@ describe('Police record validation', function () {
           HasProbation: 'No',
           HasTrial: 'No',
           List: [],
+          ListBranch: 'No',
           DomesticViolence: [
             {
               Has: 'Yes',
@@ -95,7 +97,8 @@ describe('Police record validation', function () {
           HasCharges: 'No',
           HasProbation: 'No',
           HasTrial: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -448,7 +451,7 @@ describe('Police record validation', function () {
             }
           ]
         },
-        expected: false
+        expected: true
       }
     ]
 

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -6,10 +6,15 @@ import { validDateField, validGenericTextfield } from './helpers'
 export default class RelativesValidator {
   constructor (state = {}, props = {}) {
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validItems () {
     if (this.list.length === 0) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -1591,7 +1591,8 @@ describe('Relatives validation', function () {
                 Relations: ['Mother']
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -1679,7 +1680,8 @@ describe('Relatives validation', function () {
                 }
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }

--- a/src/validators/taxes.js
+++ b/src/validators/taxes.js
@@ -5,6 +5,7 @@ export default class TaxesValidator {
   constructor (state = {}, props = {}) {
     this.hasTaxes = state.HasTaxes
     this.list = state.List || []
+    this.listBranch = state.ListBranch
   }
 
   validHasTaxes () {
@@ -25,6 +26,10 @@ export default class TaxesValidator {
     }
 
     if (!this.list || !this.list.length) {
+      return false
+    }
+
+    if (this.listBranch !== 'No') {
       return false
     }
 

--- a/src/validators/taxes.test.js
+++ b/src/validators/taxes.test.js
@@ -314,21 +314,24 @@ describe('taxes component validation', function () {
       {
         state: {
           HasTaxes: 'No',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: true
       },
       {
         state: {
           HasTaxes: 'Yes',
-          List: []
+          List: [],
+          ListBranch: 'No'
         },
         expected: false
       },
       {
         state: {
           HasTaxes: 'Yes',
-          List: [{}]
+          List: [{}],
+          ListBranch: 'No'
         },
         expected: false
       },
@@ -367,7 +370,8 @@ describe('taxes component validation', function () {
                 value: 'The description'
               }
             }
-          ]
+          ],
+          ListBranch: 'No'
         },
         expected: true
       }


### PR DESCRIPTION
Issues: 

 - #1205: Removed redundant "add" button if there is an addendum present. In these situations the accordion is now driven by a "yes/no" option.
 - #1194: Clean up verbiage used for append buttons/context to be more specific to the use case
 - #1195: Removed default title casing and made conditional on name or addresses
 - #1183: Shrunk accordion item "close" button hit area
