### PR TITLE
Foreign Activity updates

### DIFF
--- a/src/components/Form/NotApplicable/NotApplicable.jsx
+++ b/src/components/Form/NotApplicable/NotApplicable.jsx
@@ -27,7 +27,8 @@ export default class NotApplicable extends React.Component {
   renderChildren () {
     return React.Children.map(this.props.children, (child) => {
       let extendedProps = {
-        disabled: !this.state.applicable
+        disabled: !this.state.applicable,
+        onError: this.props.onError
       }
 
       return React.cloneElement(child, {

--- a/src/components/Section/Foreign/Business/Sponsorship.jsx
+++ b/src/components/Section/Foreign/Business/Sponsorship.jsx
@@ -100,13 +100,10 @@ export default class Sponsorship extends SubsectionElement {
                    adjustFor="birthplace"
                    validate={false}>
               <Location name="Birthplace"
-                        layout={Location.CITY_COUNTRY}
-                        fields={['city', 'country']}
-                        help=""
+                        layout={Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY}
                         label={i18n.t('foreign.business.sponsorship.label.birthplace')}
                         cityPlaceholder={i18n.t('foreign.business.sponsorship.placeholder.city')}
                         countryPlaceholder={i18n.t('foreign.business.sponsorship.placeholder.country')}
-                        hideCounty={true}
                         className="foreign-business-sponsorship-birthplace"
                         bind={true}
                         />

--- a/src/validators/foreignbusinesssponsorship.test.js
+++ b/src/validators/foreignbusinesssponsorship.test.js
@@ -71,7 +71,7 @@ describe('Foreign business sponsorship component validation', function () {
           Birthplace: {
             city: 'Munich',
             country: 'Germnay',
-            layout: Location.CITY_COUNTRY
+            layout: Location.US_CITY_STATE_ZIP_INTERNATIONAL_CITY
           }
         },
         expected: true


### PR DESCRIPTION
#### Resolves #1557. This had two parts:

- Foreign Activities > Foreign Business ~~Activities~~ > Foreign National Sponsorship
  - Fixed birth date not rendering error messages
- Foreign Activities > Foreign Business > Foreign National Sponsorship ~~Foreign Activities > Foreign National Support~~
  - The issue mentions the address was having issues displaying the error messages. This was resolved with PR #1608.

#### Also resolves #1553 
- Switched the birth place Location component to use `city/state/zipcode` or `city/country` fields

#### Finally, #1539 
- Foreign Activities > Foreign business, professional activities, and government contacts > Event Participation
  - Updated so that Conference Contacts saves values