### PR TITLE
Shrunk the height and adjusted vertical alignment for relation types

### DIFF
--- a/src/components/Section/Relationships/Relatives/Relative.scss
+++ b/src/components/Section/Relationships/Relatives/Relative.scss
@@ -11,7 +11,26 @@
     }
   }
 
-  .relative-relation label,
+  .relative-relation label {
+    height: 6rem;
+    width: 18rem;
+    overflow: hidden;
+
+    > span > div {
+      top: 28%;
+    }
+  }
+
+  .relation-child > label > span {
+    > div:not(:last-of-type) {
+      top: 18%;
+    }
+
+    > div:not(:first-of-type) {
+      margin-top: -3rem;
+    }
+  }
+
   .relative-abroad label,
   .relative-naturalized label,
   .relative-derived label,
@@ -36,6 +55,7 @@
       }
     }
   }
+
   h3.relative-citizenship-documentation {
     margin-bottom: 2.1rem;
   }


### PR DESCRIPTION
Issue: #1298

In order to get four columns we would have to remove the subtext to
the option of "Child".

## Preview
![relations-smaller](https://cloud.githubusercontent.com/assets/697855/26733942/6e91635a-478a-11e7-9ba9-4822807acb98.png)

