### PR TITLE
Fix hit area issue on navigation buttons

### DIFF
--- a/src/components/Section/SectionView.jsx
+++ b/src/components/Section/SectionView.jsx
@@ -13,41 +13,37 @@ export class SectionViews extends React.Component {
       const currentSection = this.props.current || ''
       // If the current route name matches one of the section view child component names
       if (currentSection === child.props.name) {
-        let previousButton = null
+        let previousButton = <div className="btn-cell"></div>
         if (child.props.back) {
           previousButton = (
-            <div className="btn-cell btn-prev">
-              <button className="back" onClick={this.handleTransition.bind(this, child.props.back)}>
-                <div className="actions back">
-                  <div className="icon">
-                    <i className="fa fa-arrow-circle-left" aria-hidden="true"></i>
-                  </div>
-                  <div className="text">
-                    <div className="direction">Back</div>
-                    <div className="label">{child.props.backLabel}</div>
-                  </div>
+            <button className="btn-cell back" onClick={this.handleTransition.bind(this, child.props.back)}>
+              <div className="actions back">
+                <div className="icon">
+                  <i className="fa fa-arrow-circle-left" aria-hidden="true"></i>
                 </div>
-              </button>
-            </div>
+                <div className="text">
+                  <div className="direction">Back</div>
+                  <div className="label">{child.props.backLabel}</div>
+                </div>
+              </div>
+            </button>
           )
         }
 
-        let nextButton = null
+        let nextButton = <div className="btn-cell"></div>
         if (child.props.next) {
           nextButton = (
-            <div className="btn-cell btn-next">
-              <button className="next" onClick={this.handleTransition.bind(this, child.props.next)}>
-                <div className="actions next">
-                  <div className="text">
-                    <div className="direction">Next</div>
-                    <div className="label">{child.props.nextLabel}</div>
-                  </div>
-                  <div className="icon">
-                    <i className="fa fa-arrow-circle-right" aria-hidden="true"></i>
-                  </div>
+            <button className="btn-cell next" onClick={this.handleTransition.bind(this, child.props.next)}>
+              <div className="actions next">
+                <div className="text">
+                  <div className="direction">Next</div>
+                  <div className="label">{child.props.nextLabel}</div>
                 </div>
-              </button>
-            </div>
+                <div className="icon">
+                  <i className="fa fa-arrow-circle-right" aria-hidden="true"></i>
+                </div>
+              </div>
+            </button>
           )
         }
 

--- a/src/components/Section/SectionView.scss
+++ b/src/components/Section/SectionView.scss
@@ -13,23 +13,34 @@
   }
 
   .btn-wrap {
-    display: table;
+    display: block;
     width: 100%;
 
     .btn-container {
-      display: table-row;
+      display: flex;
 
       .btn-cell,
       .btn-spacer {
-        display: table-cell;
+        display: inline-block;
         vertical-align: middle;
       }
 
       .btn-cell {
         width: 30%;
+      }
+
+      .btn-spacer {
+        width: 40%;
+      }
+
+      .btn-cell.back,
+      .btn-cell.next {
         border-radius: 3px;
         transition: background-color 0.3s;
         background-color: $eapp-blue;
+        margin: 0;
+        line-height: normal !important;
+        padding: 1.5rem 2rem;
 
         .next {
           text-align: right;
@@ -39,41 +50,29 @@
           background-color: $eapp-blue-dark;
         }
 
-        button {
-          margin: 0;
-          line-height: normal !important;
+        .actions {
+          display: table;
           width: 100%;
-          padding: 1.5rem 2rem;
-          background: none;
 
-          &:hover {
-            background: none;
+          .direction {
+            font-weight: 600;
           }
 
-          .actions {
-            display: table;
-            width: 100%;
+          .text, .icon {
+            display: table-cell;
+            vertical-align: middle;
+          }
 
-            .direction {
-              font-weight: 600;
-            }
+          .icon {
+            width: 2.4rem;
+          }
 
-            .text, .icon {
-              display: table-cell;
-              vertical-align: middle;
-            }
+          &.next {
+            text-align: right;
+          }
 
-            .icon {
-              width: 2.4rem;
-            }
-
-            &.next {
-              text-align: right;
-            }
-
-            &.back {
-              text-align: left;
-            }
+          &.back {
+            text-align: left;
           }
         }
       }


### PR DESCRIPTION
So the hit area was fine until the button text wrapped. So scrapped
the use of the CSS table styles and leveraged the CSS flex instead
along with some minor structural changes. The buttons might be one or
two pixels different in width, but nothing visible to the eye.

Issue: #1388