### PR TITLE
Standardize `showTop` value to be boolean

### DIFF
--- a/src/components/Section/Citizenship/Citizenship.jsx
+++ b/src/components/Section/Citizenship/Citizenship.jsx
@@ -27,7 +27,7 @@ class Citizenship extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="citizenship/passports"
                        backLabel={i18n.t('citizenship.destination.passports')}
                        next="military"

--- a/src/components/Section/Financial/Financial.jsx
+++ b/src/components/Section/Financial/Financial.jsx
@@ -29,7 +29,7 @@ class Financial extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="financial/nonpayment"
                        backLabel={i18n.t('financial.destination.nonpayment')}
                        next="history"

--- a/src/components/Section/Foreign/Foreign.jsx
+++ b/src/components/Section/Foreign/Foreign.jsx
@@ -125,7 +125,7 @@ class Foreign extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="foreign/travel"
                        backLabel={i18n.t('foreign.destination.travel')}
                        next="substance/drugs/usage"

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -28,7 +28,7 @@ class Identification extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        next="financial"
                        nextLabel={i18n.t('financial.destination.gambling')}
                        back="identification/physical"

--- a/src/components/Section/Legal/Legal.jsx
+++ b/src/components/Section/Legal/Legal.jsx
@@ -401,7 +401,7 @@ class Legal extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="legal/associations/terrorism-activities"
                        backLabel={i18n.t('legal.destination.associations.activities')}
                        next="psychological/intro"

--- a/src/components/Section/Military/Military.jsx
+++ b/src/components/Section/Military/Military.jsx
@@ -56,7 +56,7 @@ class Military extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="military/foreign"
                        backLabel={i18n.t('military.destination.foreign')}
                        next="foreign/passport"

--- a/src/components/Section/Psychological/Psychological.jsx
+++ b/src/components/Section/Psychological/Psychological.jsx
@@ -110,7 +110,7 @@ class Psychological extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="psychological/conditions"
                        backLabel={ i18n.t('psychological.destination.existingConditions') }>
 

--- a/src/components/Section/Relationships/Relationships.jsx
+++ b/src/components/Section/Relationships/Relationships.jsx
@@ -117,7 +117,7 @@ class Relationships extends SectionElement {
           <SectionView name="review"
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
-                       showTop="true"
+                       showTop={true}
                        back="relationships/relatives"
                        backLabel={i18n.t('relationships.destination.relatives')}
                        next="citizenship/status"

--- a/src/components/Section/SectionView.jsx
+++ b/src/components/Section/SectionView.jsx
@@ -65,7 +65,7 @@ export class SectionViews extends React.Component {
         }
 
         let topButtons = null
-        if (child.props.showTop === 'true' && buttons) {
+        if (child.props.showTop && buttons) {
           topButtons = (<div className="top-btns">{buttons}</div>)
         }
 

--- a/src/components/Section/SubstanceUse/SubstanceUse.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.jsx
@@ -250,7 +250,7 @@ class SubstanceUse extends SectionElement {
                        title={i18n.t('substance.review.title')}
                        back="substance/alcohol/additional"
                        backLabel={ i18n.t('substance.destination.police.additional') }
-                       showTop="true"
+                       showTop={true}
                        next="legal/police"
                        nextLabel={ i18n.t('legal.destination.police') }>
 


### PR DESCRIPTION
The **Your History** review section did not have the navigation
buttons on the top because the `showTop` value was boolean whereas all
other references had values of `"true"`.

Issue: #1549