### PR TITLE
Update placeholder text for street address

### DIFF
--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2791,7 +2791,7 @@ const en = {
     us: {
       street: {
         label: 'Street',
-        placeholder: 'Enter mailing address'
+        placeholder: 'Enter street address'
       },
       city: {
         label: 'City',


### PR DESCRIPTION
Leaving the placeholder text for APO/FPO and international the same as
the label states "Address" it may be more suitable.

Issue: #1448