### PR TITLE
Minor style adjust to nav

### DIFF
--- a/src/components/Sticky/Sticky.jsx
+++ b/src/components/Sticky/Sticky.jsx
@@ -150,16 +150,14 @@ export default class Sticky extends React.Component {
 
     let marginTop = this.state.marginTop
     if (scrolled.up) {
-      if (current.indexOf('bottom-visible') !== -1 && scrolled.up) {
+      if (['page-short', 'top-visible', 'anchor-visible'].some(pos => position.indexOf(pos) !== -1)) {
+        marginTop = null
+      } else if (current.indexOf('bottom-visible') !== -1 && scrolled.up) {
         const headerAdjust = document.getElementsByClassName('eapp-header')[0].clientHeight
         const offset = w.pageYOffset + getBox(this.refs.content).top - headerAdjust
         marginTop = `${offset}${this.props.unit}`
-      } else if (position.indexOf('top-visible') !== -1) {
-        marginTop = null
-      } else if (position.indexOf('anchor-visible') !== -1) {
-        marginTop = null
       }
-    } if (scrolled.down) {
+    } else if (scrolled.down) {
       marginTop = null
     }
 

--- a/src/components/Sticky/Sticky.scss
+++ b/src/components/Sticky/Sticky.scss
@@ -44,7 +44,7 @@ $fixed-width: 18.75%;
   &.both-visible {
     .sticky-content {
       position: fixed;
-      top: 1rem;
+      top: 5.4rem;
       bottom: unset;
       width: $fixed-width;
     }
@@ -53,7 +53,7 @@ $fixed-width: 18.75%;
   &.top-visible.scrolled-up {
     .sticky-content {
       position: fixed;
-      top: 1rem;
+      top: 5.4rem;
       bottom: unset;
       width: $fixed-width;
     }

--- a/src/components/Sticky/Sticky.scss
+++ b/src/components/Sticky/Sticky.scss
@@ -1,9 +1,10 @@
 $fixed-width: 18.75%;
+$fixed-top: 5.4rem;
 
 .sticky-dipstick {
   position: static;
   display: block;
-  margin-top: -1rem;
+  margin-top: $fixed-top * -1;
 }
 
 .sticky-container {
@@ -19,56 +20,53 @@ $fixed-width: 18.75%;
     position: relative;
   }
 
-  &.bottom-visible.scrolled-down {
-    .sticky-content {
-      position: fixed;
-      bottom: 1rem;
-      width: $fixed-width;
+  &:not(.page-short) {
+    &.bottom-visible.scrolled-down {
+      .sticky-content {
+        position: fixed;
+        bottom: 1rem;
+        width: $fixed-width;
+        min-width: 28rem;
+      }
     }
-  }
 
-  &.bottom-visible.scrolled-down.page-short {
-    .sticky-content {
-      position: relative;
-      bottom: unset;
-      width: initial;
+    &.bottom-visible.scrolled-up {
+      .sticky-content {
+        position: relative;
+      }
     }
-  }
 
-  &.bottom-visible.scrolled-up {
-    .sticky-content {
-      position: relative;
+    &.both-visible {
+      .sticky-content {
+        position: fixed;
+        top: $fixed-top;
+        bottom: unset;
+        width: $fixed-width;
+        min-width: 28rem;
+      }
     }
-  }
 
-  &.both-visible {
-    .sticky-content {
-      position: fixed;
-      top: 5.4rem;
-      bottom: unset;
-      width: $fixed-width;
+    &.top-visible.scrolled-up {
+      .sticky-content {
+        position: fixed;
+        top: $fixed-top;
+        bottom: unset;
+        width: $fixed-width;
+        min-width: 28rem;
+      }
     }
-  }
 
-  &.top-visible.scrolled-up {
-    .sticky-content {
-      position: fixed;
-      top: 5.4rem;
-      bottom: unset;
-      width: $fixed-width;
+    &.none-visible.scrolled-up {
+      .sticky-content {
+        position: relative;
+      }
     }
-  }
 
-  &.none-visible.scrolled-up {
-    .sticky-content {
-      position: relative;
-    }
-  }
-
-  &.anchor-visible {
-    .sticky-content {
-      top: unset;
-      bottom: unset;
+    &.anchor-visible {
+      .sticky-content {
+        top: unset;
+        bottom: unset;
+      }
     }
   }
 }


### PR DESCRIPTION
Made a `top ` adjustment when the navigation is in a sticky state. Due to the sticky header, the nav looks like this when it's stuck:

![selection_331](https://user-images.githubusercontent.com/5938731/28324417-5067ffe0-6ba9-11e7-8ea3-b1dcbe238452.png)

However, after the update, it looks like this:
![selection_332](https://user-images.githubusercontent.com/5938731/28324431-5f1fc964-6ba9-11e7-92bf-d02cb1d29964.png)

Let me know if this is ok.
