### PR TITLE
Do not allow end date before start date for treatments

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -219,7 +219,7 @@ export default class DateControl extends ValidationElement {
         // Call any `onError` binding with error checking specific to the `DateControl`
         local = local.concat(this.constructor.errors.map(err => {
           return {
-            code: err.code,
+            code: `${this.props.prefix ? this.props.prefix : 'date'}.${err.code}`,
             valid: err.func(date, props),
             uid: this.state.uid
           }
@@ -227,15 +227,17 @@ export default class DateControl extends ValidationElement {
       } else {
         local = local.concat(this.constructor.errors.map(err => {
           return {
-            code: err.code,
+            code: `${this.props.prefix ? this.props.prefix : 'date'}.${err.code}`,
             valid: null,
             uid: this.state.uid
           }
         }))
       }
 
-      // Pass any local and child errors to bound functions
-      this.props.onError(date, local)
+      this.setState({ error: local.some(x => x.valid === false) }, () => {
+        // Pass any local and child errors to bound functions
+        this.props.onError(date, local)
+      })
     })
 
     // Return the original array of errors to the child control
@@ -267,7 +269,7 @@ export default class DateControl extends ValidationElement {
   }
 
   render () {
-    let klass = `datecontrol ${this.props.className || ''} ${this.props.hideDay ? 'day-hidden' : ''}`.trim()
+    let klass = `datecontrol ${this.state.error ? 'usa-input-error' : ''} ${this.props.className || ''} ${this.props.hideDay ? 'day-hidden' : ''}`.trim()
     return (
       <div className={klass}>
         <div>
@@ -279,6 +281,7 @@ export default class DateControl extends ValidationElement {
                       maxlength="2"
                       receiveProps={this.props.receiveProps}
                       value={this.state.month}
+                      error={this.state.error}
                       disabled={this.state.disabled}
                       readonly={this.props.readonly}
                       required={this.props.required}
@@ -325,6 +328,7 @@ export default class DateControl extends ValidationElement {
                     step="1"
                     receiveProps="true"
                     value={this.state.day}
+                    error={this.state.error}
                     onChange={this.handleChange}
                     onError={this.handleErrorDay}
                     tabBack={() => { this.refs.month.refs.autosuggest.input.focus() }}
@@ -346,6 +350,7 @@ export default class DateControl extends ValidationElement {
                     step="1"
                     receiveProps="true"
                     value={this.state.year}
+                    error={this.state.error}
                     onChange={this.handleChange}
                     onError={this.handleErrorYear}
                     tabBack={() => { this.refs.day.refs.number.refs.input.focus() }}
@@ -403,7 +408,7 @@ DateControl.errors = [
     }
   },
   {
-    code: 'date.max',
+    code: 'max',
     func: (value, props) => {
       if (!value || isNaN(value)) {
         return null
@@ -412,7 +417,7 @@ DateControl.errors = [
     }
   },
   {
-    code: 'date.min',
+    code: 'min',
     func: (value, props) => {
       if (!value || isNaN(value)) {
         return null

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -207,7 +207,7 @@ export default class DateControl extends ValidationElement {
       const existingErr = this.state.errors.some(e => e.valid === false)
 
       // If the date is valid and there are no child errors...
-      let local = [...arr]
+      let local = []
       if (date && !existingErr) {
         // Prepare some properties for the error testing
         const props = {
@@ -217,26 +217,26 @@ export default class DateControl extends ValidationElement {
         }
 
         // Call any `onError` binding with error checking specific to the `DateControl`
-        local = local.concat(this.constructor.errors.map(err => {
+        local = this.constructor.errors.map(err => {
           return {
             code: `${this.props.prefix ? this.props.prefix : 'date'}.${err.code}`,
             valid: err.func(date, props),
             uid: this.state.uid
           }
-        }))
+        })
       } else {
-        local = local.concat(this.constructor.errors.map(err => {
+        local = this.constructor.errors.map(err => {
           return {
             code: `${this.props.prefix ? this.props.prefix : 'date'}.${err.code}`,
             valid: null,
             uid: this.state.uid
           }
-        }))
+        })
       }
 
       this.setState({ error: local.some(x => x.valid === false) }, () => {
         // Pass any local and child errors to bound functions
-        this.props.onError(date, local)
+        this.props.onError(date, [...arr].concat(local))
       })
     })
 

--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounseling.jsx
@@ -98,6 +98,8 @@ export default class ReceivedCounseling extends ValidationElement {
   }
 
   render () {
+    const maxDate = (this.props.TreatmentEndDate || {}).date || new Date()
+    const minDate = (this.props.TreatmentBeganDate || {}).date || null
     return (
       <div className="voluntary-counseling">
         <Field title={i18n.t('substance.alcohol.receivedCounseling.heading.treatmentProviderName')}
@@ -158,6 +160,8 @@ export default class ReceivedCounseling extends ValidationElement {
           <DateControl name="TreatmentBeganDate"
                        className="treatment-began-date"
                        {...this.props.TreatmentBeganDate}
+                       prefix="treatment.began"
+                       maxDate={maxDate}
                        onUpdate={this.updateTreatmentBeganDate}
                        onError={this.props.onError}
                        />
@@ -170,6 +174,8 @@ export default class ReceivedCounseling extends ValidationElement {
                        className="treatment-end-date"
                        {...this.props.TreatmentEndDate}
                        receiveProps={this.props.PresentTreatmentEndDate || false}
+                       prefix="treatment.end"
+                       minDate={minDate}
                        disabled={this.props.PresentTreatmentEndDate}
                        onUpdate={this.updateTreatmentEndDate}
                        onError={this.props.onError}

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -600,6 +600,28 @@ const en = {
         message: 'Check for any spelling mistakes in your email address.',
         note: 'Example of valid email format: name@domain.com'
       }
+    },
+    treatment: {
+      began: {
+        max: {
+          title: 'There is a problem with the date',
+          message: 'The date can\'t be in the future.'
+        },
+        min: {
+          title: 'There is a problem with the date',
+          message: 'The date should be on or after your date of birth.'
+        }
+      },
+      end: {
+        max: {
+          title: 'There is a problem with the date',
+          message: 'The date can\'t be in the future.'
+        },
+        min: {
+          title: 'There is a problem with the date',
+          message: 'The date should be after the date treatment began.'
+        }
+      }
     }
     // order: {
     //   datecontrol: {

--- a/src/validators/alcoholreceivedcounseling.js
+++ b/src/validators/alcoholreceivedcounseling.js
@@ -80,6 +80,7 @@ export class ReceivedCounselingValidator {
       validGenericTextfield(this.agencyName) &&
       this.validCompletedTreatment() &&
       validDateField(this.treatmentBeganDate) &&
-      validDateField(this.treatmentEndDate)
+      validDateField(this.treatmentEndDate) &&
+      this.treatmentBeganDate.date < this.treatmentEndDate.date
   }
 }

--- a/src/validators/alcoholreceivedcounseling.test.js
+++ b/src/validators/alcoholreceivedcounseling.test.js
@@ -70,9 +70,9 @@ describe('received counseling component validation', function () {
           },
           TreatmentEndDate: {
             day: '1',
-            month: '1',
+            month: '2',
             year: '2016',
-            date: new Date('1/1/2016')
+            date: new Date('1/2/2016')
           },
           CompletedTreatment: 'Yes',
           NoCompletedTreatmentExplanation: {
@@ -119,8 +119,51 @@ describe('received counseling component validation', function () {
     })
   })
 
-  it('can validate list of received counseling', () => {
+  it('can validate treatment dates', () => {
     const tests = [
+      {
+        state: {
+          ListBranch: 'No',
+          ReceivedTreatment: 'Yes',
+          List: [
+            {
+              ReceivedCounseling: {
+                UseSameAddress: 'Yes',
+                TreatmentProviderName: {
+                  value: 'The name'
+                },
+                TreatmentProviderAddress: {
+                  addressType: 'United States',
+                  address: '1234 Some Rd',
+                  city: 'Arlington',
+                  state: 'Virginia',
+                  zipcode: '22202'
+                },
+                AgencyName: {
+                  value: 'The agency name'
+                },
+                TreatmentBeganDate: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                  date: new Date('1/1/2016')
+                },
+                TreatmentEndDate: {
+                  day: '1',
+                  month: '2',
+                  year: '2016',
+                  date: new Date('1/2/2016')
+                },
+                CompletedTreatment: 'Yes',
+                NoCompletedTreatmentExplanation: {
+                  value: 'Foo'
+                }
+              }
+            }
+          ]
+        },
+        expected: true
+      },
       {
         state: {
           ListBranch: 'No',
@@ -153,6 +196,100 @@ describe('received counseling component validation', function () {
                   month: '1',
                   year: '2016',
                   date: new Date('1/1/2016')
+                },
+                CompletedTreatment: 'Yes',
+                NoCompletedTreatmentExplanation: {
+                  value: 'Foo'
+                }
+              }
+            }
+          ]
+        },
+        expected: false
+      },
+      {
+        state: {
+          ListBranch: 'No',
+          ReceivedTreatment: 'Yes',
+          List: [
+            {
+              ReceivedCounseling: {
+                UseSameAddress: 'Yes',
+                TreatmentProviderName: {
+                  value: 'The name'
+                },
+                TreatmentProviderAddress: {
+                  addressType: 'United States',
+                  address: '1234 Some Rd',
+                  city: 'Arlington',
+                  state: 'Virginia',
+                  zipcode: '22202'
+                },
+                AgencyName: {
+                  value: 'The agency name'
+                },
+                TreatmentBeganDate: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                  date: new Date('1/1/2016')
+                },
+                TreatmentEndDate: {
+                  day: '1',
+                  month: '1',
+                  year: '1982',
+                  date: new Date('1/1/1982')
+                },
+                CompletedTreatment: 'Yes',
+                NoCompletedTreatmentExplanation: {
+                  value: 'Foo'
+                }
+              }
+            }
+          ]
+        },
+        expected: false
+      }
+    ]
+    tests.forEach(test => {
+      expect(new ReceivedCounselingsValidator(test.state, null).isValid()).toBe(test.expected)
+    })
+  })
+
+  it('can validate list of received counseling', () => {
+    const tests = [
+      {
+        state: {
+          ListBranch: 'No',
+          ReceivedTreatment: 'Yes',
+          List: [
+            {
+              ReceivedCounseling: {
+                UseSameAddress: 'Yes',
+                TreatmentProviderName: {
+                  value: 'The name'
+                },
+                TreatmentProviderAddress: {
+                  addressType: 'United States',
+                  address: '1234 Some Rd',
+                  city: 'Arlington',
+                  state: 'Virginia',
+                  zipcode: '22202'
+                },
+                AgencyName: {
+                  value: 'The agency name'
+                },
+                TreatmentBeganDate: {
+                  day: '1',
+                  month: '1',
+                  year: '2016',
+                  date: new Date('1/1/2016')
+                },
+                TreatmentEndDate: {
+                  day: '1',
+                  month: '2',
+                  year: '2016',
+                  date: new Date('1/2/2016')
                 },
                 CompletedTreatment: 'Yes',
                 NoCompletedTreatmentExplanation: {

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -78,6 +78,13 @@ input[type='checkbox'], input[type='radio'] {
     box-shadow: none;
     border-width: 2px;
     width: 100%;
+
+    &.usa-input-success {
+      box-shadow: none;
+      background: url('../img/exclamation-point.svg') no-repeat right 0.7rem center / 1.7rem auto;
+      border-width: 2px;
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Issue: #919

## Preview

![screen shot 2017-06-23 at 10 42 38 am](https://user-images.githubusercontent.com/697855/27487192-03bbc98a-5801-11e7-9cf3-43ff39fd52fc.png)

Instead of passing error state downwards the error is applied at the composite component and visually managed through styles.
