### PR TITLE
Do not re-validate if validation was already completed

### DIFF
--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -14,12 +14,12 @@ import { LocationValidator } from '../../../validators'
 import { AddressSuggestion } from './AddressSuggestion'
 import Layouts from './Layouts'
 
-const timeout = (fn, milliseconds = 400) => {
-  if (!window) {
+export const timeout = (fn, milliseconds = 400, w = window) => {
+  if (!w) {
     return
   }
 
-  window.setTimeout(fn, milliseconds)
+  w.setTimeout(fn, milliseconds)
 }
 
 export default class Location extends ValidationElement {

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -60,7 +60,7 @@ export default class Location extends ValidationElement {
         county: this.props.county,
         country: this.props.country,
         layout: this.props.layout,
-        validated: false,
+        validated: this.props.validated,
         ...queue
       })
     }
@@ -113,6 +113,8 @@ export default class Location extends ValidationElement {
             spinner: false,
             spinnerAction: SpinnerAction.Spin,
             suggestions: true
+          }, () => {
+            this.update({ validated: true })
           })
         }, 1000)
       })
@@ -157,23 +159,38 @@ export default class Location extends ValidationElement {
   }
 
   updateStreet (event) {
-    this.update({street: event.target.value})
+    this.update({
+      street: event.target.value,
+      validated: false
+    })
   }
 
   updateCity (event) {
-    this.update({city: event.target.value})
+    this.update({
+      city: event.target.value,
+      validated: false
+    })
   }
 
   updateState (event) {
-    this.update({state: event.target.value})
+    this.update({
+      state: event.target.value,
+      validated: false
+    })
   }
 
   updateCountry (event) {
-    this.update({country: event.target.value})
+    this.update({
+      country: event.target.value,
+      validated: false
+    })
   }
 
   updateZipcode (event) {
-    this.update({zipcode: event.target.value})
+    this.update({
+      zipcode: event.target.value,
+      validated: false
+    })
   }
 
   updateAddress (address) {
@@ -184,7 +201,8 @@ export default class Location extends ValidationElement {
       state: address.state,
       zipcode: address.zipcode,
       country: address.country,
-      addressType: address.addressType
+      addressType: address.addressType,
+      validated: false
     })
   }
 
@@ -194,7 +212,8 @@ export default class Location extends ValidationElement {
       state: location.state,
       zipcode: location.zipcode,
       county: location.county,
-      country: location.country
+      country: location.country,
+      validated: false
     })
   }
 
@@ -505,6 +524,7 @@ Location.STREET_CITY = Layouts.STREET_CITY
 
 Location.defaultProps = {
   layout: Layouts.ADDRESS,
+  validated: false,
   geocode: false,
   geocodeResult: {},
   spinner: false,

--- a/src/components/Form/Location/Location.test.jsx
+++ b/src/components/Form/Location/Location.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import Location from './Location'
+import Location, { timeout } from './Location'
 
 describe('The Address component', () => {
   it('Renders without errors', () => {
@@ -183,5 +183,21 @@ describe('The Address component', () => {
     }
     const component = mount(<Location {...props} />)
     expect(component.find('.suggestions').length).toBe(1)
+  })
+
+  it('can set timeout function', () => {
+    let called = false
+    const w = {
+      setTimeout: (fn, ms) => { called = true }
+    }
+    timeout(null, 0, w)
+    expect(called).toBe(true)
+  })
+
+  it('timeout does nothing if window does not exist', () => {
+    let called = false
+    const w = null
+    timeout(null, 0, w)
+    expect(called).toBe(false)
   })
 })

--- a/src/components/Section/Foreign/Business/Contact.test.jsx
+++ b/src/components/Section/Foreign/Business/Contact.test.jsx
@@ -59,6 +59,7 @@ describe('The foreign business contact component', () => {
     }
     const component = mount(<Contact {...expected} />)
     expect(component.find('.accordion').length).toBe(1)
+    updates = 0
     component.find('.foreign-business-contact-name .first input').simulate('change')
     component.find('.foreign-business-contact-location .yes input').simulate('change')
     component.find('.foreign-business-contact-date .day input').simulate('change')
@@ -66,6 +67,6 @@ describe('The foreign business contact component', () => {
     component.find('.foreign-business-contact-representatives textarea').simulate('change')
     component.find('.foreign-business-contact-purpose textarea').simulate('change')
     component.find('.has-foreign-contacts .no input').simulate('change')
-    expect(updates).toBe(8)
+    expect(updates).toBe(7)
   })
 })

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -48,9 +48,9 @@ describe('The civil union component', () => {
     component.find('.separated .yes input').simulate('change')
     component.find('.divorced .yes input').simulate('change')
     component.find('.dateseparated .month input').simulate('change', { target: { value: '12' } })
-    component.find('.address-separated .yes input').simulate('change')
+    component.find('.address-separated .no input').simulate('change')
     component.find('.address-separated input[name="OtherNameNotApplicable"]').simulate('change')
-    expect(updates).toBe(24)
+    expect(updates).toBe(25)
   })
 
   it('renders current address', () => {


### PR DESCRIPTION
The `validated` property was always being set to `false` instead of tracking when items were considered **dirty**. This was causing the validation to be triggered on blur even after validation was successful.

Issue: #1203