### PR TITLE
If there is a selection in the element then autotabbing is bypassed

### DIFF
--- a/src/components/Form/Generic/Generic.jsx
+++ b/src/components/Form/Generic/Generic.jsx
@@ -1,8 +1,16 @@
 import React from 'react'
-import ValidationElement, { newGuid } from '../ValidationElement'
+import ValidationElement from '../ValidationElement'
 
 export const autotab = (event, maxlength, back, next) => {
   const input = event.target
+
+  // If there is a selection (highlighted text) within the element then we
+  // need to let normal operations take precedence.
+  const highlighted = ((input.selectionEnd || 0) - (input.selectionStart || 0)) !== 0
+  if (highlighted) {
+    return
+  }
+
   const value = input.value
   const code = event.keyCode
   const backCodes = [8, 46]

--- a/src/components/Form/Generic/Generic.test.jsx
+++ b/src/components/Form/Generic/Generic.test.jsx
@@ -90,6 +90,19 @@ describe('The generic component', () => {
     expect(tabbed).toBe(true)
   })
 
+  it('does not autotab if text is selected', () => {
+    let tabbed = false
+    const expected = {
+      name: 'input-type-text',
+      value: '11',
+      maxlength: '2',
+      tabNext: () => { tabbed = true }
+    }
+    const component = mount(<Generic {...expected} />)
+    component.find('input').simulate('keydown', { keyCode: 48, target: { value: '1', selectionDirection: 'forward', selectionStart: 0, selectionEnd: 2 } })
+    expect(tabbed).toBe(false)
+  })
+
   it('trims whitespace for validation', () => {
     let persisted = false
     const expected = {


### PR DESCRIPTION
Issue: #1624

Autotabbing listens to the `keydown` event. When there is selected text in an element and then a key is pressed this event is triggered before a change in the elements value has been made.

To avoid this situation we can turn off the autotabbing if there is a selection in the element and allow normal behavior to fall through.