### PR TITLE
Updated locale reference for country

### DIFF
--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -138,6 +138,7 @@ export default class Address extends ValidationElement {
                 <Street name="address"
                         className="mailing street"
                         label={this.props.streetLabel}
+                        placeholder={this.props.streetPlaceholder}
                         value={this.props.street}
                         onChange={this.updateStreet}
                         onError={this.handleError}
@@ -192,6 +193,7 @@ export default class Address extends ValidationElement {
               <div>
                 <Street name="address"
                         label={this.props.streetLabel}
+                        placeholder={this.props.streetPlaceholder}
                         className="mailing street"
                         value={this.props.street}
                         onChange={this.updateStreet}
@@ -233,6 +235,7 @@ export default class Address extends ValidationElement {
               <div>
                 <Street name="address"
                         label={i18n.t('address.apoFpo.street.label')}
+                        placeholder={this.props.postOfficeStreetPlaceholder}
                         className="mailing street"
                         value={this.props.street}
                         onChange={this.updateStreet}
@@ -308,6 +311,7 @@ Address.defaultProps = {
   country: 'United States',
   onError: (value, arr) => { return arr },
   streetLabel: i18n.t('address.us.street.label'),
+  postOfficeStreetPlaceholder: i18n.t('address.apoFpo.street.placeholder'),
   street2Label: i18n.t('address.us.street2.label')
 }
 

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -413,8 +413,8 @@ Location.defaultProps = {
   cityPlaceholder: i18n.t('address.us.city.placeholder'),
   zipcodePlaceholder: i18n.t('address.us.zipcode.placeholder'),
   zipcodeLabel: i18n.t('address.us.zipcode.label'),
-  countyLabel: i18n.t('identification.birthplace.label.county'),
-  countyPlaceholder: i18n.t('identification.birthplace.placeholder.county'),
+  countyLabel: i18n.t('address.us.county.label'),
+  countyPlaceholder: i18n.t('address.us.county.placeholder'),
   countryLabel: i18n.t('address.international.country.label'),
   countryPlaceholder: i18n.t('address.international.country.placeholder')
 }

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -415,8 +415,8 @@ Location.defaultProps = {
   zipcodeLabel: i18n.t('address.us.zipcode.label'),
   countyLabel: i18n.t('identification.birthplace.label.county'),
   countyPlaceholder: i18n.t('identification.birthplace.placeholder.county'),
-  countryLabel: i18n.t('identification.birthplace.label.country'),
-  countryPlaceholder: i18n.t('identification.birthplace.placeholder.country')
+  countryLabel: i18n.t('address.international.country.label'),
+  countryPlaceholder: i18n.t('address.international.country.placeholder')
 }
 
 Location.errors = []

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -101,7 +101,7 @@ export default class ToggleableLocation extends ValidationElement {
             <City name="city"
               className="city"
               key={key}
-              label={i18n.t('address.us.city.label')}
+              label={this.props.cityLabel}
               placeholder={this.props.cityPlaceholder}
               value={this.props.city}
               onChange={this.updateCity}
@@ -129,8 +129,8 @@ export default class ToggleableLocation extends ValidationElement {
             <MilitaryState name="state"
               key={key}
               className="state"
-              label={i18n.t('address.us.state.label')}
-              placeholder={i18n.t('address.us.state.placeholder')}
+              label={this.props.stateLabel}
+              placeholder={this.props.statePlaceholder}
               value={this.props.state}
               includeStates="true"
               onChange={this.updateState}
@@ -144,8 +144,8 @@ export default class ToggleableLocation extends ValidationElement {
             <div className="state-zip-wrap">
               <MilitaryState name="state"
                 className="state"
-                label={i18n.t('address.us.state.label')}
-                placeholder={i18n.t('address.us.state.placeholder')}
+                label={this.props.stateLabel}
+                placeholder={this.props.statePlaceholder}
                 value={this.props.state}
                 includeStates="true"
                 onChange={this.updateState}
@@ -156,8 +156,8 @@ export default class ToggleableLocation extends ValidationElement {
               <ZipCode name="zipcode"
                 key="us_zipcode"
                 className="zipcode"
-                label={i18n.t('address.us.zipcode.label')}
-                placeholder={i18n.t('address.us.zipcode.placeholder')}
+                label={this.props.zipcodeLabel}
+                placeholder={this.props.zipcodePlaceholder}
                 value={this.props.zipcode}
                 onChange={this.updateZipcode}
                 onError={this.props.onError}
@@ -176,7 +176,7 @@ export default class ToggleableLocation extends ValidationElement {
           return (
             <City name="city"
               key={key}
-              label={i18n.t('address.us.city.label')}
+              label={this.props.cityLabel}
               placeholder={this.props.cityPlaceholder}
               value={this.props.city}
               onChange={this.updateCity}

--- a/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.jsx
+++ b/src/components/Section/Identification/ApplicantBirthPlace/ApplicantBirthPlace.jsx
@@ -13,6 +13,14 @@ export default class ApplicantBirthPlace extends SubsectionElement {
         <Location name="birthplace"
              layout={Location.BIRTHPLACE}
              label={i18n.t('identification.birthplace.label.location')}
+             stateLabel={i18n.t('identification.birthplace.label.state')}
+             statePlaceholder={i18n.t('identification.birthplace.placeholder.state')}
+             cityLabel={i18n.t('identification.birthplace.label.city')}
+             cityPlaceholder={i18n.t('identification.birthplace.placeholder.city')}
+             countyLabel={i18n.t('identification.birthplace.label.county')}
+             countyPlaceholder={i18n.t('identification.birthplace.placeholder.county')}
+             countryLabel={i18n.t('identification.birthplace.label.country')}
+             countryPlaceholder={i18n.t('identification.birthplace.placeholder.country')}
              {...this.props.value}
              onUpdate={this.props.onUpdate}
              onError={this.handleError}

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2867,6 +2867,10 @@ const en = {
         label: 'State',
         placeholder: 'Enter state'
       },
+      county: {
+        label: 'County',
+        placeholder: 'Enter county'
+      },
       zipcode: {
         label: 'Zip Code',
         placeholder: 'Enter zipcode'

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2896,7 +2896,7 @@ const en = {
       },
       street: {
         label: 'Address',
-        placeholder: 'Enter mailing address'
+        placeholder: 'Enter address'
       },
       city: {
         label: 'City',


### PR DESCRIPTION
Updated locale text for Country label/placeholder to be generic like the other location fields. Resolves one of the issues found in #1420 and #1328. ~~Still waiting for confirmation on the actual fields being rendered.~~

- Removed hardcoded locale text and swapped with prop (e.g. `this.props.stateLabel`)