### PR TITLE
Update DateControl and DateRange to highlight entire date on some errors

### DIFF
--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -152,14 +152,16 @@ export default class DateControl extends ValidationElement {
 
         // This will force a blur/validation
         if (d && (changed.year || changed.month)) {
-          this.refs.day.refs.number.refs.input.focus()
-          this.refs.day.refs.number.refs.input.blur()
+          window.setTimeout(() => {
+            this.refs.day.refs.number.refs.input.focus()
+            this.refs.day.refs.number.refs.input.blur()
 
-          if (changed.month) {
-            this.refs.month.refs.autosuggest.input.focus()
-          } else if (event.target.focus) {
-            event.target.focus()
-          }
+            if (changed.month) {
+              this.refs.month.refs.autosuggest.input.focus()
+            } else if (event.target.focus) {
+              event.target.focus()
+            }
+          }, 200)
         }
 
         if (this.props.onUpdate) {
@@ -395,18 +397,6 @@ DateControl.defaultProps = {
 }
 
 DateControl.errors = [
-  {
-    code: 'day.max',
-    func: (value, props) => {
-      if (!value || isNaN(value)) {
-        return null
-      }
-      if (value) {
-        return parseInt(props.day) <= daysInMonth(value.getMonth() + 1, value.getFullYear())
-      }
-      return parseInt(props.day) <= daysInMonth(parseInt(props.month), parseInt(props.year))
-    }
-  },
   {
     code: 'max',
     func: (value, props) => {

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -291,7 +291,7 @@ export default class DateControl extends ValidationElement {
                       beforeChange={this.beforeChange}
                       onError={this.handleErrorMonth}
                       displayText={this.monthDisplayText}
-                      tabNext={() => { this.refs.day.refs.number.refs.input.focus() }}>
+                      tabNext={() => { this.props.tab(this.refs.day.refs.number.refs.input) }}>
               <option key="jan" value="1">January</option>
               <option key="feb" value="2">February</option>
               <option key="mar" value="3">March</option>
@@ -333,8 +333,8 @@ export default class DateControl extends ValidationElement {
                     error={this.state.error}
                     onChange={this.handleChange}
                     onError={this.handleErrorDay}
-                    tabBack={() => { this.refs.month.refs.autosuggest.input.focus() }}
-                    tabNext={() => { this.refs.year.refs.number.refs.input.focus() }}
+                    tabBack={() => { this.props.tab(this.refs.month.refs.autosuggest.input) }}
+                    tabNext={() => { this.props.tab(this.refs.year.refs.number.refs.input) }}
                     />
           </div>
           <div className="usa-form-group year">
@@ -355,7 +355,7 @@ export default class DateControl extends ValidationElement {
                     error={this.state.error}
                     onChange={this.handleChange}
                     onError={this.handleErrorYear}
-                    tabBack={() => { this.refs.day.refs.number.refs.input.focus() }}
+                    tabBack={() => { this.props.tab(this.refs.day.refs.number.refs.input) }}
                     />
           </div>
         </div>
@@ -393,7 +393,8 @@ DateControl.defaultProps = {
   prefix: '',
   maxDate: new Date(),
   minDate: null,
-  onError: (value, arr) => { return arr }
+  onError: (value, arr) => { return arr },
+  tab: (el) => { el.focus() }
 }
 
 DateControl.errors = [

--- a/src/components/Form/DateControl/DateControl.test.jsx
+++ b/src/components/Form/DateControl/DateControl.test.jsx
@@ -301,4 +301,46 @@ describe('The date component', () => {
     expect(component.find('.datecontrol').length).toBe(1)
     expect(component.find('.flags .estimated').length).toBe(0)
   })
+
+  it('can autotab forward', () => {
+    let tabbed = false
+    const expected = {
+      tab: () => { tabbed = true }
+    }
+
+    // Month
+    let component = mount(<DateControl {...expected} />)
+    component.find('.month input').simulate('keydown', { keyCode: 8, target: { value: '' } })
+    expect(tabbed).toBe(false)
+    component.find('.month input').simulate('keydown', { keyCode: 48, target: { value: '12' } })
+    expect(tabbed).toBe(true)
+
+    // Day
+    tabbed = false
+    component = mount(<DateControl {...expected} />)
+    component.find('.day input').simulate('keydown', { keyCode: 48, target: { value: '12' } })
+    expect(tabbed).toBe(true)
+  })
+
+  it('can autotab backward', () => {
+    let tabbed = false
+    const expected = {
+      tab: () => { tabbed = true }
+    }
+
+    // Year
+    let component = mount(<DateControl {...expected} />)
+    component.find('.year input').simulate('keydown', { keyCode: 48, target: { value: '1' } })
+    expect(tabbed).toBe(false)
+    component.find('.year input').simulate('keydown', { keyCode: 8, target: { value: '' } })
+    expect(tabbed).toBe(true)
+
+    // Day
+    tabbed = false
+    component = mount(<DateControl {...expected} />)
+    component.find('.day input').simulate('keydown', { keyCode: 48, target: { value: '1' } })
+    expect(tabbed).toBe(false)
+    component.find('.day input').simulate('keydown', { keyCode: 8, target: { value: '' } })
+    expect(tabbed).toBe(true)
+  })
 })

--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -17,6 +17,7 @@ export default class DateRange extends ValidationElement {
       presentClicked: false,
       trickleDown: false,
       title: props.title || 'Date Range',
+      error: false,
       errors: []
     }
 
@@ -143,7 +144,7 @@ export default class DateRange extends ValidationElement {
     // if there were **any** errors found in other child components.
     this.storeErrors(arr, () => {
       const existingErr = this.state.errors.some(e => e.valid === false)
-      let local = [...arr]
+      let local = []
 
       if (!existingErr && this.state.from.date && this.state.to.date) {
         // Prepare some properties for the error testing
@@ -152,24 +153,26 @@ export default class DateRange extends ValidationElement {
           to: this.state.to
         }
 
-        local = local.concat(this.constructor.errors.map(err => {
+        local = this.constructor.errors.map(err => {
           return {
             code: err.code,
             valid: err.func(null, props),
             uid: this.state.uid
           }
-        }))
+        })
       } else {
-        local = local.concat(this.constructor.errors.map(err => {
+        local = this.constructor.errors.map(err => {
           return {
             code: err.code,
             valid: null,
             uid: this.state.uid
           }
-        }))
+        })
       }
 
-      this.props.onError(value, local)
+      this.setState({ error: local.some(x => x.valid === false) }, () => {
+        this.props.onError(value, [...arr].concat(local))
+      })
     })
 
     return arr
@@ -177,6 +180,7 @@ export default class DateRange extends ValidationElement {
 
   render () {
     const klass = `daterange usa-grid ${this.props.className || ''}`.trim()
+    const klassTo = `to ${this.state.error ? 'usa-input-error' : ''}`.trim()
 
     return (
       <div className={klass}>
@@ -205,7 +209,7 @@ export default class DateRange extends ValidationElement {
           </div>
           <DateControl name="to"
                        ref="to"
-                       className="to"
+                       className={klassTo}
                        {...this.state.to}
                        estimated={this.state.estimated}
                        receiveProps={this.state.trickleDown || this.state.presentClicked}

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -56,6 +56,7 @@ describe('The date range component', () => {
     const component = mount(<DateRange {...expected} />)
     component.find('input[name="present"]').simulate('change')
     expect(updates).toBeGreaterThan(0)
+    expect(component.find('.to.usa-input-error').length).toBe(1)
   })
 
   it('loads data', () => {

--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -59,7 +59,7 @@ export default class Field extends ValidationElement {
       if (errors.length && errors.some(err => err.valid === false)) {
         this.scrollIntoView()
       }
-      return
+      return arr
     }
 
     for (const e of arr) {
@@ -76,6 +76,8 @@ export default class Field extends ValidationElement {
         this.scrollIntoView()
       }
     })
+
+    return arr
   }
 
   /**
@@ -218,22 +220,19 @@ export default class Field extends ValidationElement {
 
       let props = child.props || {}
       let extendedProps = { ...props }
+      let injected = false
 
       if (React.isValidElement(child)) {
         // Inject ourselves in to the validation callback
         if (props.onError) {
+          injected = true
           extendedProps.onError = (value, arr) => {
-            let childErrors = []
-            if (props.onError) {
-              childErrors = props.onError(value, arr)
-            }
-            this.handleError(value, childErrors)
-            return childErrors
+            return this.handleError(value, props.onError(value, arr))
           }
         }
       }
 
-      if (props.children) {
+      if (props.children && !injected) {
         const typeOfChildren = Object.prototype.toString.call(props.children)
         if (props.children && ['[object Object]', '[object Array]'].includes(typeOfChildren)) {
           extendedProps.children = this.children(props.children)

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -78,6 +78,13 @@ input[type='checkbox'], input[type='radio'] {
     box-shadow: none;
     border-width: 2px;
     width: 100%;
+
+    &.usa-input-success {
+      box-shadow: none;
+      background: url('../img/exclamation-point.svg') no-repeat right 0.7rem center / 1.7rem auto;
+      border-width: 2px;
+      width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
Issue: #1457 

If the date control or range has an error which concerns the entire date then we want to ensure the entire date is highlighted and not just an individual component.