### PR TITLE
DateControl bug fixes

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -6,15 +6,6 @@ import Dropdown from '../Dropdown'
 import { daysInMonth, validDate } from '../../Section/History/dateranges'
 import DateControlValidator from '../../../validators/datecontrol'
 
-export const trimLeadingZero = (num) => {
-  if (isNaN(num)) {
-    return num
-  }
-
-  const i = parseInt(`0${num}`, 10)
-  return i === 0 ? '' : '' + i
-}
-
 export const datePart = (part, date) => {
   if (!date) {
     return ''
@@ -59,9 +50,9 @@ export default class DateControl extends ValidationElement {
       error: props.error,
       valid: props.valid,
       maxDate: props.maxDate,
-      month: trimLeadingZero(props.month) || datePart('m', props.value),
-      day: trimLeadingZero(props.day) || props.hideDay ? 1 : datePart('d', props.value),
-      year: trimLeadingZero(props.year) || datePart('y', props.value),
+      month: props.month || datePart('m', props.value),
+      day: props.day || props.hideDay ? 1 : datePart('d', props.value),
+      year: props.year || datePart('y', props.value),
       foci: [false, false, false],
       validity: [null, null, null],
       errorCodes: []
@@ -126,11 +117,11 @@ export default class DateControl extends ValidationElement {
     const name = target.name || target.id || ''
 
     if (name.indexOf('month') !== -1) {
-      month = trimLeadingZero(event.target.value)
+      month = event.target.value
     } else if (name.indexOf('day') !== -1) {
-      day = trimLeadingZero(event.target.value)
+      day = event.target.value
     } else if (name.indexOf('year') !== -1) {
-      year = trimLeadingZero(event.target.value)
+      year = event.target.value
     } else if (name.indexOf('estimated') !== -1) {
       estimated = event.target.checked
     }
@@ -312,6 +303,15 @@ export default class DateControl extends ValidationElement {
               <option key="jul" value="7">July</option>
               <option key="aug" value="8">August</option>
               <option key="sep" value="9">September</option>
+              <option key="ja0" value="01">January</option>
+              <option key="fe0" value="02">February</option>
+              <option key="ma0" value="03">March</option>
+              <option key="ap0" value="04">April</option>
+              <option key="ma0" value="05">May</option>
+              <option key="ju0" value="06">June</option>
+              <option key="ju0" value="07">July</option>
+              <option key="au0" value="08">August</option>
+              <option key="se0" value="09">September</option>
               <option key="oct" value="10">October</option>
               <option key="nov" value="11">November</option>
               <option key="dec" value="12">December</option>
@@ -350,7 +350,7 @@ export default class DateControl extends ValidationElement {
                     disabled={this.state.disabled}
                     min="1000"
                     max={this.props.maxDate && this.props.maxDate.getFullYear()}
-                    maxlength={this.props.maxDate && `${('' + this.props.maxDate.getFullYear()).length}`}
+                    maxlength="4"
                     pattern={this.props.pattern}
                     readonly={this.props.readonly}
                     step="1"

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import DateControl, { trimLeadingZero, datePart } from './DateControl'
+import DateControl, { datePart } from './DateControl'
 
 describe('The date component', () => {
   const children = 4
@@ -222,23 +222,6 @@ describe('The date component', () => {
     const component = mount(<DateControl {...expected} />)
     component.find('input[type="checkbox"]').simulate('change')
     expect(updates).toBe(1)
-  })
-
-  it('trims leading zeros', () => {
-    const tests = [
-      {
-        value: '01',
-        expected: '1'
-      },
-      {
-        value: '1f',
-        expected: '1f'
-      }
-    ]
-
-    tests.forEach(test => {
-      expect(trimLeadingZero(test.value)).toBe(test.expected)
-    })
   })
 
   it('parses date part', () => {

--- a/src/components/Form/Number/Number.jsx
+++ b/src/components/Form/Number/Number.jsx
@@ -2,20 +2,12 @@ import React from 'react'
 import ValidationElement from '../ValidationElement'
 import Generic from '../Generic'
 
-export const trimLeadingZero = (num) => {
-  if (isNaN(num) || num === '') {
-    return ''
-  }
-
-  return '' + parseInt(`0${num}`, 10)
-}
-
 export default class Number extends ValidationElement {
   constructor (props) {
     super(props)
 
     this.state = {
-      value: trimLeadingZero(props.value),
+      value: isNaN(props.value) ? '' : props.value,
       max: props.max
     }
 
@@ -28,7 +20,7 @@ export default class Number extends ValidationElement {
     }
 
     const old = this.state.max
-    this.setState({ max: next.max, value: trimLeadingZero(next.value) }, () => {
+    this.setState({ max: next.max, value: next.value }, () => {
       if (old !== next.max) {
         this.handleValidation(
           {
@@ -53,7 +45,7 @@ export default class Number extends ValidationElement {
       value = value.replace(/\D/g, '')
     }
 
-    this.setState({ value: trimLeadingZero(value) }, () => {
+    this.setState({ value: value }, () => {
       super.handleChange(event)
       if (this.props.onUpdate) {
         this.props.onUpdate({

--- a/src/components/Form/Number/Number.test.jsx
+++ b/src/components/Form/Number/Number.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import Number, { trimLeadingZero } from './Number'
+import Number from './Number'
 
 describe('The number component', () => {
   it('default value is not numeric displays as empty', () => {
@@ -54,18 +54,5 @@ describe('The number component', () => {
     const component = mount(<Number {...expected} />)
     component.find('input').simulate('change', { target: { value: '100a' } })
     expect(component.find({ type: 'text', value: expected.value }).length).toEqual(1)
-  })
-
-  it('trims zeroes appropriately', () => {
-    const tests = [
-      { given: '0', expected: '0' },
-      { given: '', expected: '' },
-      { given: '100', expected: '100' },
-      { given: '010', expected: '10' }
-    ]
-
-    tests.forEach(test => {
-      expect(trimLeadingZero(test.given)).toBe(test.expected)
-    })
   })
 })

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.test.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.test.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Bankruptcies from './Bankruptcies'
 
-describe('The bankruptcy component', () => {
+describe('The bankruptcies component', () => {
   it('no error on empty', () => {
     const expected = {
       name: 'bankruptcy'
@@ -43,12 +43,12 @@ describe('The bankruptcy component', () => {
             value: 'C1234'
           },
           DateFiled: {
-            month: 1,
-            year: 2010
+            month: '1',
+            year: '2010'
           },
           DateDischarged: {
-            month: 1,
-            year: 2012
+            month: '1',
+            year: '2012'
           },
           NameDebt: {
             first: 'Foo',


### PR DESCRIPTION
Issue: #1330

If `maxDate` was null then it allowed more than 4 digits in the
year. This has been set explicitly to "4" now.

Issue: #1248

Allow leading zeroes in the number and date control components.