### PR TITLE
Switched city/state placement

### DIFF
--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -350,7 +350,7 @@ export default class Location extends ValidationElement {
         return (
         <ToggleableLocation
           {...this.props}
-          domesticFields={['state', 'city', 'county']}
+          domesticFields={['city', 'state', 'county']}
           internationalFields={['city', 'country']}
           onBlur={this.handleBlur}
           onUpdate={this.updateToggleableLocation}
@@ -362,7 +362,7 @@ export default class Location extends ValidationElement {
         return (
         <ToggleableLocation
           {...this.props}
-          domesticFields={['state', 'city']}
+          domesticFields={['city', 'state']}
           internationalFields={['city', 'country']}
           onBlur={this.handleBlur}
           onUpdate={this.updateToggleableLocation}


### PR DESCRIPTION
Resolves #1629. `City` field now comes before `State`.