### PR TITLE
Modify the "address needs more information" to be friendlier

### DIFF
--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -436,10 +436,27 @@ export default class Location extends ValidationElement {
   }
 
   suggestionParagraph () {
-    return (<p>{i18n.t(`${this.state.geocodeResult.Error}.para`)}</p>)
+    const e = this.state.geocodeResult.Error
+    if (e === 'error.geocode.defaultAddress') {
+      return (
+        <span>
+          <p>{i18n.t(`${e}.para`)}</p>
+          <button className="suggestion-btn" onClick={this.onSuggestionDismiss.bind(this)}>
+            <span>{i18n.t('suggestions.address.more')}</span>
+            <i className="fa fa-arrow-circle-right"></i>
+          </button>
+        </span>
+      )
+    }
+    return (<p>{i18n.t(`${e}.para`)}</p>)
   }
 
   dismissAlternative () {
+    const e = this.state.geocodeResult.Error
+    if (e === 'error.geocode.defaultAddress') {
+      return null
+    }
+
     if (!this.state.geocodeResult.Suggestions || this.state.geocodeResult.Suggestions.length === 0) {
       return i18n.t('suggestions.address.alternate')
     }

--- a/src/components/Form/Suggestions/Suggestions.scss
+++ b/src/components/Form/Suggestions/Suggestions.scss
@@ -12,6 +12,14 @@
     margin-top: 0;
   }
 
+  .suggestion-btn {
+    padding: 2rem;
+
+    i {
+      margin-left: 1rem;
+    }
+  }
+
   .suggestion {
     .value {
       display: inline-block;
@@ -38,6 +46,7 @@
   .dismiss {
     border-top: 2px solid $eapp-grey;
     padding-top: 1rem;
+    margin-top: 3rem;
 
     a {
       text-decoration: none;

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2967,7 +2967,8 @@ const en = {
       label: 'Suggested address',
       use: 'Use this address',
       dismiss: 'Keep original address',
-      alternate: 'Manually correct this address'
+      alternate: 'Manually correct this address',
+      more: 'Add more information'
     }
   },
 


### PR DESCRIPTION
To help the conversational tone and reduce the amount of options the
suggestion dialog has been modified when an address isn't exactly
incorrect but does require more information.

Issue: #1202

## Preview

![image](https://user-images.githubusercontent.com/697855/28032506-bf76f5d0-6578-11e7-81ec-fee9f296c8ed.png)
