### PR TITLE
Relatives updates

### DIFF
--- a/src/components/Form/BirthPlace/BirthPlace.jsx
+++ b/src/components/Form/BirthPlace/BirthPlace.jsx
@@ -8,6 +8,7 @@ import MilitaryState from '../MilitaryState'
 import County from '../County'
 import Country from '../Country'
 import Branch from '../Branch'
+import Show from '../Show'
 
 export default class BirthPlace extends ValidationElement {
   constructor (props) {
@@ -43,7 +44,7 @@ export default class BirthPlace extends ValidationElement {
       return
     }
 
-    let part = this.extractPart(event.target.id)
+    let part = event.target.id
     let value = event.target.value
     let updated = null
 
@@ -123,13 +124,6 @@ export default class BirthPlace extends ValidationElement {
     return new BirthPlaceValidator(this.state, null).isValid()
   }
 
-  /**
-   * Returns the part name from the pull generated identifier.
-   */
-  extractPart (id) {
-    return id.split('-').pop()
-  }
-
   onUpdate (value, event) {
     let updated = null
     if (value === 'No') {
@@ -201,10 +195,10 @@ export default class BirthPlace extends ValidationElement {
           {this.options()}
           <Field adjustFor="labels">
             <MilitaryState name="state"
-                           label={i18n.t('identification.birthplace.label.state')}
+                           label={this.props.stateLabel}
                            value={this.state.state}
                            className="state"
-                           placeholder={i18n.t('identification.birthplace.placeholder.state')}
+                           placeholder={this.props.statePlaceholder}
                            includeStates="true"
                            required="true"
                            disabled={this.state.disabledState}
@@ -216,10 +210,10 @@ export default class BirthPlace extends ValidationElement {
           </Field>
           <Field adjustFor="labels">
             <City name="city"
-                  label={i18n.t('identification.birthplace.label.city')}
+                  label={this.props.cityLabel}
                   value={this.state.city}
                   className="city"
-                  placeholder={i18n.t('identification.birthplace.placeholder.city')}
+                  placeholder={this.props.cityPlaceholder}
                   maxlength="100"
                   onChange={this.handleChange}
                   onValidate={this.handleValidation}
@@ -227,19 +221,21 @@ export default class BirthPlace extends ValidationElement {
                   onBlur={this.props.onBlur}
                   />
           </Field>
-          <Field adjustFor="labels">
-            <County name="county"
-                    label={i18n.t('identification.birthplace.label.county')}
-                    value={this.state.county}
-                    className="county"
-                    placeholder={i18n.t('identification.birthplace.placeholder.county')}
-                    maxlength="255"
-                    onChange={this.handleChange}
-                    onValidate={this.handleValidation}
-                    onFocus={this.props.onFocus}
-                    onBlur={this.props.onBlur}
-                    />
-          </Field>
+          <Show when={this.props.hideCounty === false}>
+            <Field adjustFor="labels">
+              <County name="county"
+                      label={this.props.countyLabel}
+                      value={this.state.county}
+                      className="county"
+                      placeholder={this.props.countyPlaceholder}
+                      maxlength="255"
+                      onChange={this.handleChange}
+                      onValidate={this.handleValidation}
+                      onFocus={this.props.onFocus}
+                      onBlur={this.props.onBlur}
+                      />
+            </Field>
+          </Show>
         </div>
       )
     }
@@ -249,10 +245,10 @@ export default class BirthPlace extends ValidationElement {
         {this.options()}
         <Field adjustFor="labels">
           <City name="city"
-                label={i18n.t('identification.birthplace.label.city')}
+                label={this.props.cityLabel}
                 value={this.state.city}
                 className="city"
-                placeholder={i18n.t('identification.birthplace.placeholder.city')}
+                placeholder={this.props.cityPlaceholder}
                 maxlength="100"
                 onChange={this.handleChange}
                 onValidate={this.handleValidation}
@@ -262,10 +258,10 @@ export default class BirthPlace extends ValidationElement {
         </Field>
         <Field adjustFor="labels">
           <Country name="country"
-                   label={i18n.t('identification.birthplace.label.country')}
+                   label={this.props.countryLabel}
                    value={this.state.country}
                    className="country"
-                   placeholder={i18n.t('identification.birthplace.placeholder.country')}
+                   placeholder={this.props.countryPlaceholder}
                    excludeUnitedStates="true"
                    disabled={this.state.disabledCountry}
                    onChange={this.handleChange}
@@ -284,5 +280,14 @@ BirthPlace.defaultProps = {
   help: 'identification.birthplace.branch.help',
   branch: true,
   disabledCountry: false,
-  disabledState: false
+  disabledState: false,
+  hideCounty: false,
+  stateLabel: i18n.t('identification.birthplace.label.state'),
+  statePlaceholder: i18n.t('identification.birthplace.placeholder.state'),
+  cityLabel: i18n.t('identification.birthplace.label.city'),
+  cityPlaceholder: i18n.t('identification.birthplace.placeholder.city'),
+  countyLabel: i18n.t('identification.birthplace.label.county'),
+  countyPlaceholder: i18n.t('identification.birthplace.placeholder.county'),
+  countryLabel: i18n.t('identification.birthplace.label.country'),
+  countryPlaceholder: i18n.t('identification.birthplace.placeholder.country')
 }

--- a/src/components/Form/BirthPlace/BirthPlace.scss
+++ b/src/components/Form/BirthPlace/BirthPlace.scss
@@ -8,3 +8,7 @@
     margin-bottom: 0;
   }
 }
+
+.field .birthplace {
+  margin-bottom: 0;
+}

--- a/src/components/Section/History/dateranges.js
+++ b/src/components/Section/History/dateranges.js
@@ -116,7 +116,7 @@ export const leapYear = (year) => {
  * Returns how many days are in a month based on the given year
  */
 export const daysInMonth = (month, year) => {
-  const m = parseInt(month || 0)
+  const m = parseInt(month || 1)
   const y = parseInt(year || 0)
 
   // Setup for upperbounds of days in months
@@ -125,7 +125,7 @@ export const daysInMonth = (month, year) => {
     upperBounds[1] = 29
   }
 
-  return upperBounds[m - 1]
+  return Math.min(31, upperBounds[m - 1])
 }
 
 /**

--- a/src/components/Section/Relationships/Relatives/Alias.jsx
+++ b/src/components/Section/Relationships/Relatives/Alias.jsx
@@ -58,8 +58,9 @@ export default class Alias extends ValidationElement {
               onUpdate={this.updateName}
               />
 
-        <h4>{i18n.t('relationships.relatives.heading.alias.maiden')}</h4>
         <Branch name="MaidenName"
+                label={i18n.t('relationships.relatives.heading.alias.maiden')}
+                labelSize="h4"
                 className="alias-maiden"
                 value={this.state.MaidenName}
                 onUpdate={this.updateMaidenName} >

--- a/src/components/Section/Relationships/Relatives/Alias.jsx
+++ b/src/components/Section/Relationships/Relatives/Alias.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
-import { ValidationElement, Branch, Name, DateRange, Field, Textarea } from '../../../Form'
+import { ValidationElement, Branch, Name, DateRange, Field, Textarea, Show } from '../../../Form'
 
 export default class Alias extends ValidationElement {
   constructor (props) {
@@ -58,13 +58,15 @@ export default class Alias extends ValidationElement {
               onUpdate={this.updateName}
               />
 
-        <Branch name="MaidenName"
-                label={i18n.t('relationships.relatives.heading.alias.maiden')}
-                labelSize="h4"
-                className="alias-maiden"
-                value={this.state.MaidenName}
-                onUpdate={this.updateMaidenName} >
-        </Branch>
+        <Show when={this.props.hideMaiden === false}>
+          <Branch name="MaidenName"
+                  label={i18n.t('relationships.relatives.heading.alias.maiden')}
+                  labelSize="h4"
+                  className="alias-maiden"
+                  value={this.state.MaidenName}
+                  onUpdate={this.updateMaidenName} >
+          </Branch>
+        </Show>
 
         <Field help="relationships.relatives.help.aliasdates"
                adjustFor="daterange"
@@ -94,5 +96,6 @@ Alias.defaultProps = {
   Name: {},
   MaidenName: '',
   Dates: {},
-  Reason: {}
+  Reason: {},
+  hideMaiden: false
 }

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -40,6 +40,7 @@ export default class Relative extends ValidationElement {
       Derived: props.Derived,
       DerivedComments: props.DerivedComments,
       DocumentNumber: props.DocumentNumber,
+      DocumentExpiration: props.DocumentExpiration,
       CourtName: props.CourtName,
       CourtAddress: props.CourtAddress,
       Document: props.Document,
@@ -78,6 +79,7 @@ export default class Relative extends ValidationElement {
     this.updateDerived = this.updateDerived.bind(this)
     this.updateDerivedComments = this.updateDerivedComments.bind(this)
     this.updateDocumentNumber = this.updateDocumentNumber.bind(this)
+    this.updateDocumentExpiration = this.updateDocumentExpiration.bind(this)
     this.updateCourtName = this.updateCourtName.bind(this)
     this.updateCourtAddress = this.updateCourtAddress.bind(this)
     this.updateDocument = this.updateDocument.bind(this)
@@ -167,6 +169,10 @@ export default class Relative extends ValidationElement {
 
   updateDocumentNumber (values) {
     this.onUpdate('DocumentNumber', values)
+  }
+
+  updateDocumentExpiration (values) {
+    this.onUpdate('DocumentExpiration', values)
   }
 
   updateCourtName (values) {
@@ -604,6 +610,17 @@ export default class Relative extends ValidationElement {
                     />
             </Field>
 
+            <Field title={i18n.t('relationships.relatives.heading.us.expiration')}
+                   help="relationships.relatives.help.documentexpiration"
+                   adjustFor="datecontrol">
+              <DateControl name="DocumentExpiration"
+                           {...this.state.DocumentExpiration}
+                           className="relative-documentexpiration"
+                           onUpdate={this.updateDocumentExpiration}
+                           onValidate={this.props.onValidate}
+                           />
+            </Field>
+
             <Field title={i18n.t('relationships.relatives.heading.us.name')}
                    titleSize="h3"
                    help="relationships.relatives.help.courtname">
@@ -940,6 +957,7 @@ Relative.defaultProps = {
   Derived: '',
   DerivedComments: {},
   DocumentNumber: {},
+  DocumentExpiration: {},
   CourtName: {},
   CourtAddress: {},
   Document: '',

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -263,7 +263,6 @@ export default class Relative extends ValidationElement {
   }
 
   render () {
-    console.log('relation:', this.state.Relation)
     const validator = new RelativeValidator(this.state, null)
     const mother = this.state.Relation === 'Mother'
     const immediateFamily = ['Father', 'Mother', 'Child', 'Stepchild', 'Brother', 'Sister', 'Half-brother', 'Half-sister', 'Stepbrother', 'Stepsister', 'Stepmother', 'Stepfather'].includes(this.state.Relation)

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -3,7 +3,7 @@ import { i18n } from '../../../../config'
 import { ValidationElement, Branch, Show, Svg, BranchCollection,
          Name, Text, Textarea, Address, DateControl,
          Checkbox, CheckboxGroup, Radio, RadioGroup, Country,
-         Field, NotApplicable
+         Field, NotApplicable, BirthPlace
        } from '../../../Form'
 import { RelativeValidator } from '../../../../validators'
 import Alias from './Alias'
@@ -411,13 +411,18 @@ export default class Relative extends ValidationElement {
 
         <Field title={i18n.t('relationships.relatives.heading.birthplace')}
                help="relationships.relatives.help.birthplace"
-               adjustFor="address">
-          <Address name="Birthplace"
-                   className="relative-birthplace"
-                   {...this.state.Birthplace}
-                   onValidate={this.props.onValidate}
-                   onUpdate={this.updateBirthplace}
-                   />
+               adjustFor="button">
+          <BirthPlace name="Birthplace"
+                      label=""
+                      help=""
+                      cityPlaceholder={i18n.t('relationships.relatives.placeholder.city')}
+                      countryPlaceholder={i18n.t('relationships.relatives.placeholder.country')}
+                      hideCounty={true}
+                      className="relative-birthplace"
+                      {...this.state.Birthplace}
+                      onValidate={this.props.onValidate}
+                      onUpdate={this.updateBirthplace}
+                      />
         </Field>
 
         <Field title={i18n.t('relationships.relatives.heading.citizenship')}
@@ -471,7 +476,7 @@ export default class Relative extends ValidationElement {
                 <Alias name="Item"
                        onValidate={this.props.onValidate}
                        hideMaiden={mother}
-                  bind={true} />
+                       bind={true} />
               </div>
             </BranchCollection>
           </div>
@@ -568,33 +573,33 @@ export default class Relative extends ValidationElement {
               <RadioGroup className="relative-derived option-list"
                           selectedValue={this.state.Derived}>
                 <Radio name="derived-alien"
-                        label={i18n.m('relationships.relatives.label.derived.alien')}
-                        value="Alien"
-                        className="derived-alien"
-                        onValidate={this.props.onValidate}
-                        onChange={this.updateDerived}
-                        />
+                       label={i18n.m('relationships.relatives.label.derived.alien')}
+                       value="Alien"
+                       className="derived-alien"
+                       onValidate={this.props.onValidate}
+                       onChange={this.updateDerived}
+                       />
                 <Radio name="derived-permanent"
-                        label={i18n.m('relationships.relatives.label.derived.permanent')}
-                        value="Permanent"
-                        className="derived-permanent"
-                        onValidate={this.props.onValidate}
-                        onChange={this.updateDerived}
-                        />
+                       label={i18n.m('relationships.relatives.label.derived.permanent')}
+                       value="Permanent"
+                       className="derived-permanent"
+                       onValidate={this.props.onValidate}
+                       onChange={this.updateDerived}
+                       />
                 <Radio name="derived-certificate"
-                        label={i18n.m('relationships.relatives.label.derived.certificate')}
-                        value="Certificate"
-                        className="derived-certificate"
-                        onValidate={this.props.onValidate}
-                        onChange={this.updateDerived}
-                        />
+                       label={i18n.m('relationships.relatives.label.derived.certificate')}
+                       value="Certificate"
+                       className="derived-certificate"
+                       onValidate={this.props.onValidate}
+                       onChange={this.updateDerived}
+                       />
                 <Radio name="derived-other"
-                        label={i18n.m('relationships.relatives.label.derived.other')}
-                        value="Other"
-                        className="derived-other"
-                        onValidate={this.props.onValidate}
-                        onChange={this.updateDerived}
-                        />
+                       label={i18n.m('relationships.relatives.label.derived.other')}
+                       value="Other"
+                       className="derived-other"
+                       onValidate={this.props.onValidate}
+                       onChange={this.updateDerived}
+                       />
               </RadioGroup>
             </Field>
 

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -465,7 +465,7 @@ export default class Relative extends ValidationElement {
                 </Field>
                 <Alias name="Item"
                        onValidate={this.props.onValidate}
-                       hideMaiden={this.state.Relation === 'Mother'}
+                       hideMaiden={mother}
                   bind={true} />
               </div>
             </BranchCollection>
@@ -495,16 +495,14 @@ export default class Relative extends ValidationElement {
 
         <Show when={validator.requiresCitizenshipDocumentation()}>
           <div>
-            <h3 className="more title">{i18n.t('relationships.relatives.heading.needmore')}</h3>
-            <Svg src="img/date-down-arrow.svg" className="more arrow" />
+            <h2>{i18n.t('relationships.relatives.heading.us.title')}</h2>
 
-            <h3>{i18n.t('relationships.relatives.heading.us.title')}</h3>
-            <h4>{i18n.t('relationships.relatives.heading.us.documentation')}</h4>
-
-            {i18n.m('relationships.relatives.para.abroad')}
-            <Field help="relationships.relatives.help.abroad"
-                   adjustFor="buttons"
+            <Field title={i18n.t('relationships.relatives.heading.us.documentation')}
+                   titleSize="h3"
+                   help="relationships.relatives.help.abroad"
+                   adjustFor="p"
                    shrink={true}>
+              {i18n.m('relationships.relatives.para.abroad')}
               <RadioGroup className="relative-abroad option-list"
                           selectedValue={this.state.Abroad}>
                 <Radio name="abroad-fs"
@@ -524,9 +522,9 @@ export default class Relative extends ValidationElement {
               </RadioGroup>
             </Field>
 
-            {i18n.m('relationships.relatives.para.naturalized')}
             <Field help="relationships.relatives.help.naturalized"
-                   adjustFor="big-buttons">
+                   adjustFor="p">
+              {i18n.m('relationships.relatives.para.naturalized')}
               <RadioGroup className="relative-naturalized option-list"
                           selectedValue={this.state.Naturalized}>
                 <Radio name="naturalized-alien"
@@ -554,51 +552,49 @@ export default class Relative extends ValidationElement {
             </Field>
 
             <Field help="relationships.relatives.help.derived"
-                   adjustFor="big-buttons"
+                   adjustFor="p"
                    comments={true}
                    commentsName="DerivedComments"
                    commentsValue={this.state.DerivedComments}
                    commentsActive={this.state.Derived === 'Other'}
                    onUpdate={this.updateDerivedComments}
                    >
-              <div>
-                {i18n.m('relationships.relatives.para.derived')}
-                <RadioGroup className="relative-derived option-list"
-                            selectedValue={this.state.Derived}>
-                  <Radio name="derived-alien"
-                         label={i18n.m('relationships.relatives.label.derived.alien')}
-                         value="Alien"
-                         className="derived-alien"
-                         onValidate={this.props.onValidate}
-                         onChange={this.updateDerived}
-                         />
-                  <Radio name="derived-permanent"
-                         label={i18n.m('relationships.relatives.label.derived.permanent')}
-                         value="Permanent"
-                         className="derived-permanent"
-                         onValidate={this.props.onValidate}
-                         onChange={this.updateDerived}
-                         />
-                  <Radio name="derived-certificate"
-                         label={i18n.m('relationships.relatives.label.derived.certificate')}
-                         value="Certificate"
-                         className="derived-certificate"
-                         onValidate={this.props.onValidate}
-                         onChange={this.updateDerived}
-                         />
-                  <Radio name="derived-other"
-                         label={i18n.m('relationships.relatives.label.derived.other')}
-                         value="Other"
-                         className="derived-other"
-                         onValidate={this.props.onValidate}
-                         onChange={this.updateDerived}
-                         />
-                </RadioGroup>
-              </div>
+              {i18n.m('relationships.relatives.para.derived')}
+              <RadioGroup className="relative-derived option-list"
+                          selectedValue={this.state.Derived}>
+                <Radio name="derived-alien"
+                        label={i18n.m('relationships.relatives.label.derived.alien')}
+                        value="Alien"
+                        className="derived-alien"
+                        onValidate={this.props.onValidate}
+                        onChange={this.updateDerived}
+                        />
+                <Radio name="derived-permanent"
+                        label={i18n.m('relationships.relatives.label.derived.permanent')}
+                        value="Permanent"
+                        className="derived-permanent"
+                        onValidate={this.props.onValidate}
+                        onChange={this.updateDerived}
+                        />
+                <Radio name="derived-certificate"
+                        label={i18n.m('relationships.relatives.label.derived.certificate')}
+                        value="Certificate"
+                        className="derived-certificate"
+                        onValidate={this.props.onValidate}
+                        onChange={this.updateDerived}
+                        />
+                <Radio name="derived-other"
+                        label={i18n.m('relationships.relatives.label.derived.other')}
+                        value="Other"
+                        className="derived-other"
+                        onValidate={this.props.onValidate}
+                        onChange={this.updateDerived}
+                        />
+              </RadioGroup>
             </Field>
 
             <Field title={i18n.t('relationships.relatives.heading.us.number')}
-                   titleSize="h4"
+                   titleSize="h3"
                    help="relationships.relatives.help.documentnumber">
               <Text name="DocumentNumber"
                     className="relative-documentnumber"
@@ -609,7 +605,7 @@ export default class Relative extends ValidationElement {
             </Field>
 
             <Field title={i18n.t('relationships.relatives.heading.us.name')}
-                   titleSize="h4"
+                   titleSize="h3"
                    help="relationships.relatives.help.courtname">
               <Text name="CourtName"
                     className="relative-courtname"
@@ -620,7 +616,7 @@ export default class Relative extends ValidationElement {
             </Field>
 
             <Field title={i18n.t('relationships.relatives.heading.us.address')}
-                   titleSize="h4"
+                   titleSize="h3"
                    help="relationships.relatives.help.courtaddress"
                    adjustFor="address">
               <Address name="CourtAddress"

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -25,7 +25,7 @@ export default class Relative extends ValidationElement {
     super(props)
 
     this.state = {
-      Relations: props.Relations,
+      Relation: props.Relation,
       Name: props.Name,
       Birthdate: props.Birthdate,
       Birthplace: props.Birthplace,
@@ -63,7 +63,7 @@ export default class Relative extends ValidationElement {
     }
 
     this.onUpdate = this.onUpdate.bind(this)
-    this.updateRelations = this.updateRelations.bind(this)
+    this.updateRelation = this.updateRelation.bind(this)
     this.updateName = this.updateName.bind(this)
     this.updateBirthdate = this.updateBirthdate.bind(this)
     this.updateBirthplace = this.updateBirthplace.bind(this)
@@ -109,19 +109,8 @@ export default class Relative extends ValidationElement {
     })
   }
 
-  updateRelations (event) {
-    let relation = event.target.value
-    let selected = [...(this.state.Relations || [])]
-
-    if (selected.includes(relation)) {
-      // Remove the relation if it was previously selected
-      selected.splice(selected.indexOf(relation), 1)
-    } else {
-      // Add the relation if it wasn't already
-      selected.push(relation)
-    }
-
-    this.onUpdate('Relations', selected)
+  updateRelation (event) {
+    this.onUpdate('Relation', event.target.value)
   }
 
   updateName (values) {
@@ -214,7 +203,7 @@ export default class Relative extends ValidationElement {
 
   updateMethods (event) {
     let method = event.target.value
-    let selected = [...(this.state.Relations || [])]
+    let selected = [...(this.state.Methods || [])]
 
     if (selected.includes(method)) {
       // Remove the relation if it was previously selected
@@ -268,130 +257,131 @@ export default class Relative extends ValidationElement {
   }
 
   render () {
+    console.log('relation:', this.state.Relation)
     const validator = new RelativeValidator(this.state, null)
-    const mother = this.state.Relations.some(x => x === 'Mother')
-    const immediateFamily = this.state.Relations.some(x => ['Father', 'Mother', 'Child', 'Stepchild', 'Brother', 'Sister', 'Half-brother', 'Half-sister', 'Stepbrother', 'Stepsister', 'Stepmother', 'Stepfather'].includes(x))
+    const mother = this.state.Relation === 'Mother'
+    const immediateFamily = ['Father', 'Mother', 'Child', 'Stepchild', 'Brother', 'Sister', 'Half-brother', 'Half-sister', 'Stepbrother', 'Stepsister', 'Stepmother', 'Stepfather'].includes(this.state.Relation)
 
     return (
       <div className="relative-item">
         <Field title={i18n.t('relationships.relatives.heading.relation')}
                help="relationships.relatives.help.relation"
                adjustFor="big-buttons">
-          <CheckboxGroup className="relative-relation option-list"
-                         selectedValues={this.state.Relations}>
-            <Checkbox name="relation-mother"
-                      label={i18n.m('relationships.relatives.label.relation.mother')}
-                      value="Mother"
-                      className="relation-mother"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-father"
-                      label={i18n.m('relationships.relatives.label.relation.father')}
-                      value="Father"
-                      className="relation-father"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-stepmother"
-                      label={i18n.m('relationships.relatives.label.relation.stepmother')}
-                      value="Stepmother"
-                      className="relation-stepmother"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-stepfather"
-                      label={i18n.m('relationships.relatives.label.relation.stepfather')}
-                      value="Stepfather"
-                      className="relation-stepfather"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-fosterparent"
-                      label={i18n.m('relationships.relatives.label.relation.fosterparent')}
-                      value="Fosterparent"
-                      className="relation-fosterparent"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-child"
-                      label={i18n.m('relationships.relatives.label.relation.child')}
-                      value="Child"
-                      className="relation-child"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-stepchild"
-                      label={i18n.m('relationships.relatives.label.relation.stepchild')}
-                      value="Stepchild"
-                      className="relation-stepchild"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-brother"
-                      label={i18n.m('relationships.relatives.label.relation.brother')}
-                      value="Brother"
-                      className="relation-brother"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-sister"
-                      label={i18n.m('relationships.relatives.label.relation.sister')}
-                      value="Sister"
-                      className="relation-sister"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-stepbrother"
-                      label={i18n.m('relationships.relatives.label.relation.stepbrother')}
-                      value="Stepbrother"
-                      className="relation-stepbrother"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-stepsister"
-                      label={i18n.m('relationships.relatives.label.relation.stepsister')}
-                      value="Stepsister"
-                      className="relation-stepsister"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-halfbrother"
-                      label={i18n.m('relationships.relatives.label.relation.halfbrother')}
-                      value="Half-brother"
-                      className="relation-halfbrother"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-halfsister"
-                      label={i18n.m('relationships.relatives.label.relation.halfsister')}
-                      value="Half-sister"
-                      className="relation-halfsister"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-fatherinlaw"
-                      label={i18n.m('relationships.relatives.label.relation.fatherinlaw')}
-                      value="Father-in-law"
-                      className="relation-fatherinlaw"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-montherinlaw"
-                      label={i18n.m('relationships.relatives.label.relation.montherinlaw')}
-                      value="Monther-in-law"
-                      className="relation-montherinlaw"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-            <Checkbox name="relation-guardian"
-                      label={i18n.m('relationships.relatives.label.relation.guardian')}
-                      value="Guardian"
-                      className="relation-guardian"
-                      onValidate={this.props.onValidate}
-                      onChange={this.updateRelations}
-                      />
-          </CheckboxGroup>
+          <RadioGroup className="relative-relation option-list"
+                      selectedValue={this.state.Relation}>
+            <Radio name="relation-mother"
+                   label={i18n.m('relationships.relatives.label.relation.mother')}
+                   value="Mother"
+                   className="relation-mother"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-father"
+                   label={i18n.m('relationships.relatives.label.relation.father')}
+                   value="Father"
+                   className="relation-father"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-stepmother"
+                   label={i18n.m('relationships.relatives.label.relation.stepmother')}
+                   value="Stepmother"
+                   className="relation-stepmother"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-stepfather"
+                   label={i18n.m('relationships.relatives.label.relation.stepfather')}
+                   value="Stepfather"
+                   className="relation-stepfather"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-fosterparent"
+                   label={i18n.m('relationships.relatives.label.relation.fosterparent')}
+                   value="Fosterparent"
+                   className="relation-fosterparent"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-child"
+                   label={i18n.m('relationships.relatives.label.relation.child')}
+                   value="Child"
+                   className="relation-child"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-stepchild"
+                   label={i18n.m('relationships.relatives.label.relation.stepchild')}
+                   value="Stepchild"
+                   className="relation-stepchild"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-brother"
+                   label={i18n.m('relationships.relatives.label.relation.brother')}
+                   value="Brother"
+                   className="relation-brother"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-sister"
+                   label={i18n.m('relationships.relatives.label.relation.sister')}
+                   value="Sister"
+                   className="relation-sister"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-stepbrother"
+                   label={i18n.m('relationships.relatives.label.relation.stepbrother')}
+                   value="Stepbrother"
+                   className="relation-stepbrother"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-stepsister"
+                   label={i18n.m('relationships.relatives.label.relation.stepsister')}
+                   value="Stepsister"
+                   className="relation-stepsister"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-halfbrother"
+                   label={i18n.m('relationships.relatives.label.relation.halfbrother')}
+                   value="Half-brother"
+                   className="relation-halfbrother"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-halfsister"
+                   label={i18n.m('relationships.relatives.label.relation.halfsister')}
+                   value="Half-sister"
+                   className="relation-halfsister"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-fatherinlaw"
+                   label={i18n.m('relationships.relatives.label.relation.fatherinlaw')}
+                   value="Father-in-law"
+                   className="relation-fatherinlaw"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-montherinlaw"
+                   label={i18n.m('relationships.relatives.label.relation.montherinlaw')}
+                   value="Monther-in-law"
+                   className="relation-montherinlaw"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+            <Radio name="relation-guardian"
+                   label={i18n.m('relationships.relatives.label.relation.guardian')}
+                   value="Guardian"
+                   className="relation-guardian"
+                   onValidate={this.props.onValidate}
+                   onChange={this.updateRelation}
+                   />
+          </RadioGroup>
         </Field>
 
         <h3>{i18n.t('relationships.relatives.heading.name')}</h3>
@@ -475,8 +465,8 @@ export default class Relative extends ValidationElement {
                 </Field>
                 <Alias name="Item"
                        onValidate={this.props.onValidate}
-                       hideMaiden={this.state.Relations.some(x => x === 'Mother')}
-                       bind={true} />
+                       hideMaiden={this.state.Relation === 'Mother'}
+                  bind={true} />
               </div>
             </BranchCollection>
           </div>
@@ -939,7 +929,7 @@ export default class Relative extends ValidationElement {
 }
 
 Relative.defaultProps = {
-  Relations: [],
+  Relation: '',
   Name: {},
   Birthdate: {},
   Birthplace: {},

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -411,9 +411,9 @@ export default class Relative extends ValidationElement {
 
         <Field title={i18n.t('relationships.relatives.heading.birthplace')}
                help="relationships.relatives.help.birthplace"
-               adjustFor="button">
+               adjustFor="label">
           <BirthPlace name="Birthplace"
-                      label=""
+                      label={i18n.t('relationships.relatives.label.birthplace')}
                       help=""
                       cityPlaceholder={i18n.t('relationships.relatives.placeholder.city')}
                       countryPlaceholder={i18n.t('relationships.relatives.placeholder.country')}

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -474,8 +474,9 @@ export default class Relative extends ValidationElement {
                   <Svg src="img/date-down-arrow.svg" className="more arrow" />
                 </Field>
                 <Alias name="Item"
-                  onValidate={this.props.onValidate}
-                  bind={true} />
+                       onValidate={this.props.onValidate}
+                       hideMaiden={this.state.Relations.some(x => x === 'Mother')}
+                       bind={true} />
               </div>
             </BranchCollection>
           </div>
@@ -767,8 +768,8 @@ export default class Relative extends ValidationElement {
                        commentsName="MethodsComments"
                        commentsValue={this.state.MethodsComments}
                        commentsActive={(this.state.Methods || []).some(x => x === 'Other')}
-                       onUpdate={this.updateMethodsComments}
-                       adjustFor="big-buttons">
+                  onUpdate={this.updateMethodsComments}
+                  adjustFor="big-buttons">
                   <div>
                     {i18n.m('relationships.relatives.para.checkall')}
                     <CheckboxGroup className="relative-methods option-list"
@@ -903,10 +904,10 @@ export default class Relative extends ValidationElement {
                 </Field>
 
                 <NotApplicable name="EmployerRelationshipNotApplicable"
-                                label={i18n.t('relationships.relatives.label.idk')}
-                                or={i18n.m('relationships.relatives.para.or')}
-                                onValidate={this.props.onValidate}
-                                onUpdate={this.updateEmployerRelationshipNotApplicable}>
+                               label={i18n.t('relationships.relatives.label.idk')}
+                               or={i18n.m('relationships.relatives.para.or')}
+                               onValidate={this.props.onValidate}
+                               onUpdate={this.updateEmployerRelationshipNotApplicable}>
                   <Branch name="has_affiliation"
                           label={i18n.t('relationships.relatives.heading.employer.affiliated')}
                           labelSize="h3"
@@ -918,7 +919,7 @@ export default class Relative extends ValidationElement {
                   </Branch>
                   <Show when={this.state.HasAffiliation === 'Yes'}>
                     <Field title={i18n.t('relationships.relatives.heading.employer.relationship')}
-                            help="relationships.relatives.help.employerrelationship">
+                           help="relationships.relatives.help.employerrelationship">
                       <Textarea name="EmployerRelationship"
                                 className="relative-employer-relationship"
                                 {...this.state.EmployerRelationship}

--- a/src/components/Section/Relationships/Relatives/Relative.test.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.test.jsx
@@ -210,6 +210,8 @@ describe('The relative component', () => {
     expect(component.find('.relative-maidenname').length).toBeGreaterThan(0)
     component.find('.relative-maidenname .last input').simulate('change', { target: { value: 'maidenname' } })
     expect(updates).toBe(2)
+    component.find('.relative-alias .branch .yes input').simulate('change')
+    expect(component.find('.alias-maiden').length).toBe(0)
   })
 
   it('is immediate relationships?', () => {
@@ -230,14 +232,13 @@ describe('The relative component', () => {
     expect(component.find('.relative-alias .branch').length).toBeGreaterThan(0)
     component.find('.relative-alias .branch .yes input').simulate('change')
     component.find('.alias-name .first input').simulate('change', { target: { name: 'first', value: 'The name' } })
-    component.find('.alias-maiden .yes input').simulate('change')
     component.find('.alias-dates .datecontrol.from .month input').simulate('change', { target: { name: 'month', value: '1' } })
     component.find('.alias-dates .datecontrol.from .day input').simulate('change', { target: { name: 'day', value: '1' } })
     component.find('.alias-dates .datecontrol.from .year input').simulate('change', { target: { name: 'year', value: '2001' } })
     component.find('.alias-dates .datecontrol.to .month input').simulate('change', { target: { name: 'month', value: '1' } })
     component.find('.alias-dates .datecontrol.to .day input').simulate('change', { target: { name: 'day', value: '1' } })
     component.find('.alias-dates .datecontrol.to .year input').simulate('change', { target: { name: 'year', value: '2005' } })
-    expect(updates).toBe(9)
+    expect(updates).toBe(8)
   })
 
   it('is a citizen but lives abroad?', () => {

--- a/src/components/Section/Relationships/Relatives/Relative.test.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.test.jsx
@@ -79,8 +79,7 @@ describe('The relative component', () => {
         ]
       },
       Birthplace: {
-        addressType: 'International',
-        address: '1234 Some Rd',
+        domestic: 'No',
         city: 'Munich',
         country: 'Germany'
       },
@@ -106,8 +105,7 @@ describe('The relative component', () => {
         ]
       },
       Birthplace: {
-        addressType: 'International',
-        address: '1234 Some Rd',
+        domestic: 'No',
         city: 'Munich',
         country: 'Germany'
       },
@@ -130,8 +128,7 @@ describe('The relative component', () => {
         ]
       },
       Birthplace: {
-        addressType: 'International',
-        address: '1234 Some Rd',
+        domestic: 'No',
         city: 'Munich',
         country: 'Germany'
       },
@@ -154,8 +151,7 @@ describe('The relative component', () => {
         ]
       },
       Birthplace: {
-        addressType: 'International',
-        address: '1234 Some Rd',
+        domestic: 'No',
         city: 'Munich',
         country: 'Germany'
       },
@@ -185,11 +181,11 @@ describe('The relative component', () => {
     component.find('.relative-birthdate .day input').simulate('change', { target: { name: 'day', value: '1' } })
     component.find('.relative-birthdate .month input').simulate('change', { target: { name: 'month', value: '1' } })
     component.find('.relative-birthdate .year input').simulate('change', { target: { name: 'year', value: '2005' } })
-    component.find('.relative-birthplace .international input').simulate('change')
-    component.find('.relative-birthplace .country input#country').simulate('change', { target: { name: 'country', value: 'Germany' } })
+    component.find('.relative-birthplace .no input').simulate('change')
+    component.find('.relative-birthplace .city input').simulate('change', { target: { name: 'city', value: 'Munich' } })
     component.find('.relative-citizenship input').simulate('change', { target: { name: 'country', value: 'United States' } })
     component.find('.relative-deceased .no input').simulate('change')
-    expect(updates).toBe(8)
+    expect(updates).toBe(7)
   })
 
   it('are you my mother?', () => {
@@ -199,7 +195,7 @@ describe('The relative component', () => {
       Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
-      Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
+      Birthplace: { domestic: 'Yes', city: 'Arlington', state: 'Virginia' },
       Citizenship: { value: [{ name: 'United States', value: 'United States' }] },
       IsDeceased: 'No',
       onUpdate: (obj) => {
@@ -222,7 +218,7 @@ describe('The relative component', () => {
       Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
-      Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
+      Birthplace: { domestic: 'Yes', city: 'Arlington', state: 'Virginia' },
       Citizenship: { value: [{ name: 'United States', value: 'United States' }] },
       IsDeceased: 'No',
       onUpdate: (obj) => {
@@ -249,7 +245,7 @@ describe('The relative component', () => {
       Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
-      Birthplace: { addressType: 'International', address: '1234 Some Rd', city: 'Munich', country: 'Germany' },
+      Birthplace: { domestic: 'No', city: 'Munich', country: 'Germany' },
       Citizenship: { value: [{ name: 'United States', value: 'United States' }] },
       IsDeceased: 'No',
       Address: { addressType: 'International', address: '1234 Some Rd', city: 'Munich', country: 'Germany' },
@@ -275,7 +271,7 @@ describe('The relative component', () => {
       Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
-      Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
+      Birthplace: { domestic: 'Yes', city: 'Arlington', state: 'Virginia' },
       Citizenship: { value: [{ name: 'Germany', value: 'Germany' }] },
       IsDeceased: 'No',
       Address: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
@@ -302,7 +298,7 @@ describe('The relative component', () => {
       Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
-      Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
+      Birthplace: { domestic: 'Yes', city: 'Arlington', state: 'Virginia' },
       Citizenship: { value: [{ name: 'Germany', value: 'Germany' }] },
       IsDeceased: 'No',
       Address: { addressType: 'International', address: '1234 Some Rd', city: 'Munich', country: 'Germany' },

--- a/src/components/Section/Relationships/Relatives/Relative.test.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.test.jsx
@@ -44,7 +44,7 @@ describe('The relative component', () => {
     }
 
     const component = mount(<Relative {...expected} />)
-    component.find({ type: 'checkbox', value: 'Mother' }).simulate('change')
+    component.find({ type: 'radio', value: 'Mother' }).simulate('change')
     component.find('.relative-maiden-diff .no input').simulate('change')
     expect(component.find('.relative-maidenname').length).toEqual(1)
   })
@@ -55,7 +55,7 @@ describe('The relative component', () => {
     }
 
     const component = mount(<Relative {...expected} />)
-    component.find({ type: 'checkbox', value: 'Father' }).simulate('change')
+    component.find({ type: 'radio', value: 'Father' }).simulate('change')
     expect(component.find('.relative-alias').length).toEqual(1)
   })
 
@@ -195,7 +195,7 @@ describe('The relative component', () => {
     let updates = 0
     const expected = {
       name: 'relative',
-      Relations: ['Mother'],
+      Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
       Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
@@ -218,7 +218,7 @@ describe('The relative component', () => {
     let updates = 0
     const expected = {
       name: 'relative',
-      Relations: ['Mother'],
+      Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
       Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
@@ -245,7 +245,7 @@ describe('The relative component', () => {
     let updates = 0
     const expected = {
       name: 'relative',
-      Relations: ['Mother'],
+      Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
       Birthplace: { addressType: 'International', address: '1234 Some Rd', city: 'Munich', country: 'Germany' },
@@ -270,7 +270,7 @@ describe('The relative component', () => {
     let updates = 0
     const expected = {
       name: 'relative',
-      Relations: ['Mother'],
+      Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
       Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },
@@ -297,7 +297,7 @@ describe('The relative component', () => {
     let updates = 0
     const expected = {
       name: 'relative',
-      Relations: ['Mother'],
+      Relation: 'Mother',
       Name: { first: 'Foo', firstInitialOnly: false, middle: 'J', middleInitialOnly: true, noMiddleName: false, last: 'Bar', lastInitialOnly: false, suffix: 'Jr' },
       Birthdate: { day: '1', month: '1', year: '2016', date: new Date('1/1/2016') },
       Birthplace: { addressType: 'United States', address: '1234 Some Rd', city: 'Arlington', state: 'Virginia', zipcode: '22202' },

--- a/src/components/Section/Relationships/Relatives/Relative.test.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.test.jsx
@@ -23,6 +23,7 @@ describe('The relative component', () => {
     expect(component.find('.relative-naturalized').length).toEqual(0)
     expect(component.find('.relative-derived').length).toEqual(0)
     expect(component.find('.relative-documentnumber').length).toEqual(0)
+    expect(component.find('.relative-documentexpiration').length).toEqual(0)
     expect(component.find('.relative-courtname').length).toEqual(0)
     expect(component.find('.relative-courtaddress').length).toEqual(0)
     expect(component.find('.relative-document').length).toEqual(0)
@@ -261,9 +262,10 @@ describe('The relative component', () => {
     component.find('.relative-naturalized .naturalized-alien input').simulate('change')
     component.find('.relative-derived .derived-alien input').simulate('change')
     component.find('.relative-documentnumber input').simulate('change', { target: { value: 'documentnumber' } })
+    component.find('.relative-documentexpiration .day input').simulate('change', { target: { name: 'day', value: '1' } })
     component.find('.relative-courtname input').simulate('change', { target: { value: 'courtname' } })
     component.find('.relative-courtaddress .city input').simulate('change', { target: { name: 'city', value: 'The city' } })
-    expect(updates).toBe(6)
+    expect(updates).toBe(7)
   })
 
   it('is not a citizen but lives in the United States?', () => {

--- a/src/components/Section/Relationships/Relatives/Relatives.test.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.test.jsx
@@ -21,7 +21,7 @@ describe('The relatives component', () => {
       }
     }
     const component = mount(<Relatives {...expected} />)
-    component.find({ type: 'checkbox', value: 'Mother' }).simulate('change')
+    component.find({ type: 'radio', value: 'Mother' }).simulate('change')
     component.find('.relative-name .first input').simulate('change', { target: { name: 'first', value: 'The name' } })
     component.find('.relative-name .first input').simulate('change', { target: { name: 'first', value: '123123123' } })
     expect(updates).toBeGreaterThan(1)

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2151,7 +2151,8 @@ const en = {
           same: 'Same as listed',
           diff: 'Different name'
         },
-        estimated: 'Estimated'
+        estimated: 'Estimated',
+        birthplace: 'Was this person born in the United States of America?'
       },
       placeholder: {
         city: 'Please enter the city of birth',

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2153,6 +2153,10 @@ const en = {
         },
         estimated: 'Estimated'
       },
+      placeholder: {
+        city: 'Please enter the city of birth',
+        country: 'Please enter the country of birth'
+      },
       help: {
         relation: {
           title: 'Need help selecting relatives?',

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2012,6 +2012,7 @@ const en = {
         us: {
           title: 'U.S. Citizenship Documentation',
           documentation: 'Provide one type of citizenship documentation and document number below:',
+          expiration: 'Provide document expiration date',
           number: 'Provide the document number',
           name: 'Provide the name of the court that issued the Certificate of Naturalization',
           address: 'Provide the address of the court that issued the Certificate of Naturalization'
@@ -2149,7 +2150,8 @@ const en = {
         maiden: {
           same: 'Same as listed',
           diff: 'Different name'
-        }
+        },
+        estimated: 'Estimated'
       },
       help: {
         relation: {
@@ -2205,6 +2207,11 @@ const en = {
         documentnumber: {
           title: 'Need help with the document number?',
           message: 'Provide the document number for the citizenship',
+          note: ''
+        },
+        documentexpiration: {
+          title: 'Need help with the date of expiration?',
+          message: 'Provide the approximate date of expiration',
           note: ''
         },
         courtname: {

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2001,7 +2001,7 @@ const en = {
         alias: {
           branch: 'Has this relative used any additional names?',
           title: 'Provide other names used and the period of time that your relative used them.',
-          maiden: 'Maiden name?',
+          maiden: 'Was this their maiden name?',
           reason: 'Provide the reason(s) why the name changed.',
           additional: 'Has this relative used any additional names?'
         },

--- a/src/validators/birthplace.js
+++ b/src/validators/birthplace.js
@@ -5,6 +5,7 @@ export default class BirthPlaceValidator {
     this.city = state.city
     this.state = state.state
     this.county = state.county
+    this.hideCounty = (props || {}).hideCounty || false
   }
 
   /**
@@ -19,8 +20,10 @@ export default class BirthPlaceValidator {
       return false
     }
 
-    if (!this.county) {
-      return false
+    if (!this.hideCounty) {
+      if (!this.county) {
+        return false
+      }
     }
 
     if (!this.city) {
@@ -41,6 +44,7 @@ export default class BirthPlaceValidator {
     if (!this.city) {
       return false
     }
+
     return true
   }
 

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -44,6 +44,7 @@ export class RelativeValidator {
     this.derived = state.Derived
     this.derivedComments = state.DerivedComments
     this.documentNumber = state.DocumentNumber
+    this.documentExpiration = state.DocumentExpiration
     this.courtName = state.CourtName
     this.courtAddress = state.CourtAddress
     this.document = state.Document
@@ -187,6 +188,14 @@ export class RelativeValidator {
     return validGenericTextfield(this.documentNumber)
   }
 
+  validDocumentExpiration () {
+    if (!this.requiresCitizenshipDocumentation()) {
+      return true
+    }
+
+    return !!this.documentExpiration && validDateField(this.documentExpiration)
+  }
+
   validCourtName () {
     if (!this.requiresCitizenshipDocumentation()) {
       return true
@@ -311,6 +320,7 @@ export class RelativeValidator {
       this.validNaturalized() &&
       this.validDerived() &&
       this.validDocumentNumber() &&
+      this.validDocumentExpiration() &&
       this.validCourtName() &&
       this.validCourtAddress() &&
       this.validDocument() &&

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -29,7 +29,7 @@ export default class RelativesValidator {
 
 export class RelativeValidator {
   constructor (state = {}, props = {}) {
-    this.relations = state.Relations || []
+    this.relation = state.Relation || []
     this.name = state.Name
     this.birthdate = state.Birthdate
     this.birthplace = state.Birthplace
@@ -70,7 +70,7 @@ export class RelativeValidator {
     const relations = ['Father', 'Mother', 'Child', 'Stepchild', 'Brother', 'Sister', 'Half-brother', 'Half-sister', 'Stepbrother', 'Stepsister', 'Stepmother', 'Stepfather']
     const citizen = this.citizen()
 
-    if (this.relations && this.relations.some(x => relations.includes(x)) && citizen && this.birthplace.addressType === 'International' && this.isDeceased === 'Yes') {
+    if (this.relation && relations.includes(this.relation) && citizen && this.birthplace.addressType === 'International' && this.isDeceased === 'Yes') {
       return true
     }
 
@@ -89,8 +89,8 @@ export class RelativeValidator {
     return false
   }
 
-  validRelations () {
-    return this.relations.length > 0
+  validRelation () {
+    return !!this.relation && this.relation.length > 0
   }
 
   validName () {
@@ -128,7 +128,7 @@ export class RelativeValidator {
         continue
       }
 
-      const props = { hideMaiden: this.relations.some(x => x === 'Mother') }
+      const props = { hideMaiden: this.relation === 'Mother' }
       if (has && new AliasValidator(alias.Item, props).isValid() === false) {
         return false
       }
@@ -298,7 +298,7 @@ export class RelativeValidator {
   }
 
   isValid () {
-    return this.validRelations() &&
+    return this.validRelation() &&
       this.validName() &&
       this.validBirthdate() &&
       this.validBirthplace() &&

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -1,5 +1,6 @@
 import NameValidator from './name'
 import AddressValidator from './address'
+import BirthPlaceValidator from './birthplace'
 import DateRangeValidator from './daterange'
 import { validDateField, validGenericTextfield } from './helpers'
 
@@ -71,19 +72,19 @@ export class RelativeValidator {
     const relations = ['Father', 'Mother', 'Child', 'Stepchild', 'Brother', 'Sister', 'Half-brother', 'Half-sister', 'Stepbrother', 'Stepsister', 'Stepmother', 'Stepfather']
     const citizen = this.citizen()
 
-    if (this.relation && relations.includes(this.relation) && citizen && this.birthplace.addressType === 'International' && this.isDeceased === 'Yes') {
+    if (this.relation && relations.includes(this.relation) && citizen && this.birthplace.domestic === 'No' && this.isDeceased === 'Yes') {
       return true
     }
 
-    if (this.address && this.address.addressType === 'United States' && this.birthplace.addressType === 'International' && citizen) {
+    if (this.address && this.address.addressType === 'United States' && this.birthplace.domestic === 'No' && citizen) {
       return true
     }
 
-    if (this.address && this.address.addressType === 'APOFPO' && this.birthplace.addressType === 'International' && citizen) {
+    if (this.address && this.address.addressType === 'APOFPO' && this.birthplace.domestic === 'No' && citizen) {
       return true
     }
 
-    if (this.birthplace && this.birthplace.addressType === 'International' && citizen) {
+    if (this.birthplace && this.birthplace.domestic === 'No' && citizen) {
       return true
     }
 
@@ -103,7 +104,7 @@ export class RelativeValidator {
   }
 
   validBirthplace () {
-    return !!this.birthplace && new AddressValidator(this.birthplace, null).isValid()
+    return !!this.birthplace && new BirthPlaceValidator(this.birthplace, { hideCounty: true }).isValid()
   }
 
   validCitizenship () {

--- a/src/validators/relatives.js
+++ b/src/validators/relatives.js
@@ -128,7 +128,8 @@ export class RelativeValidator {
         continue
       }
 
-      if (has && new AliasValidator(alias.Item, null).isValid() === false) {
+      const props = { hideMaiden: this.relations.some(x => x === 'Mother') }
+      if (has && new AliasValidator(alias.Item, props).isValid() === false) {
         return false
       }
     }
@@ -331,6 +332,7 @@ export class AliasValidator {
     this.maidenName = state.MaidenName
     this.dates = state.Dates
     this.reason = state.Reason
+    this.hideMaiden = props.hideMaiden
   }
 
   validName () {
@@ -338,6 +340,10 @@ export class AliasValidator {
   }
 
   validMaidenName () {
+    if (this.hideMaiden) {
+      return true
+    }
+
     return !!this.maidenName && (this.maidenName === 'No' || this.maidenName === 'Yes')
   }
 

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -104,11 +104,10 @@ describe('Relatives validation', function () {
       {
         state: {
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            country: 'United States',
             city: 'Arlington',
-            state: 'Virginia',
-            zipcode: '22202'
+            state: 'VA',
+            domestic: 'Yes'
           }
         },
         expected: true
@@ -377,10 +376,11 @@ describe('Relatives validation', function () {
           },
           IsDeceased: 'Yes',
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
-            city: 'Munich',
-            country: 'Germany'
+            country: 'Germany',
+            city: 'Arlington',
+            county: 'Arlington',
+            state: '',
+            domestic: 'No'
           }
         },
         expected: true
@@ -393,10 +393,11 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
-            city: 'Munich',
-            country: 'Germany'
+            country: 'Germany',
+            city: 'Arlington',
+            county: 'Arlington',
+            state: '',
+            domestic: 'No'
           },
           Address: {
             addressType: 'United States',
@@ -416,10 +417,11 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
-            city: 'Munich',
-            country: 'Germany'
+            country: 'Germany',
+            city: 'Arlington',
+            county: 'Arlington',
+            state: '',
+            domestic: 'No'
           },
           Address: {
             addressType: 'APOFPO',
@@ -439,10 +441,11 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
-            city: 'Munich',
-            country: 'Germany'
+            country: 'Germany',
+            city: 'Arlington',
+            county: 'Arlington',
+            state: '',
+            domestic: 'No'
           }
         },
         expected: true
@@ -489,11 +492,11 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            country: 'United States',
             city: 'Arlington',
-            state: 'Virginia',
-            zipcode: '22202'
+            county: 'Arlington',
+            state: 'VA',
+            domestic: 'Yes'
           },
           IsDeceased: 'No',
           Address: {
@@ -515,8 +518,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -540,8 +542,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -588,11 +589,10 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            domestic: 'Yes',
             city: 'Arlington',
             state: 'Virginia',
-            zipcode: '22202'
+            country: 'United States'
           },
           IsDeceased: 'No',
           Address: {
@@ -614,8 +614,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -639,8 +638,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -687,11 +685,10 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            domestic: 'Yes',
             city: 'Arlington',
             state: 'Virginia',
-            zipcode: '22202'
+            country: 'United States'
           },
           IsDeceased: 'No',
           Address: {
@@ -713,8 +710,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -738,8 +734,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -786,11 +781,10 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            domestic: 'Yes',
             city: 'Arlington',
             state: 'Virginia',
-            zipcode: '22202'
+            country: 'United States'
           },
           IsDeceased: 'No',
           Address: {
@@ -812,8 +806,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -837,8 +830,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -887,11 +879,10 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            domestic: 'Yes',
             city: 'Arlington',
             state: 'Virginia',
-            zipcode: '22202'
+            country: 'United States'
           },
           IsDeceased: 'No',
           Address: {
@@ -913,8 +904,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -940,8 +930,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -997,11 +986,10 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            domestic: 'Yes',
             city: 'Arlington',
             state: 'Virginia',
-            zipcode: '22202'
+            country: 'United States'
           },
           Address: {
             addressType: 'United States',
@@ -1022,8 +1010,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -1047,8 +1034,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -1097,11 +1083,10 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'United States',
-            address: '1234 Some Rd',
+            domestic: 'Yes',
             city: 'Arlington',
             state: 'Virginia',
-            zipcode: '22202'
+            country: 'United States'
           },
           IsDeceased: 'No',
           Address: {
@@ -1123,8 +1108,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -1148,8 +1132,7 @@ describe('Relatives validation', function () {
             ]
           },
           Birthplace: {
-            addressType: 'International',
-            address: '1234 Some Rd',
+            domestic: 'No',
             city: 'Munich',
             country: 'Germany'
           },
@@ -1742,11 +1725,10 @@ describe('Relatives validation', function () {
                   date: new Date('1/1/2016')
                 },
                 Birthplace: {
-                  addressType: 'United States',
-                  address: '1234 Some Rd',
+                  domestic: 'Yes',
                   city: 'Arlington',
                   state: 'Virginia',
-                  zipcode: '22202'
+                  country: 'United States'
                 },
                 Citizenship: {
                   value: [
@@ -1810,6 +1792,7 @@ describe('Relatives validation', function () {
     ]
 
     tests.forEach(test => {
+      console.log('-------------------------------')
       expect(new RelativesValidator(test.state, null).isValid()).toBe(test.expected)
     })
   })

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -208,11 +208,17 @@ describe('Relatives validation', function () {
       {
         state: {
         },
+        props: {
+          hideMaiden: false
+        },
         expected: false
       },
       {
         state: {
           Aliases: []
+        },
+        props: {
+          hideMaiden: false
         },
         expected: false
       },
@@ -224,6 +230,9 @@ describe('Relatives validation', function () {
             }
           ]
         },
+        props: {
+          hideMaiden: false
+        },
         expected: true
       },
       {
@@ -233,6 +242,9 @@ describe('Relatives validation', function () {
               Has: 'Yes'
             }
           ]
+        },
+        props: {
+          hideMaiden: false
         },
         expected: false
       },
@@ -269,12 +281,15 @@ describe('Relatives validation', function () {
             }
           ]
         },
+        props: {
+          hideMaiden: false
+        },
         expected: true
       }
     ]
 
     tests.forEach(test => {
-      expect(new RelativeValidator(test.state, null).validAliases()).toBe(test.expected)
+      expect(new RelativeValidator(test.state, test.props).validAliases()).toBe(test.expected)
     })
   })
 

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -862,6 +862,115 @@ describe('Relatives validation', function () {
     })
   })
 
+  it('validate relative requires citizenship documentation document expiration', () => {
+    const tests = [
+      {
+        state: {
+          Relation: 'Father',
+          IsDeceased: 'Yes'
+        },
+        expected: true
+      },
+      {
+        state: {
+          Relation: 'Father',
+          IsDeceased: 'No'
+        },
+        expected: true
+      },
+      {
+        state: {
+          Relation: 'Father',
+          Citizenship: {
+            value: [
+              { name: 'United States', value: 'United States' }
+            ]
+          },
+          Birthplace: {
+            addressType: 'United States',
+            address: '1234 Some Rd',
+            city: 'Arlington',
+            state: 'Virginia',
+            zipcode: '22202'
+          },
+          IsDeceased: 'No',
+          Address: {
+            addressType: 'United States',
+            address: '1234 Some Rd',
+            city: 'Arlington',
+            state: 'Virginia',
+            zipcode: '22202'
+          }
+        },
+        expected: true
+      },
+      {
+        state: {
+          Relation: 'Father',
+          Citizenship: {
+            value: [
+              { name: 'United States', value: 'United States' }
+            ]
+          },
+          Birthplace: {
+            addressType: 'International',
+            address: '1234 Some Rd',
+            city: 'Munich',
+            country: 'Germany'
+          },
+          IsDeceased: 'No',
+          Address: {
+            addressType: 'International',
+            address: '1234 Some Rd',
+            city: 'Munich',
+            country: 'Germany'
+          },
+          DocumentNumber: {
+            value: '11111111111111111'
+          }
+        },
+        expected: false
+      },
+      {
+        state: {
+          Relation: 'Father',
+          Citizenship: {
+            value: [
+              { name: 'United States', value: 'United States' }
+            ]
+          },
+          Birthplace: {
+            addressType: 'International',
+            address: '1234 Some Rd',
+            city: 'Munich',
+            country: 'Germany'
+          },
+          IsDeceased: 'No',
+          Address: {
+            addressType: 'International',
+            address: '1234 Some Rd',
+            city: 'Munich',
+            country: 'Germany'
+          },
+          DocumentNumber: {
+            value: '0000000000000'
+          },
+          DocumentExpiration: {
+            day: '1',
+            month: '1',
+            year: '2016',
+            date: new Date('1/1/2016')
+          }
+        },
+        expected: true
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(new RelativeValidator(test.state, null).validDocumentExpiration()).toBe(test.expected)
+    })
+  })
+
   it('validate relative requires citizenship documentation court name', () => {
     const tests = [
       {

--- a/src/validators/relatives.test.js
+++ b/src/validators/relatives.test.js
@@ -5,20 +5,20 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: []
+          Relation: ''
         },
         expected: false
       },
       {
         state: {
-          Relations: ['Mother']
+          Relation: 'Mother'
         },
         expected: true
       }
     ]
 
     tests.forEach(test => {
-      expect(new RelativeValidator(test.state, null).validRelations()).toBe(test.expected)
+      expect(new RelativeValidator(test.state, null).validRelation()).toBe(test.expected)
     })
   })
 
@@ -369,7 +369,7 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -468,21 +468,21 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -508,7 +508,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -533,7 +533,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -567,21 +567,21 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -607,7 +607,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -632,7 +632,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -666,21 +666,21 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -706,7 +706,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -731,7 +731,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -765,21 +765,21 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -805,7 +805,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -830,7 +830,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -866,21 +866,21 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No',
           Citizenship: {
             value: [
@@ -906,7 +906,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -931,7 +931,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -967,21 +967,21 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'No'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -1007,7 +1007,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -1032,7 +1032,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -1071,14 +1071,14 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -1090,7 +1090,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'Germany', value: 'Germany' }
@@ -1103,7 +1103,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'Germany', value: 'Germany' }
@@ -1125,14 +1125,14 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -1144,7 +1144,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'Germany', value: 'Germany' }
@@ -1157,7 +1157,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'Germany', value: 'Germany' }
@@ -1181,14 +1181,14 @@ describe('Relatives validation', function () {
     const tests = [
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           IsDeceased: 'Yes'
         },
         expected: true
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'United States', value: 'United States' }
@@ -1200,7 +1200,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'Germany', value: 'Germany' }
@@ -1213,7 +1213,7 @@ describe('Relatives validation', function () {
       },
       {
         state: {
-          Relations: ['Father'],
+          Relation: 'Father',
           Citizenship: {
             value: [
               { name: 'Germany', value: 'Germany' }
@@ -1603,7 +1603,7 @@ describe('Relatives validation', function () {
           List: [
             {
               Item: {
-                Relations: ['Mother']
+                Relation: 'Mother'
               }
             }
           ]
@@ -1615,7 +1615,7 @@ describe('Relatives validation', function () {
           List: [
             {
               Item: {
-                Relations: ['Mother'],
+                Relation: 'Mother',
                 Name: {
                   first: 'Foo',
                   firstInitialOnly: false,


### PR DESCRIPTION
Issues: 

 - #1214: Update maiden name text
 - #1209: Maiden name is conditional used in the relatives additional names
 - #1210: Made relative relation a single value instead of an array
 - #1223: Removed a continuation arrow and increased headers
 - #1224: Added field for document expiration
 - #1182: Applied a ceiling of `31` to days in month
 - #1189: POB is now using the `BirthPlace` component