### PR TITLE
Ssn verify error

### DIFF
--- a/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.jsx
+++ b/src/components/Section/Identification/ApplicantSSN/ApplicantSSN.jsx
@@ -53,6 +53,7 @@ export default class ApplicantSSN extends SubsectionElement {
       // we are going to forcefully flush them.
       if (verified) {
         this.handleError(values, [])
+        this.verificationError(values, [])
       }
     })
   }


### PR DESCRIPTION
Resolves this scenario:
- 1. User fills out SSN1
- 2. User fills out SSN2 with a value that causes mismatch error
- 3. User corrects SSN2 to match SSN1
- 4. The navigation would still show red circle indicating an error when issue was actually fixed.