### PR TITLE
Dropdown displaytext

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -66,6 +66,7 @@ export default class DateControl extends ValidationElement {
       validity: [null, null, null],
       errorCodes: []
     }
+    this.beforeChange = this.beforeChange.bind(this)
   }
 
   componentWillReceiveProps (next) {
@@ -307,6 +308,14 @@ export default class DateControl extends ValidationElement {
       })
   }
 
+  beforeChange (value) {
+    return value.replace(/\D/g, '')
+  }
+
+  monthDisplayText (value, name) {
+    return `${name} (${value})`.trim()
+  }
+
   render () {
     let klass = `datecontrol ${this.props.className || ''} ${this.props.hideDay ? 'day-hidden' : ''}`.trim()
     return (
@@ -324,12 +333,12 @@ export default class DateControl extends ValidationElement {
                       readonly={this.props.readonly}
                       required={this.props.required}
                       onChange={this.handleChange}
+                      beforeChange={this.beforeChange}
                       onFocus={this.handleFocus}
                       onBlur={this.handleBlur}
                       onValidate={this.handleValidation}
-                      tabNext={() => { this.refs.day.refs.number.refs.input.focus() }}
-                      >
-              <option key="jan" value="Janurary">1</option>
+                      displayText={this.monthDisplayText}>
+              <option key="jan" value="January">1</option>
               <option key="feb" value="February">2</option>
               <option key="mar" value="March">3</option>
               <option key="apr" value="April">4</option>

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -308,7 +308,7 @@ export default class DateControl extends ValidationElement {
       })
   }
 
-  beforeChange (value) {
+  beforeChange (value = '') {
     return value.replace(/\D/g, '')
   }
 
@@ -337,7 +337,8 @@ export default class DateControl extends ValidationElement {
                       onFocus={this.handleFocus}
                       onBlur={this.handleBlur}
                       onValidate={this.handleValidation}
-                      displayText={this.monthDisplayText}>
+                      displayText={this.monthDisplayText}
+                      tabNext={() => { this.refs.day.refs.number.refs.input.focus() }}>
               <option key="jan" value="January">1</option>
               <option key="feb" value="February">2</option>
               <option key="mar" value="March">3</option>

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -308,7 +308,7 @@ export default class DateControl extends ValidationElement {
       })
   }
 
-  beforeChange (value = '') {
+  beforeChange (value) {
     return value.replace(/\D/g, '')
   }
 

--- a/src/components/Form/DateControl/DateControl.scss
+++ b/src/components/Form/DateControl/DateControl.scss
@@ -3,7 +3,7 @@
   width: initial !important;
 
   .month {
-    width: 14rem;
+    width: 15rem;
     display: inline-block;
     margin-right: 1rem;
     vertical-align: top;

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -79,7 +79,7 @@ describe('The date component', () => {
     const component = mount(<DateControl {...expected} />)
     expect(component.find('label').length).toEqual(children)
     expect(component.find('input#day').length).toEqual(1)
-    expect(component.find('input#month').nodes[0].value).toEqual('1')
+    expect(component.find('input#month').nodes[0].value).toEqual('1 (January)')
     expect(component.find('input#day').nodes[0].value).toEqual('28')
     expect(component.find('input#year').nodes[0].value).toEqual('2016')
     expect(component.find('.usa-input-error-label').length).toEqual(0)

--- a/src/components/Form/Dropdown/Dropdown.test.jsx
+++ b/src/components/Form/Dropdown/Dropdown.test.jsx
@@ -56,4 +56,46 @@ describe('The Dropdown component', () => {
     expect(component.find({ type: 'text', name: 'dropdown', value: '111' }).length).toBe(0)
     expect(component.find({ type: 'text', name: 'dropdown', value: '' }).length).toBe(1)
   })
+
+  it('executes default displayText func', () => {
+    const expected = {
+      name: 'state',
+      value: 'foo',
+      maxlength: '1',
+      className: 'dropdown-test',
+      focus: false
+    }
+    const component = mount(
+      <Dropdown {...expected}>
+        <option name="foo" value="bar">Foo</option>
+        <option name="bar" value="foo">Bar</option>
+      </Dropdown>
+    )
+    expect(component.find('div.dropdown-test').length).toEqual(1)
+    component.find('input').simulate('focus')
+    expect(component.state().value).toBe('Bar')
+  })
+
+  it('executes custom displayText func', () => {
+    const expected = {
+      name: 'state',
+      value: 'foo',
+      maxlength: '1',
+      className: 'dropdown-test',
+      displayText: (value, name) => {
+        return `${value}---${name}`.trim()
+      },
+      focus: false
+    }
+    const component = mount(
+      <Dropdown {...expected}>
+        <option name="foo" value="bar">Foo</option>
+        <option name="bar" value="foo">Bar</option>
+      </Dropdown>
+    )
+    expect(component.find('div.dropdown-test').length).toEqual(1)
+    expect(component.find('input').nodes[0].value).toEqual('foo---Bar')
+    component.find('input').simulate('focus')
+    expect(component.state().value).toBe('Bar')
+  })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -45,7 +45,7 @@ describe('The cohabitant component', () => {
     component.find('.dateseparated input#month').simulate('change', { target: { value: '12' } })
     component.find('.address-separated input#address').simulate('change')
     component.find('.address-separated input[name="OtherNameNotApplicable"]').simulate('change')
-    expect(updates).toBe(26)
+    expect(updates).toBe(27)
   })
 
   it('renders current address', () => {


### PR DESCRIPTION
#1206 
- Added `displayText` hook in Dropdown to render user friendly representation of a dropdown value
- Added `beforeChange` hook in Dropdown to allow value to be modified before being set
- Month dropdown only allows numerical values