### PR TITLE
Previously used address in sections referenced in R&D

### DIFF
--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { i18n } from '../../../config'
 import ValidationElement from '../ValidationElement'
 import Street from '../Street'
 import MilitaryState from '../MilitaryState'
@@ -9,11 +10,16 @@ import RadioGroup from '../RadioGroup'
 import Radio from '../Radio'
 import ApoFpo from '../ApoFpo'
 import Show from '../Show'
-import { i18n } from '../../../config'
+import Suggestions from '../Suggestions'
+import { AddressSuggestion } from './AddressSuggestion'
 
 export default class Address extends ValidationElement {
   constructor (props) {
     super(props)
+
+    this.state = {
+      showAddressBook: false
+    }
 
     this.update = this.update.bind(this)
     this.updateStreet = this.updateStreet.bind(this)
@@ -24,6 +30,10 @@ export default class Address extends ValidationElement {
     this.updateZipcode = this.updateZipcode.bind(this)
     this.updateAddressType = this.updateAddressType.bind(this)
     this.addressTypeFunc = this.addressTypeFunc.bind(this)
+    this.openAddressBook = this.openAddressBook.bind(this)
+    this.closeAddressBook = this.closeAddressBook.bind(this)
+    this.renderAddressBookItem = this.renderAddressBookItem.bind(this)
+    this.selectAddressBookItem = this.selectAddressBookItem.bind(this)
   }
 
   updateStreet (event) {
@@ -99,7 +109,36 @@ export default class Address extends ValidationElement {
     }
   }
 
+  openAddressBook () {
+    this.setState({ showAddressBook: true })
+  }
+
+  closeAddressBook () {
+    this.setState({ showAddressBook: false })
+  }
+
+  renderAddressBookItem (suggestion) {
+    return (
+      <AddressSuggestion suggestion={suggestion} current={suggestion} />
+    )
+  }
+
+  selectAddressBookItem (suggestion) {
+    this.setState({ showAddressBook: false }, () => {
+      this.update({
+        street: suggestion.street,
+        street2: suggestion.street2,
+        city: suggestion.city,
+        state: suggestion.state,
+        zipcode: suggestion.zipcode,
+        county: suggestion.county,
+        country: suggestion.country
+      })
+    })
+  }
+
   render () {
+    const book = this.props.addressBooks[this.props.addressBook] || []
     return (
       <div className="address">
         <Show when={!this.props.disableToggle}>
@@ -139,6 +178,27 @@ export default class Address extends ValidationElement {
             </RadioGroup>
           </div>
         </Show>
+
+        <Show when={this.props.addressBook}>
+          <div className="reuse-address">
+            <a className="reuse-address-open-modal" href="#" title={i18n.t('address.addressBook.reuse')} onClick={this.openAddressBook}>
+              <i className="fa fa-address-book-o" aria-hidden="true" />
+              <span>{i18n.t('address.addressBook.reuse')}</span>
+            </a>
+            <Suggestions show={this.state.showAddressBook}
+                         suggestions={book}
+                         renderSuggestion={this.renderAddressBookItem}
+                         suggestionTitle={i18n.t('suggestions.addressBook.title')}
+                         suggestionParagraph={i18n.m('suggestions.addressBook.para')}
+                         suggestionLabel={i18n.t('suggestions.addressBook.label')}
+                         suggestionUseLabel={i18n.t('suggestions.addressBook.use')}
+                         suggestionDismissLabel={i18n.t('suggestions.addressBook.dismiss')}
+                         onSuggestion={this.selectAddressBookItem}
+                         onDismiss={this.closeAddressBook}
+                         />
+          </div>
+        </Show>
+
         <div className="fields">
           <div>
             <Show when={this.props.country === 'United States'}>
@@ -322,7 +382,9 @@ Address.defaultProps = {
   postOfficeStreetPlaceholder: i18n.t('address.apoFpo.street.placeholder'),
   postOfficeStateLabel: i18n.t('address.apoFpo.apoFpo.label'),
   postOfficeZipcodeLabel: i18n.t('address.apoFpo.zipcode.label'),
-  street2Label: i18n.t('address.us.street2.label')
+  street2Label: i18n.t('address.us.street2.label'),
+  addressBooks: {},
+  addressBook: ''
 }
 
 Address.errors = []

--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -226,12 +226,12 @@ export default class Address extends ValidationElement {
           </div>
         </Show>
 
-        <Show when={this.props.addressBook}>
+        <Show when={this.props.addressBook && book.length}>
           <div className="reuse-address">
-            <a className="reuse-address-open-modal" href="#" title={i18n.t('address.addressBook.reuse')} onClick={this.openAddressBook}>
+            <button className="reuse-address-open-modal" title={i18n.t('address.addressBook.reuse')} onClick={this.openAddressBook}>
               <i className="fa fa-address-book-o" aria-hidden="true" />
               <span>{i18n.t('address.addressBook.reuse')}</span>
-            </a>
+            </button>
             <Suggestions show={this.state.showAddressBook}
                          suggestions={book}
                          renderSuggestion={this.renderAddressBookItem}

--- a/src/components/Form/Location/Address.scss
+++ b/src/components/Form/Location/Address.scss
@@ -80,7 +80,10 @@
   .reuse-address {
     padding: 1rem 0 1.4rem 0;
 
-    > a {
+    > button {
+      background-color: #fff;
+      padding: 0;
+
       &.reuse-address-open-modal,
       &.reuse-address-open-modal:link,
       &.reuse-address-open-modal:visited,

--- a/src/components/Form/Location/Address.scss
+++ b/src/components/Form/Location/Address.scss
@@ -1,4 +1,3 @@
-
 @import 'eqip-colors';
 
 .address {
@@ -75,6 +74,32 @@
     .highlight {
       background-color: $eapp-blue-lightest;
       font-weight: 600;
+    }
+  }
+
+  .reuse-address {
+    padding: 1rem 0 1.4rem 0;
+
+    > a {
+      &.reuse-address-open-modal,
+      &.reuse-address-open-modal:link,
+      &.reuse-address-open-modal:visited,
+      &.reuse-address-open-modal:hover,
+      &.reuse-address-open-modal:active {
+        text-decoration: none;
+      }
+
+      > i {
+        margin-right: 1rem;
+        color: $eapp-blue;
+        vertical-align: middle;
+        font-size: 3rem;
+      }
+
+      > span {
+        color: $eapp-blue;
+        border-bottom: 1px $eapp-blue dashed;
+      }
     }
   }
 }

--- a/src/components/Form/Location/AddressSuggestion.jsx
+++ b/src/components/Form/Location/AddressSuggestion.jsx
@@ -9,13 +9,13 @@ export function AddressSuggestion (props) {
   return (
     <div className="address-suggestion">
       <div>
-        <HighlightedField new={ suggestion.Street } current={current.street} />
+        <HighlightedField new={ suggestion.Street || suggestion.street } current={ current.street } />
       </div>
       <div>
-        <HighlightedField new={ suggestion.Street2 } current={current.street2} />
+        <HighlightedField new={ suggestion.Street2 || suggestion.street2 } current={ current.street2 } />
       </div>
       <div>
-        <HighlightedField new={ suggestion.City } current={current.city} />, <HighlightedField new={ suggestion.State } current={current.state} /> <HighlightedField new={ suggestion.Zipcode } current={current.zipcode} />
+        <HighlightedField new={ suggestion.City || suggestion.city } current={ current.city } />, <HighlightedField new={ suggestion.State || suggestion.state } current={ current.state } /> <HighlightedField new={ suggestion.Zipcode || suggestion.zipcode } current={ current.zipcode } />
       </div>
     </div>
   )

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { updateApplication } from '../../../actions/ApplicationActions'
+import { i18n } from '../../../config'
 import ValidationElement from '../ValidationElement'
 import Street from '../Street'
 import MilitaryState from '../MilitaryState'
@@ -8,7 +10,6 @@ import ZipCode from '../ZipCode'
 import Spinner, { SpinnerAction } from '../Spinner'
 import Suggestions from '../Suggestions'
 import Address from './Address'
-import { i18n } from '../../../config'
 import ToggleableLocation from './ToggleableLocation'
 import { LocationValidator } from '../../../validators'
 import { AddressSuggestion } from './AddressSuggestion'
@@ -53,19 +54,29 @@ export default class Location extends ValidationElement {
   }
 
   update (queue) {
-    if (this.props.onUpdate) {
-      this.props.onUpdate({
-        street: this.props.street,
-        street2: this.props.street2,
-        city: this.props.city,
-        zipcode: this.props.zipcode,
-        state: this.props.state,
-        county: this.props.county,
-        country: this.props.country,
-        layout: this.props.layout,
-        validated: this.props.validated,
-        ...queue
-      })
+    const values = {
+      street: this.props.street,
+      street2: this.props.street2,
+      city: this.props.city,
+      zipcode: this.props.zipcode,
+      state: this.props.state,
+      county: this.props.county,
+      country: this.props.country,
+      layout: this.props.layout,
+      validated: this.props.validated,
+      ...queue
+    }
+
+    // Send the update back upstream
+    this.props.onUpdate(values)
+
+    // If there is an associated address book then push the updates there
+    if (this.props.addressBook && values.validated) {
+      const updatedBook = [
+        ...(this.props.addressBooks[this.props.addressBook] || []),
+        values
+      ]
+      this.props.dispatch(updateApplication('AddressBooks', this.props.addressBook, updatedBook))
     }
   }
 
@@ -586,7 +597,11 @@ Location.defaultProps = {
   countyLabel: i18n.t('address.us.county.label'),
   countyPlaceholder: i18n.t('address.us.county.placeholder'),
   countryLabel: i18n.t('address.international.country.label'),
-  countryPlaceholder: i18n.t('address.international.country.placeholder')
+  countryPlaceholder: i18n.t('address.international.country.placeholder'),
+  addressBooks: {},
+  addressBook: '',
+  onUpdate: (queue) => {},
+  dispatch: (action) => {}
 }
 
 Location.errors = []

--- a/src/components/Form/Reference/Reference.jsx
+++ b/src/components/Form/Reference/Reference.jsx
@@ -227,6 +227,9 @@ export default class Reference extends ValidationElement {
                     label={i18n.t(`${prefix}reference.label.address`)}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook={this.props.addressBook}
+                    dispatch={this.props.dispatch}
                     onUpdate={this.onUpdate.bind(this, 'Address')}
                     onError={this.props.onError}
                     />
@@ -250,5 +253,8 @@ Reference.defaultProps = {
   error: false,
   valid: false,
   prefix: 'reference',
+  addressBooks: {},
+  addressBook: 'Reference',
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
@@ -78,6 +78,8 @@ export default class Bankruptcies extends SubsectionElement {
                      appendTitle={i18n.t('financial.bankruptcy.collection.summary.appendTitle')}
                      appendLabel={i18n.t('financial.bankruptcy.collection.append')}>
             <Bankruptcy name="Bankruptcy"
+                        dispatch={this.props.dispatch}
+                        addressBooks={this.props.addressBooks}
                         bind={true} />
           </Accordion>
         </Show>
@@ -90,6 +92,7 @@ Bankruptcies.defaultProps = {
   List: [],
   ListBranch: '',
   HasBankruptcy: '',
+  addressBooks: {},
   onError: (value, arr) => { return arr },
   section: 'financial',
   subsection: 'bankruptcy',

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -251,6 +251,9 @@ export default class Bankruptcy extends ValidationElement {
                     {...this.props.CourtAddress}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    dispatch={this.props.dispatch}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Court"
                     onUpdate={this.updateCourtAddress}
                     onError={this.props.onError}
                     />
@@ -311,6 +314,8 @@ export default class Bankruptcy extends ValidationElement {
 }
 
 Bankruptcy.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Financial/Card/Card.jsx
+++ b/src/components/Section/Financial/Card/Card.jsx
@@ -103,6 +103,9 @@ export default class Card extends SubsectionElement {
                         layout={Location.ADDRESS}
                         geocode={true}
                         bind={true}
+                        dispatch={this.props.dispatch}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Agency"
                         />
             </Field>
 

--- a/src/components/Section/Financial/Credit/Credit.jsx
+++ b/src/components/Section/Financial/Credit/Credit.jsx
@@ -117,6 +117,9 @@ export default class Credit extends SubsectionElement {
               <Location name="Location"
                           layout={Location.CITY_STATE}
                           className="credit-location"
+                          dispatch={this.props.dispatch}
+                          addressBooks={this.props.addressBooks}
+                          addressBook="Agency"
                           bind={true}
                           help=""
                           statePlaceholder={i18n.t('financial.credit.placeholder.state')}
@@ -143,6 +146,7 @@ Credit.defaultProps = {
   HasCreditCounseling: '',
   List: [],
   ListBranch: '',
+  addressBooks: {},
   onError: (value, arr) => { return arr },
   section: 'financial',
   subsection: 'credit',

--- a/src/components/Section/Financial/Delinquent/Delinquent.jsx
+++ b/src/components/Section/Financial/Delinquent/Delinquent.jsx
@@ -207,6 +207,9 @@ export default class Delinquent extends SubsectionElement {
                         geocode={true}
                         className="delinquent-courtaddress"
                         bind={true}
+                        dispatch={this.props.dispatch}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Court"
                         />
             </Field>
 

--- a/src/components/Section/Financial/Financial.jsx
+++ b/src/components/Section/Financial/Financial.jsx
@@ -37,6 +37,7 @@ class Financial extends SectionElement {
             <h2>{i18n.t('financial.bankruptcy.title')}</h2>
             <Bankruptcies name="bankruptcy"
                           {...this.props.Bankruptcy}
+                          addressBooks={this.props.AddressBooks}
                           dispatch={this.props.dispatch}
                           onUpdate={this.handleUpdate.bind(this, 'Bankruptcy')}
                           onError={this.handleError}
@@ -67,6 +68,7 @@ class Financial extends SectionElement {
             <h2>{i18n.t('financial.card.title')}</h2>
             <Card name="card"
                   {...this.props.Card}
+                  addressBooks={this.props.AddressBooks}
                   dispatch={this.props.dispatch}
                   onUpdate={this.handleUpdate.bind(this, 'Card')}
                   onError={this.handleError}
@@ -77,6 +79,7 @@ class Financial extends SectionElement {
             <h2>{i18n.t('financial.credit.title')}</h2>
             <Credit name="credit"
                     {...this.props.Credit}
+                    addressBooks={this.props.AddressBooks}
                     dispatch={this.props.dispatch}
                     onUpdate={this.handleUpdate.bind(this, 'Credit')}
                     onError={this.handleError}
@@ -94,6 +97,7 @@ class Financial extends SectionElement {
             </ul>
             <Delinquent name="delinquent"
                         {...this.props.Delinquent}
+                        addressBooks={this.props.AddressBooks}
                         dispatch={this.props.dispatch}
                         onUpdate={this.handleUpdate.bind(this, 'Delinquent')}
                         onError={this.handleError}
@@ -129,6 +133,7 @@ class Financial extends SectionElement {
             <h2>{i18n.t('financial.bankruptcy.title')}</h2>
             <Bankruptcies name="bankruptcy"
                           {...this.props.Bankruptcy}
+                          addressBooks={this.props.AddressBooks}
                           dispatch={this.props.dispatch}
                           onUpdate={this.handleUpdate.bind(this, 'Bankruptcy')}
                           onError={this.handleError}
@@ -171,6 +176,7 @@ class Financial extends SectionElement {
             <h2>{i18n.t('financial.card.title')}</h2>
             <Card name="card"
                   {...this.props.Card}
+                  addressBooks={this.props.AddressBooks}
                   dispatch={this.props.dispatch}
                   onUpdate={this.handleUpdate.bind(this, 'Card')}
                   onError={this.handleError}
@@ -185,6 +191,7 @@ class Financial extends SectionElement {
             <h2>{i18n.t('financial.credit.title')}</h2>
             <Credit name="credit"
                     {...this.props.Credit}
+                    addressBooks={this.props.AddressBooks}
                     dispatch={this.props.dispatch}
                     onUpdate={this.handleUpdate.bind(this, 'Credit')}
                     onError={this.handleError}
@@ -206,6 +213,7 @@ class Financial extends SectionElement {
             </ul>
             <Delinquent name="delinquent"
                         {...this.props.Delinquent}
+                        addressBooks={this.props.AddressBooks}
                         dispatch={this.props.dispatch}
                         onUpdate={this.handleUpdate.bind(this, 'Delinquent')}
                         onError={this.handleError}
@@ -242,10 +250,12 @@ class Financial extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let financial = app.Financial || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const financial = app.Financial || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     Financial: financial,
     Gambling: financial.Gambling || {},
@@ -256,7 +266,8 @@ function mapStateToProps (state) {
     Delinquent: financial.Delinquent || {},
     Nonpayment: financial.Nonpayment || {},
     Errors: errors.financial || [],
-    Completed: completed.financial || []
+    Completed: completed.financial || [],
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/Foreign/Activities/CoOwner.jsx
+++ b/src/components/Section/Foreign/Activities/CoOwner.jsx
@@ -67,6 +67,9 @@ export default class CoOwner extends ValidationElement {
                     label={i18n.t(`foreign.${prefix}.label.address`)}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="ForeignNational"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateAddress}
                     onError={this.props.onError}
                     />
@@ -97,6 +100,8 @@ export default class CoOwner extends ValidationElement {
 
 CoOwner.defaultProps = {
   prefix: 'coOwner',
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Activities/CoOwners.jsx
+++ b/src/components/Section/Foreign/Activities/CoOwners.jsx
@@ -36,6 +36,8 @@ export default class CoOwners extends ValidationElement {
           <CoOwner name="CoOwner"
                    bind={true}
                    prefix={`${this.props.prefix}.coOwner`}
+                   addressBooks={this.props.addressBooks}
+                   dispatch={this.props.dispatch}
                    onError={this.props.onError}
                    />
         </BranchCollection>
@@ -45,6 +47,8 @@ export default class CoOwners extends ValidationElement {
 }
 
 CoOwner.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectActivity.jsx
@@ -85,6 +85,8 @@ export default class DirectActivity extends SubsectionElement {
                      appendTitle={i18n.t('foreign.activities.direct.collection.appendTitle')}
                      appendLabel={i18n.t('foreign.activities.direct.collection.appendLabel')}>
             <DirectInterest name="DirectInterest"
+                            addressBooks={this.props.addressBooks}
+                            dispatch={this.props.dispatch}
                             bind={true}
                             />
           </Accordion>
@@ -104,7 +106,8 @@ DirectActivity.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'activities/direct',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new ForeignDirectActivityValidator(state, props).isValid()
   }

--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectInterest.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectInterest.jsx
@@ -264,6 +264,8 @@ export default class DirectInterest extends ValidationElement {
 
         <CoOwners prefix={prefix}
                   {...this.props.CoOwners}
+                  addressBooks={this.props.addressBooks}
+                  dispatch={this.props.dispatch}
                   onUpdate={this.updateCoOwners}
                   onError={this.props.onError}
                   />
@@ -275,6 +277,8 @@ export default class DirectInterest extends ValidationElement {
 
 DirectInterest.defaultProps = {
   prefix: 'activities.direct.interest',
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectActivity.jsx
@@ -86,6 +86,8 @@ export default class IndirectActivity extends SubsectionElement {
                      appendTitle={i18n.t('foreign.activities.indirect.collection.appendTitle')}
                      appendLabel={i18n.t('foreign.activities.indirect.collection.appendLabel')}>
             <IndirectInterest name="IndirectInterest"
+                              addressBooks={this.props.addressBooks}
+                              dispatch={this.props.dispatch}
                               bind={true}
                               />
           </Accordion>
@@ -105,7 +107,8 @@ IndirectActivity.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'activities/indirect',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new ForeignIndirectActivityValidator(state, props).isValid()
   }

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectInterest.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectInterest.jsx
@@ -312,6 +312,8 @@ export default class IndirectInterest extends ValidationElement {
 
         <CoOwners prefix={prefix}
                   {...this.props.CoOwners}
+                  addressBooks={this.props.addressBooks}
+                  dispatch={this.props.dispatch}
                   onUpdate={this.updateCoOwners}
                   onError={this.props.onError}
                   />
@@ -323,6 +325,8 @@ export default class IndirectInterest extends ValidationElement {
 
 IndirectInterest.defaultProps = {
   prefix: 'activities.indirect.interest',
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Activities/Support.jsx
+++ b/src/components/Section/Foreign/Activities/Support.jsx
@@ -95,6 +95,9 @@ export default class Support extends SubsectionElement {
                         className="foreign-activities-support-address"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBook="ForeignNational"
+                        addressBooks={this.props.addressBooks}
+                        dispatch={this.props.dispatch}
                         bind={true}
                         required={this.props.required}
                         />
@@ -167,6 +170,7 @@ Support.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'activities/support',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new ForeignActivitiesSupportValidator(props, props).isValid()

--- a/src/components/Section/Foreign/Business/Contact.jsx
+++ b/src/components/Section/Foreign/Business/Contact.jsx
@@ -98,6 +98,9 @@ export default class Contact extends SubsectionElement {
                           cityPlaceholder={i18n.t('foreign.business.contact.placeholder.city')}
                           countryPlaceholder={i18n.t('foreign.business.contact.placeholder.country')}
                           className="birthplace foreign-business-contact-location"
+                          addressBooks={this.props.addressBooks}
+                          addressBook="ForeignNational"
+                          dispatch={this.props.dispatch}
                           bind={true}
                           />
             </Field>
@@ -165,7 +168,8 @@ Contact.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'business/contact',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new ForeignBusinessContactValidator(state, props).isValid()
   },

--- a/src/components/Section/Foreign/Business/Sponsorship.jsx
+++ b/src/components/Section/Foreign/Business/Sponsorship.jsx
@@ -105,6 +105,9 @@ export default class Sponsorship extends SubsectionElement {
                         cityPlaceholder={i18n.t('foreign.business.sponsorship.placeholder.city')}
                         countryPlaceholder={i18n.t('foreign.business.sponsorship.placeholder.country')}
                         className="foreign-business-sponsorship-birthplace"
+                        addressBooks={this.props.addressBooks}
+                        addressBook="ForeignNational"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -115,6 +118,9 @@ export default class Sponsorship extends SubsectionElement {
               <Location name="Address"
                         className="foreign-business-sponsorship-address"
                         layout={Location.ADDRESS}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="ForeignNational"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -151,6 +157,9 @@ export default class Sponsorship extends SubsectionElement {
                           className="foreign-business-sponsorship-organizationaddress"
                           layout={Location.ADDRESS}
                           geocode={true}
+                          addressBooks={this.props.addressBooks}
+                          addressBook="Organization"
+                          dispatch={this.props.dispatch}
                           bind={true}
                           />
               </NotApplicable>
@@ -172,6 +181,9 @@ export default class Sponsorship extends SubsectionElement {
                         disableToggle={true}
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="ForeignNational"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -207,7 +219,8 @@ Sponsorship.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'business/sponsorship',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new ForeignBusinessSponsorshipValidator(state, props).isValid()
   },

--- a/src/components/Section/Foreign/Business/Ventures.jsx
+++ b/src/components/Section/Foreign/Business/Ventures.jsx
@@ -90,6 +90,9 @@ export default class Ventures extends SubsectionElement {
               <Location name="Address"
                         className="ventures-address"
                         layout={Location.ADDRESS}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="ForeignNational"
+                        dispatch={this.props.dispatch}
                         geocode={true}
                         bind={true}
                         />
@@ -184,7 +187,8 @@ Ventures.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'business/ventures',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new ForeignBusinessVenturesValidator(props, props).isValid()
   },

--- a/src/components/Section/Foreign/Contacts/Contacts.jsx
+++ b/src/components/Section/Foreign/Contacts/Contacts.jsx
@@ -74,7 +74,10 @@ export default class Contacts extends SubsectionElement {
                      appendTitle={i18n.t('foreign.contacts.collection.appendTitle')}
                      appendMessage={i18n.m('foreign.contacts.collection.appendMessage')}
                      appendLabel={i18n.t('foreign.contacts.collection.append')}>
-            <ForeignNational name="Item" bind={true} />
+            <ForeignNational name="Item"
+                             addressBooks={this.props.addressBooks}
+                             dispatch={this.props.dispatch}
+                             bind={true} />
           </Accordion>
         </Show>
       </div>
@@ -90,6 +93,7 @@ Contacts.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'foreign',
   subsection: 'contacts',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new ForeignContactsValidator(props, props).isValid()

--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -500,6 +500,9 @@ export default class ForeignNational extends ValidationElement {
                       className="birthplace"
                       layout={Location.CITY_COUNTRY}
                       {...this.props.Birthplace}
+                      addressBooks={this.props.addressBooks}
+                      addressBook="ForeignNational"
+                      dispatch={this.props.dispatch}
                       onUpdate={this.updateBirthplace}
                       onError={this.props.onError}
                       />
@@ -520,6 +523,9 @@ export default class ForeignNational extends ValidationElement {
                       {...this.props.Address}
                       layout={Location.ADDRESS}
                       geocode={true}
+                      addressBooks={this.props.addressBooks}
+                      addressBook="ForeignNational"
+                      dispatch={this.props.dispatch}
                       onUpdate={this.updateAddress}
                       onError={this.props.onError}
                       />
@@ -557,6 +563,9 @@ export default class ForeignNational extends ValidationElement {
                       {...this.props.EmployerAddress}
                       layout={Location.ADDRESS}
                       geocode={true}
+                      addressBooks={this.props.addressBooks}
+                      addressBook="Company"
+                      dispatch={this.props.dispatch}
                       onUpdate={this.updateEmployerAddress}
                       onError={this.props.onError}
                       />
@@ -632,6 +641,8 @@ ForeignNational.defaultProps = {
   EmployerAddress: {},
   HasAffiliations: '',
   Affiliations: {},
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Foreign.jsx
+++ b/src/components/Section/Foreign/Foreign.jsx
@@ -143,6 +143,7 @@ class Foreign extends SectionElement {
             <Contacts name="contacts"
                       {...this.props.Contacts}
                       defaultState={false}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateContacts}
                       onError={this.handleError}
@@ -152,6 +153,7 @@ class Foreign extends SectionElement {
             <DirectActivity name="directActivity"
                             {...this.props.DirectActivity}
                             defaultState={false}
+                            addressBooks={this.props.AddressBooks}
                             dispatch={this.props.dispatch}
                             onUpdate={this.updateDirectActivity}
                             onError={this.handleError}
@@ -161,6 +163,7 @@ class Foreign extends SectionElement {
             <IndirectActivity name="indirectActivity"
                               {...this.props.IndirectActivity}
                               defaultState={false}
+                              addressBooks={this.props.AddressBooks}
                               dispatch={this.props.dispatch}
                               onUpdate={this.updateIndirectActivity}
                               onError={this.handleError}
@@ -188,6 +191,7 @@ class Foreign extends SectionElement {
             <Support name="support"
                      {...this.props.Support}
                      defaultState={false}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateSupport}
                      onError={this.handleError}
@@ -224,6 +228,7 @@ class Foreign extends SectionElement {
             <Ventures name="ventures"
                       {...this.props.Ventures}
                       defaultState={false}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateVentures}
                       onError={this.handleError}
@@ -242,6 +247,7 @@ class Foreign extends SectionElement {
             <Contact name="Contact"
                      {...this.props.Contact}
                      defaultState={false}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateContact}
                      onError={this.handleError}
@@ -251,6 +257,7 @@ class Foreign extends SectionElement {
             <Sponsorship name="Sponsorship"
                          {...this.props.Sponsorship}
                          defaultState={false}
+                         addressBooks={this.props.AddressBooks}
                          dispatch={this.props.dispatch}
                          onUpdate={this.updateSponsorship}
                          onError={this.handleError}
@@ -306,6 +313,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.activities.activity')}>
             <Contacts name="contacts"
                       {...this.props.Contacts}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateContacts}
                       onError={this.handleError}
@@ -319,6 +327,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.activities.indirect')}>
             <DirectActivity name="directActivity"
                             {...this.props.DirectActivity}
+                            addressBooks={this.props.AddressBooks}
                             dispatch={this.props.dispatch}
                             onUpdate={this.updateDirectActivity}
                             onError={this.handleError}
@@ -331,6 +340,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.activities.indirect')}>
             <DirectActivity name="directActivity"
                             {...this.props.DirectActivity}
+                            addressBooks={this.props.AddressBooks}
                             dispatch={this.props.dispatch}
                             onUpdate={this.updateDirectActivity}
                             onError={this.handleError}
@@ -344,6 +354,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.activities.realestate')}>
             <IndirectActivity name="indirectActivity"
                               {...this.props.IndirectActivity}
+                              addressBooks={this.props.AddressBooks}
                               dispatch={this.props.dispatch}
                               onUpdate={this.updateIndirectActivity}
                               onError={this.handleError}
@@ -382,6 +393,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.business.advice')}>
             <Support name="support"
                      {...this.props.Support}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateSupport}
                      onError={this.handleError}
@@ -447,6 +459,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.business.events')}>
             <Ventures name="ventures"
                       {...this.props.Ventures}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateVentures}
                       onError={this.handleError}
@@ -473,6 +486,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.business.sponsorship')}>
             <Contact name="Contact"
                      {...this.props.Contact}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateContact}
                      onError={this.handleError}
@@ -486,6 +500,7 @@ class Foreign extends SectionElement {
                        nextLabel={i18n.t('foreign.destination.business.political')}>
             <Sponsorship name="Sponsorship"
                          {...this.props.Sponsorship}
+                         addressBooks={this.props.AddressBooks}
                          dispatch={this.props.dispatch}
                          onUpdate={this.updateSponsorship}
                          onError={this.handleError}
@@ -537,12 +552,13 @@ class Foreign extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let foreign = app.Foreign || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const foreign = app.Foreign || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const identification = app.Identification || {}
+  const addressBooks = app.AddressBooks || {}
 
-  let identification = app.Identification || {}
   let names = []
   if (identification.ApplicantName) {
     names.push(identification.ApplicantName)
@@ -575,7 +591,8 @@ function mapStateToProps (state) {
     Travel: foreign.Travel || {},
     Errors: errors.foreign || [],
     Completed: completed.foreign || [],
-    suggestedNames: names
+    suggestedNames: names,
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -96,7 +96,10 @@ export default class Employment extends SubsectionElement {
                    customDetails={this.customEmploymentDetails}
                    description={i18n.t('history.employment.default.collection.summary.title')}
                    appendLabel={i18n.t('history.employment.default.collection.append')}>
-          <EmploymentItem name="Item" bind={true} />
+          <EmploymentItem name="Item"
+                          addressBooks={this.props.addressBooks}
+                          dispatch={this.props.dispatch}
+                          bind={true} />
         </Accordion>
       </div>
     )
@@ -115,6 +118,7 @@ Employment.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'history',
   subsection: 'employment',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return props.value.every(x => {

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -199,6 +199,9 @@ export default class EmploymentItem extends ValidationElement {
                       {...this.props.Address}
                       layout={Location.ADDRESS}
                       geocode={true}
+                      addressBooks={this.props.addressBooks}
+                      addressBook="Employment"
+                      dispatch={this.props.dispatch}
                       onUpdate={this.onUpdate.bind(this, 'Address')}
                       onError={this.props.onError}
                       label={i18n.t(`${prefix}.address.label`)}
@@ -210,6 +213,8 @@ export default class EmploymentItem extends ValidationElement {
           <Field title={i18n.t(`${prefix}.heading.physicalAddress`)}>
             <PhysicalAddress name="PhysicalAddress"
                              {...this.props.PhysicalAddress}
+                             addressBooks={this.props.addressBooks}
+                             dispatch={this.props.dispatch}
                              onUpdate={this.onUpdate.bind(this, 'PhysicalAddress')}
                              onError={this.props.onError}
                              />
@@ -231,6 +236,8 @@ export default class EmploymentItem extends ValidationElement {
         <Show when={this.showSupervisor()}>
           <Supervisor name="Supervisor"
                       {...this.props.Supervisor}
+                      addressBooks={this.props.addressBooks}
+                      dispatch={this.props.dispatch}
                       onUpdate={this.onUpdate.bind(this, 'Supervisor')}
                       onError={this.props.onError}
                       />
@@ -241,6 +248,8 @@ export default class EmploymentItem extends ValidationElement {
             <h2>{i18n.t(`${prefix}.heading.reference`)}</h2>
             <Reference name="Reference"
                        {...this.props.Reference}
+                       addressBooks={this.props.addressBooks}
+                       dispatch={this.props.dispatch}
                        onUpdate={this.onUpdate.bind(this, 'Reference')}
                        onError={this.props.onError}
                        />
@@ -281,5 +290,7 @@ export default class EmploymentItem extends ValidationElement {
 }
 
 EmploymentItem.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/History/Employment/PhysicalAddress.jsx
+++ b/src/components/Section/History/Employment/PhysicalAddress.jsx
@@ -85,6 +85,9 @@ export default class PhysicalAddress extends ValidationElement {
                       placeholder={i18n.t('history.employment.default.physicalAddress.address.placeholder')}
                       layout={Location.ADDRESS}
                       geocode={true}
+                      addressBooks={this.props.addressBooks}
+                      addressBook={this.props.addressBook}
+                      dispatch={this.props.dispatch}
                       onUpdate={this.handleAddressChange}
                       onError={this.props.onError}
                       />
@@ -114,5 +117,8 @@ export default class PhysicalAddress extends ValidationElement {
 }
 
 PhysicalAddress.defaultProps = {
+  addressBooks: {},
+  addressBook: 'Company',
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/History/Employment/Supervisor.jsx
+++ b/src/components/Section/History/Employment/Supervisor.jsx
@@ -100,6 +100,9 @@ export default class Supervisor extends ValidationElement {
                     className="supervisor-address"
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook={this.props.addressBook}
+                    dispatch={this.props.dispatch}
                     onUpdate={this.onUpdate.bind(this, 'Address')}
                     onError={this.props.onError}
                     />
@@ -127,5 +130,8 @@ Supervisor.defaultProps = {
   EmailNotApplicable: {},
   Address: {},
   Telephone: {},
+  addressBooks: {},
+  addressBook: 'Supervisor',
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -101,6 +101,9 @@ export default class Federal extends SubsectionElement {
               <Location name="Address"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Agency"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -118,6 +121,7 @@ Federal.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'history',
   subsection: 'federal',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new FederalServiceValidator(props, props).isValid()

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -342,6 +342,7 @@ class History extends SectionElement {
                        overrideInitial={this.overrideInitial}
                        onUpdate={this.updateResidence}
                        onError={this.handleError}
+                       addressBooks={this.props.AddressBooks}
                        dispatch={this.props.dispatch}
                        />
 
@@ -353,6 +354,7 @@ class History extends SectionElement {
                         overrideInitial={this.overrideInitial}
                         onUpdate={this.updateEmployment}
                         onError={this.handleError}
+                        addressBooks={this.props.AddressBooks}
                         dispatch={this.props.dispatch}
                         />
 
@@ -374,6 +376,7 @@ class History extends SectionElement {
             <Federal name="federal"
                      {...this.props.Federal}
                      defaultState={false}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.handleUpdate.bind(this, 'Federal')}
                      onError={this.handleError}
@@ -401,6 +404,7 @@ class History extends SectionElement {
                        overrideInitial={this.overrideInitial}
                        onUpdate={this.updateResidence}
                        onError={this.handleError}
+                       addressBooks={this.props.AddressBooks}
                        dispatch={this.props.dispatch}
                        />
 
@@ -430,6 +434,7 @@ class History extends SectionElement {
                         overrideInitial={this.overrideInitial}
                         onUpdate={this.updateEmployment}
                         onError={this.handleError}
+                        addressBooks={this.props.AddressBooks}
                         dispatch={this.props.dispatch}
                         />
 
@@ -493,6 +498,7 @@ class History extends SectionElement {
             <h2>{i18n.t('history.federal.title')}</h2>
             <Federal name="federal"
                      {...this.props.Federal}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.handleUpdate.bind(this, 'Federal')}
                      onError={this.handleError}
@@ -518,11 +524,13 @@ const processDate = (date) => {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let identification = app.Identification || {}
-  let history = app.History || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const identification = app.Identification || {}
+  const history = app.History || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     History: history,
     Residence: history.Residence || [],
@@ -531,7 +539,8 @@ function mapStateToProps (state) {
     Federal: history.Federal || {},
     Errors: errors.history || [],
     Completed: completed.history || [],
-    Birthdate: processDate(identification.ApplicantBirthDate)
+    Birthdate: processDate(identification.ApplicantBirthDate),
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -96,7 +96,10 @@ export default class Residence extends SubsectionElement {
                    customDetails={this.customResidenceDetails}
                    description={i18n.t('history.residence.collection.summary.title')}
                    appendLabel={i18n.t('history.residence.collection.append')}>
-          <ResidenceItem name="Item" bind={true} />
+          <ResidenceItem name="Item"
+                         addressBooks={this.props.addressBooks}
+                         dispatch={this.props.dispatch}
+                         bind={true} />
         </Accordion>
       </div>
     )
@@ -115,6 +118,7 @@ Residence.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'history',
   subsection: 'residence',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return props.value.every(x => {

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -82,6 +82,8 @@ export default class ResidenceItem extends ValidationElement {
           <p>{i18n.t('history.residence.para.reference')}</p>
           <Reference name="Reference"
                      {...this.state.Reference}
+                     addressBooks={this.props.addressBooks}
+                     dispatch={this.props.dispatch}
                      onUpdate={this.onUpdate.bind(this, 'Reference')}
                      onError={this.props.onError}
                      />
@@ -110,6 +112,8 @@ export default class ResidenceItem extends ValidationElement {
                     label={i18n.t('history.residence.label.address')}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBook="Residence"
+                    addressBooks={this.props.addressBooks}
                     onUpdate={this.onUpdate.bind(this, 'Address')}
                     onError={this.props.onError}
                     />
@@ -180,5 +184,7 @@ export default class ResidenceItem extends ValidationElement {
 }
 
 ResidenceItem.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -117,6 +117,7 @@ export default class ResidenceItem extends ValidationElement {
                     geocode={true}
                     addressBook="Residence"
                     addressBooks={this.props.addressBooks}
+                    dispatch={this.props.dispatch}
                     onUpdate={this.onUpdate.bind(this, 'Address')}
                     onError={this.props.onError}
                     required={this.props.required}

--- a/src/components/Section/Legal/Associations/MembershipOverthrow.jsx
+++ b/src/components/Section/Legal/Associations/MembershipOverthrow.jsx
@@ -91,6 +91,9 @@ export default class MembershipOverthrow extends SubsectionElement {
                         className="legal-associations-overthrow-address"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Organization"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -157,7 +160,8 @@ MembershipOverthrow.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'associations/membership-overthrow',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalAssociationsOverthrowValidator(state, props).isValid()
   }

--- a/src/components/Section/Legal/Associations/MembershipViolence.jsx
+++ b/src/components/Section/Legal/Associations/MembershipViolence.jsx
@@ -91,6 +91,9 @@ export default class MembershipViolence extends SubsectionElement {
                         className="legal-associations-violence-address"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Organization"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -157,7 +160,8 @@ MembershipViolence.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'associations/membership-violence-or-force',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalAssociationsViolenceValidator(state, props).isValid()
   }

--- a/src/components/Section/Legal/Associations/TerroristOrganization.jsx
+++ b/src/components/Section/Legal/Associations/TerroristOrganization.jsx
@@ -93,6 +93,9 @@ export default class TerroristOrganization extends SubsectionElement {
                         className="legal-associations-terrorist-address"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Organization"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -159,7 +162,8 @@ TerroristOrganization.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'associations/terrorist-organization',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalAssociationsTerroristValidator(state, props).isValid()
   }

--- a/src/components/Section/Legal/Legal.jsx
+++ b/src/components/Section/Legal/Legal.jsx
@@ -145,6 +145,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.additionalOffenses')}>
             <Offenses name="offenses"
                       {...this.props.PoliceOffenses}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updatePoliceOffenses}
                       onError={this.handleError}
@@ -158,6 +159,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.domesticViolence')}>
             <OtherOffenses name="otheroffenses"
                            {...this.props.PoliceOtherOffenses}
+                           addressBooks={this.props.AddressBooks}
                            dispatch={this.props.dispatch}
                            onUpdate={this.updatePoliceOtherOffenses}
                            onError={this.handleError}
@@ -171,6 +173,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.investigations.history')}>
             <DomesticViolenceList name="domesticviolence"
                                   {...this.props.PoliceDomesticViolence}
+                                  addressBooks={this.props.AddressBooks}
                                   dispatch={this.props.dispatch}
                                   onUpdate={this.updatePoliceDomesticViolence}
                                   onError={this.handleError}
@@ -236,6 +239,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.technology.unauthorized')}>
             <NonCriminalCourtActions name="courtactions"
                       {...this.props.NonCriminalCourtActions}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateNonCriminalCourtActions}
                       onError={this.handleError}
@@ -249,6 +253,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.technology.manipulating')}>
             <Unauthorized name="unauthorized"
                           {...this.props.Unauthorized}
+                          addressBooks={this.props.AddressBooks}
                           dispatch={this.props.dispatch}
                           onUpdate={this.updateUnauthorized}
                           onError={this.handleError}
@@ -262,6 +267,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.technology.manipulating')}>
             <Unauthorized name="unauthorized"
                           {...this.props.Unauthorized}
+                          addressBooks={this.props.AddressBooks}
                           dispatch={this.props.dispatch}
                           onUpdate={this.updateUnauthorized}
                           onError={this.handleError}
@@ -275,6 +281,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.technology.unlawful')}>
             <Manipulating name="manipulating"
                           {...this.props.Manipulating}
+                          addressBooks={this.props.AddressBooks}
                           dispatch={this.props.dispatch}
                           onUpdate={this.updateManipulating}
                           onError={this.handleError}
@@ -288,6 +295,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.associations.terrorist')}>
             <Unlawful name="unlawful"
                       {...this.props.Unlawful}
+                      addressBooks={this.props.AddressBooks}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateUnlawful}
                       onError={this.handleError}
@@ -301,6 +309,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.associations.engaged')}>
             <TerroristOrganization name="terroristOrganization"
                                    {...this.props.TerroristOrganization}
+                                   addressBooks={this.props.AddressBooks}
                                    dispatch={this.props.dispatch}
                                    onUpdate={this.updateTerroristOrganization}
                                    onError={this.handleError}
@@ -314,6 +323,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.associations.engaged')}>
             <TerroristOrganization name="terroristOrganization"
                                    {...this.props.TerroristOrganization}
+                                   addressBooks={this.props.AddressBooks}
                                    dispatch={this.props.dispatch}
                                    onUpdate={this.updateTerroristOrganization}
                                    onError={this.handleError}
@@ -353,6 +363,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.associations.violence')}>
             <MembershipOverthrow name="membershipOverthrow"
                                  {...this.props.MembershipOverthrow}
+                                 addressBooks={this.props.AddressBooks}
                                  dispatch={this.props.dispatch}
                                  onUpdate={this.updateMembershipOverthrow}
                                  onError={this.handleError}
@@ -366,6 +377,7 @@ class Legal extends SectionElement {
                        nextLabel={i18n.t('legal.destination.associations.activities')}>
             <MembershipViolence name="membershipViolence"
                                 {...this.props.MembershipViolence}
+                                addressBooks={this.props.AddressBooks}
                                 dispatch={this.props.dispatch}
                                 onUpdate={this.updateMembershipViolence}
                                 onError={this.handleError}
@@ -415,6 +427,7 @@ class Legal extends SectionElement {
 
             <Offenses name="offenses"
                       {...this.props.PoliceOffenses}
+                      addressBooks={this.props.AddressBooks}
                       defaultState={false}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updatePoliceOffenses}
@@ -424,6 +437,7 @@ class Legal extends SectionElement {
             <hr/>
             <OtherOffenses name="otheroffenses"
                            {...this.props.PoliceOtherOffenses}
+                           addressBooks={this.props.AddressBooks}
                            defaultState={false}
                            dispatch={this.props.dispatch}
                            onUpdate={this.updatePoliceOtherOffenses}
@@ -433,6 +447,7 @@ class Legal extends SectionElement {
             <hr/>
             <DomesticViolenceList name="domesticviolence"
                                   {...this.props.PoliceDomesticViolence}
+                                  addressBooks={this.props.AddressBooks}
                                   dispatch={this.props.dispatch}
                                   onUpdate={this.updatePoliceDomesticViolence}
                                   onError={this.handleError}
@@ -468,6 +483,7 @@ class Legal extends SectionElement {
             <hr />
             <NonCriminalCourtActions name="courtactions"
                       {...this.props.NonCriminalCourtActions}
+                      addressBooks={this.props.AddressBooks}
                       defaultState={false}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateNonCriminalCourtActions}
@@ -476,6 +492,7 @@ class Legal extends SectionElement {
             <hr />
             <Unauthorized name="unauthorized"
                           {...this.props.Unauthorized}
+                          addressBooks={this.props.AddressBooks}
                           defaultState={false}
                           dispatch={this.props.dispatch}
                           onUpdate={this.updateUnauthorized}
@@ -485,6 +502,7 @@ class Legal extends SectionElement {
             <hr />
             <Manipulating name="manipulating"
                           {...this.props.Manipulating}
+                          addressBooks={this.props.AddressBooks}
                           defaultState={false}
                           dispatch={this.props.dispatch}
                           onUpdate={this.updateManipulating}
@@ -494,6 +512,7 @@ class Legal extends SectionElement {
             <hr />
             <Unlawful name="unlawful"
                       {...this.props.Unlawful}
+                      addressBooks={this.props.AddressBooks}
                       defaultState={false}
                       dispatch={this.props.dispatch}
                       onUpdate={this.updateUnlawful}
@@ -503,6 +522,7 @@ class Legal extends SectionElement {
             <hr />
             <TerroristOrganization name="terroristOrganization"
                                    {...this.props.TerroristOrganization}
+                                   addressBooks={this.props.AddressBooks}
                                    dispatch={this.props.dispatch}
                                    onUpdate={this.updateTerroristOrganization}
                                    onError={this.handleError}
@@ -527,6 +547,7 @@ class Legal extends SectionElement {
             <hr />
             <MembershipOverthrow name="membershipOverthrow"
                                  {...this.props.MembershipOverthrow}
+                                 addressBooks={this.props.AddressBooks}
                                  dispatch={this.props.dispatch}
                                  onUpdate={this.updateMembershipOverthrow}
                                  onError={this.handleError}
@@ -535,6 +556,7 @@ class Legal extends SectionElement {
             <hr />
             <MembershipViolence name="membershipViolence"
                                 {...this.props.MembershipViolence}
+                                addressBooks={this.props.AddressBooks}
                                 dispatch={this.props.dispatch}
                                 onUpdate={this.updateMembershipViolence}
                                 onError={this.handleError}
@@ -564,10 +586,12 @@ class Legal extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let legal = app.Legal || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const legal = app.Legal || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     Legal: legal,
     Police: legal.Police || {},
@@ -589,7 +613,8 @@ function mapStateToProps (state) {
     ActivitiesToOverthrow: legal.ActivitiesToOverthrow || {},
     TerrorismAssociation: legal.TerrorismAssociation || {},
     Errors: errors.legal || [],
-    Completed: completed.legal || []
+    Completed: completed.legal || [],
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/Legal/NonCriminalCourtAction.jsx
+++ b/src/components/Section/Legal/NonCriminalCourtAction.jsx
@@ -82,6 +82,9 @@ export default class NonCriminalCourtAction extends ValidationElement {
                     {...this.props.CourtAddress}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Court"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateCourtAddress}
                     onError={this.props.onError}
                     />
@@ -122,6 +125,8 @@ export default class NonCriminalCourtAction extends ValidationElement {
 }
 
 NonCriminalCourtAction.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Legal/NonCriminalCourtActions.jsx
+++ b/src/components/Section/Legal/NonCriminalCourtActions.jsx
@@ -74,7 +74,10 @@ export default class NonCriminalCourtActions extends SubsectionElement {
                      description={i18n.t('legal.nonCriminalAction.collection.description')}
                      appendTitle={i18n.t('legal.nonCriminalAction.collection.appendTitle')}
                      appendLabel={i18n.t('legal.nonCriminalAction.collection.appendLabel')}>
-            <NonCriminalCourtAction name="CourtAction" bind={true} />
+            <NonCriminalCourtAction name="CourtAction"
+                                    addressBooks={this.props.addressBooks}
+                                    dispatch={this.props.dispatch}
+                                    bind={true} />
           </Accordion>
         </Show>
       </div>
@@ -89,7 +92,8 @@ NonCriminalCourtActions.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'court',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalNonCriminalCourtActionsValidator(props).isValid()
   }

--- a/src/components/Section/Legal/Police/DomesticViolence.jsx
+++ b/src/components/Section/Legal/Police/DomesticViolence.jsx
@@ -96,6 +96,9 @@ export default class DomesticViolence extends ValidationElement {
                     className="domestic-courtaddress"
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Court"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateCourtAddress}
                     onError={this.props.onError}
                     />
@@ -106,6 +109,8 @@ export default class DomesticViolence extends ValidationElement {
 }
 
 DomesticViolence.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Legal/Police/DomesticViolenceList.jsx
+++ b/src/components/Section/Legal/Police/DomesticViolenceList.jsx
@@ -37,6 +37,8 @@ export default class DomesticViolenceList extends SubsectionElement {
                           onError={this.handleError}
                           onUpdate={this.updateList}>
           <DomesticViolence name="domestic"
+                            addressBooks={this.props.addressBooks}
+                            dispatch={this.props.dispatch}
                             bind={true}
                             onError={this.handleError}
                             />
@@ -52,7 +54,8 @@ DomesticViolenceList.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'police/domesticviolence',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new DomesticViolenceValidator(props, props).isValid()
   }

--- a/src/components/Section/Legal/Police/Offense.jsx
+++ b/src/components/Section/Legal/Police/Offense.jsx
@@ -247,6 +247,9 @@ export default class Offense extends ValidationElement {
                     label={i18n.t('legal.police.label.address')}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Incident"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateAddress}
                     onError={this.props.onError}
                     />
@@ -288,6 +291,9 @@ export default class Offense extends ValidationElement {
                         label={i18n.t('legal.police.label.address')}
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Agency"
+                        dispatch={this.props.dispatch}
                         onUpdate={this.updateAgencyAddress}
                         onError={this.props.onError}
                         />
@@ -344,6 +350,9 @@ export default class Offense extends ValidationElement {
                         className="offense-courtaddress"
                         geocode={true}
                         layout={Location.ADDRESS}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Court"
+                        dispatch={this.props.dispatch}
                         onUpdate={this.updateCourtAddress}
                         onError={this.props.onError}
                         />
@@ -481,6 +490,8 @@ Offense.defaultProps = {
   Sentence: {},
   AwaitingTrial: '',
   AwaitingTrialExplanation: {},
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Legal/Police/Offenses.jsx
+++ b/src/components/Section/Legal/Police/Offenses.jsx
@@ -87,6 +87,8 @@ export default class Offenses extends SubsectionElement {
                        appendMessage={i18n.m('legal.police.collection.appendMessage')}
                        appendLabel={i18n.t('legal.police.collection.append')}>
               <Offense name="Item"
+                       addressBooks={this.props.addressBooks}
+                       dispatch={this.props.dispatch}
                        bind={true}
                        />
             </Accordion>
@@ -102,7 +104,8 @@ Offenses.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'police/offenses',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new PoliceOffensesValidator(props).isValid()
   },

--- a/src/components/Section/Legal/Police/OtherOffense.jsx
+++ b/src/components/Section/Legal/Police/OtherOffense.jsx
@@ -208,6 +208,9 @@ export default class OtherOffense extends ValidationElement {
                     className="offense-courtaddress"
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Court"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateCourtAddress}
                     onError={this.props.onError}
                     />
@@ -321,6 +324,8 @@ export default class OtherOffense extends ValidationElement {
 }
 
 OtherOffense.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Legal/Police/OtherOffenses.jsx
+++ b/src/components/Section/Legal/Police/OtherOffenses.jsx
@@ -101,6 +101,8 @@ export default class OtherOffenses extends SubsectionElement {
                      appendMessage={this.otherOffenseBranch()}
                      appendLabel={i18n.t('legal.police.collection.append')}>
             <OtherOffense name="Item"
+                          addressBooks={this.props.addressBooks}
+                          dispatch={this.props.dispatch}
                           bind={true}
                           />
           </Accordion>
@@ -115,7 +117,8 @@ OtherOffenses.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'police/additionaloffenses',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new PoliceOtherOffensesValidator(props).isValid()
   },

--- a/src/components/Section/Legal/Technology/Manipulating.jsx
+++ b/src/components/Section/Legal/Technology/Manipulating.jsx
@@ -100,6 +100,9 @@ export default class Manipulating extends SubsectionElement {
                         className="legal-technology-manipulating-location"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Incident"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -129,7 +132,8 @@ Manipulating.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'technology/manipulating',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalTechnologyManipulatingValidator(state, props).isValid()
   }

--- a/src/components/Section/Legal/Technology/Unauthorized.jsx
+++ b/src/components/Section/Legal/Technology/Unauthorized.jsx
@@ -102,6 +102,9 @@ export default class Unauthorized extends SubsectionElement {
                         className="legal-technology-unauthorized-location"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Incident"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -131,7 +134,8 @@ Unauthorized.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'technology/unauthorized',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalTechnologyUnauthorizedValidator(state, props).isValid()
   }

--- a/src/components/Section/Legal/Technology/Unlawful.jsx
+++ b/src/components/Section/Legal/Technology/Unlawful.jsx
@@ -100,6 +100,9 @@ export default class Unlawful extends SubsectionElement {
                         className="legal-technology-unlawful-location"
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Incident"
+                        dispatch={this.props.dispatch}
                         bind={true}
                         />
             </Field>
@@ -129,7 +132,8 @@ Unlawful.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'legal',
   subsection: 'technology/unlawful',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new LegalTechnologyUnlawfulValidator(state, props).isValid()
   }

--- a/src/components/Section/Military/Foreign/Foreign.jsx
+++ b/src/components/Section/Military/Foreign/Foreign.jsx
@@ -27,6 +27,8 @@ export default class Foreign extends SubsectionElement {
                           onError={this.handleError}>
           <ForeignService name="Item"
                           bind={true}
+                          addressBooks={this.props.addressBooks}
+                          dispatch={this.props.dispatch}
                           defaultState={this.props.defaultState}
                           onError={this.handleError}
                           />
@@ -41,7 +43,8 @@ Foreign.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'military',
   subsection: 'foreign',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new MilitaryForeignValidator(state, props).isValid()
   },

--- a/src/components/Section/Military/Foreign/ForeignContact.jsx
+++ b/src/components/Section/Military/Foreign/ForeignContact.jsx
@@ -72,6 +72,9 @@ export default class ForeignContact extends React.Component {
           <Location name="Address"
                     className="foreign-contact-address"
                     {...this.props.Address}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="ForeignNational"
+                    dispatch={this.props.dispatch}
                     layout={Location.ADDRESS}
                     geocode={true}
                     onUpdate={this.updateAddress}
@@ -122,6 +125,8 @@ ForeignContact.defaultProps = {
   Title: {},
   Dates: {},
   Frequency: {},
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Military/Foreign/ForeignService.jsx
+++ b/src/components/Section/Military/Foreign/ForeignService.jsx
@@ -278,6 +278,8 @@ export default class ForeignService extends ValidationElement {
                        appendLabel={i18n.t('military.foreign.collection.contacts.append')}>
               <ForeignContact name="Item"
                               bind={true}
+                              addressBooks={this.props.addressBooks}
+                              dispatch={this.props.dispatch}
                               />
             </Accordion>
           </div>
@@ -288,6 +290,8 @@ export default class ForeignService extends ValidationElement {
 }
 
 ForeignService.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   defaultState: true

--- a/src/components/Section/Military/History/History.jsx
+++ b/src/components/Section/Military/History/History.jsx
@@ -116,6 +116,7 @@ History.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'military',
   subsection: 'history',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new MilitaryHistoryValidator(props, props).isValid()

--- a/src/components/Section/Military/Military.jsx
+++ b/src/components/Section/Military/Military.jsx
@@ -99,6 +99,7 @@ class Military extends SectionElement {
             {i18n.m('military.foreign.para.served')}
             <Foreign name="foreign"
                      {...this.props.Foreign}
+                     addressBooks={this.props.AddressBooks}
                      defaultState={false}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateForeign}
@@ -158,6 +159,7 @@ class Military extends SectionElement {
             {i18n.m('military.foreign.para.served')}
             <Foreign name="foreign"
                      {...this.props.Foreign}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateForeign}
                      onError={this.handleError}
@@ -170,10 +172,12 @@ class Military extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let military = app.Military || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const military = app.Military || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     Application: app || {},
     Military: military,
@@ -182,7 +186,8 @@ function mapStateToProps (state) {
     Disciplinary: military.Disciplinary || {},
     Foreign: military.Foreign || {},
     Errors: errors.military || [],
-    Completed: completed.military || []
+    Completed: completed.military || [],
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/Psychological/Competence/Competence.jsx
+++ b/src/components/Section/Psychological/Competence/Competence.jsx
@@ -77,6 +77,8 @@ export default class Competence extends SubsectionElement {
             <Order name="Competence"
                    ApplicantBirthDate={this.props.ApplicantBirthDate}
                    prefix="competence"
+                   addressBooks={this.props.addressBooks}
+                   dispatch={this.props.dispatch}
                    bind={true} />
           </Accordion>
         </Show>
@@ -94,6 +96,7 @@ Competence.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'psychological',
   subsection: 'competence',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new CompetenceValidator(props, props).isValid()

--- a/src/components/Section/Psychological/Consultation/Consultation.jsx
+++ b/src/components/Section/Psychological/Consultation/Consultation.jsx
@@ -78,6 +78,8 @@ export default class Consultation extends SubsectionElement {
             <Order name="Consultation"
                    prefix="consultation"
                    ApplicantBirthDate={this.props.ApplicantBirthDate}
+                   addressBooks={this.props.addressBooks}
+                   dispatch={this.props.dispatch}
                    bind={true} />
           </Accordion>
         </Show>
@@ -95,6 +97,7 @@ Consultation.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'psychological',
   subsection: 'consultations',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new ConsultationValidator(props, props).isValid()

--- a/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
@@ -167,6 +167,8 @@ export default class Diagnoses extends SubsectionElement {
                          appendLabel={i18n.t('psychological.diagnoses.treatment.collection.appendLabel')}>
                 <Treatment name="Treatment"
                            prefix="diagnoses.professional"
+                           addressBooks={this.props.addressBooks}
+                           dispatch={this.props.dispatch}
                            bind={true} />
               </Accordion>
             </Show>
@@ -188,6 +190,7 @@ Diagnoses.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'psychological',
   subsection: 'diagnoses',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new DiagnosesValidator(props, props).isValid()

--- a/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnoses.jsx
@@ -137,6 +137,8 @@ export default class Diagnoses extends SubsectionElement {
                          ApplicantBirthDate={this.props.ApplicantBirthDate}
                          required={this.props.required}
                          scrollIntoView={this.props.scrollIntoView}
+                         addressBooks={this.props.addressBooks}
+                         dispatch={this.props.dispatch}
                          bind={true} />
             </Accordion>
 

--- a/src/components/Section/Psychological/Diagnoses/Diagnosis.jsx
+++ b/src/components/Section/Psychological/Diagnoses/Diagnosis.jsx
@@ -152,6 +152,8 @@ export default class Diagnosis extends ValidationElement {
           <Treatment name="Treatment"
                      {...this.props.Treatment}
                      prefix={`${prefix}.person`}
+                     addressBooks={this.props.addressBooks}
+                     dispatch={this.props.dispatch}
                      onUpdate={this.updateTreatment}
                      onError={this.props.onError}
                      />
@@ -162,6 +164,8 @@ export default class Diagnosis extends ValidationElement {
           <Treatment name="TreatmentFacility"
                      {...this.props.TreatmentFacility}
                      prefix={`${prefix}.facility`}
+                     addressBooks={this.props.addressBooks}
+                     dispatch={this.props.dispatch}
                      onUpdate={this.updateTreatmentFacility}
                      onError={this.props.onError}
                      />
@@ -211,6 +215,8 @@ export default class Diagnosis extends ValidationElement {
 
 Diagnosis.defaultProps = {
   prefix: 'diagnosis',
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Psychological/Order.jsx
+++ b/src/components/Section/Psychological/Order.jsx
@@ -92,6 +92,9 @@ export default class Order extends ValidationElement {
                     label={i18n.t(`psychological.${prefix}.label.courtAddress`)}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Court"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateCourtAddress}
                     onError={this.props.onError}
                     />
@@ -158,6 +161,8 @@ export default class Order extends ValidationElement {
 Order.defaultProps = {
   List: [],
   prefix: 'order',
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Psychological/Psychological.jsx
+++ b/src/components/Section/Psychological/Psychological.jsx
@@ -52,6 +52,7 @@ class Psychological extends SectionElement {
             <Competence name="Competence"
                         {...this.props.Competence}
                         ApplicantBirthDate={this.props.ApplicantBirthDate}
+                        addressBooks={this.props.AddressBooks}
                         dispatch={this.props.dispatch}
                         onError={this.handleError}
                         onUpdate={this.handleUpdate.bind(this, 'Competence')} />
@@ -65,6 +66,7 @@ class Psychological extends SectionElement {
             <Consultation name="Consultations"
                           {...this.props.Consultations}
                           ApplicantBirthDate={this.props.ApplicantBirthDate}
+                          addressBooks={this.props.AddressBooks}
                           dispatch={this.props.dispatch}
                           onError={this.handleError}
                           onUpdate={this.handleUpdate.bind(this, 'Consultation')} />
@@ -89,6 +91,7 @@ class Psychological extends SectionElement {
             <Diagnoses name="Diagnoses"
                        {...this.props.Diagnoses}
                        ApplicantBirthDate={this.props.ApplicantBirthDate}
+                       addressBooks={this.props.AddressBooks}
                        dispatch={this.props.dispatch}
                        onError={this.handleError}
                        onUpdate={this.handleUpdate.bind(this, 'Diagnoses')}
@@ -171,10 +174,12 @@ class Psychological extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let psychological = app.Psychological || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const psychological = app.Psychological || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     Psychological: psychological,
     Competence: psychological.Competence,
@@ -185,7 +190,8 @@ function mapStateToProps (state) {
     Errors: errors.financial || [],
     Completed: completed.psychological || [],
     ShowExistingConditions: showQuestion21E(psychological),
-    ApplicantBirthDate: extractApplicantBirthDate(app)
+    ApplicantBirthDate: extractApplicantBirthDate(app),
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/Psychological/Treatment.jsx
+++ b/src/components/Section/Psychological/Treatment.jsx
@@ -71,6 +71,9 @@ export default class Treatment extends ValidationElement {
                     label={i18n.t(`psychological.${prefix}.label.address`)}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Facility"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateAddress}
                     onError={this.props.onError}
                     />
@@ -82,6 +85,8 @@ export default class Treatment extends ValidationElement {
 
 Treatment.defaultProps = {
   prefix: 'treatment',
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -319,6 +319,9 @@ export default class CivilUnion extends ValidationElement {
                       {...this.props.Address}
                       layout={Location.ADDRESS}
                       geocode={true}
+                      addressBooks={this.props.addressBooks}
+                      addressBook="Relative"
+                      dispatch={this.props.dispatch}
                       onUpdate={this.updateAddress}
                       onError={this.props.onError}
                       />
@@ -420,6 +423,8 @@ CivilUnion.defaultProps = {
   AddressSeparatedNotApplicable: {},
   Divorced: '',
   UseCurrentAddress: false,
+  addressBooks: {},
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   defaultState: true

--- a/src/components/Section/Relationships/RelationshipStatus/Marital.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Marital.jsx
@@ -122,6 +122,8 @@ export default class Marital extends SubsectionElement {
         <Show when={['Married', 'InCivilUnion', 'Separated'].includes(this.props.Status)}>
           <CivilUnion name="civilUnion"
                       {...this.props.CivilUnion}
+                      addressBooks={this.props.addressBooks}
+                      dispatch={this.props.dispatch}
                       onUpdate={this.updateCivilUnion}
                       onError={this.handleError}
                       onSpouseUpdate={this.props.onSpouseUpdate}
@@ -160,6 +162,7 @@ Marital.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'relationships',
   subsection: 'status/marital',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new MaritalValidator(props, props).isValid()

--- a/src/components/Section/Relationships/Relationships.jsx
+++ b/src/components/Section/Relationships/Relationships.jsx
@@ -66,6 +66,7 @@ class Relationships extends SectionElement {
                        nextLabel={i18n.t('relationships.destination.cohabitant')}>
             <Marital name="marital"
                      {...this.props.Marital}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateMarital}
                      onError={this.handleError}
@@ -108,6 +109,7 @@ class Relationships extends SectionElement {
                        nextLabel={i18n.t('relationships.destination.review')}>
             <Relatives name="relatives"
                        {...this.props.Relatives}
+                       addressBooks={this.props.AddressBooks}
                        dispatch={this.props.dispatch}
                        onUpdate={this.updateRelatives}
                        onError={this.handleError}
@@ -125,6 +127,7 @@ class Relationships extends SectionElement {
             <Marital name="marital"
                      {...this.props.Marital}
                      defaultState={false}
+                     addressBooks={this.props.AddressBooks}
                      dispatch={this.props.dispatch}
                      onUpdate={this.updateMarital}
                      onError={this.handleError}
@@ -155,6 +158,7 @@ class Relationships extends SectionElement {
             <Relatives name="relatives"
                        {...this.props.Relatives}
                        defaultState={false}
+                       addressBooks={this.props.AddressBooks}
                        dispatch={this.props.dispatch}
                        onUpdate={this.updateRelatives}
                        onError={this.handleError}
@@ -167,11 +171,13 @@ class Relationships extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let relationships = app.Relationships || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
-  let history = app.History || {}
+  const app = state.application || {}
+  const relationships = app.Relationships || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const history = app.History || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     Relationships: relationships,
     Relatives: relationships.Relatives || {},
@@ -181,7 +187,8 @@ function mapStateToProps (state) {
     CurrentAddress: history.CurrentAddress,
     People: relationships.People || {},
     Errors: errors.relationships || [],
-    Completed: completed.relationships || []
+    Completed: completed.relationships || [],
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -522,6 +522,9 @@ export default class Relative extends ValidationElement {
             <Location name="Address"
                       className="relative-address"
                       {...this.props.Address}
+                      addressBooks={this.props.addressBooks}
+                      addressBook={this.props.addressBook}
+                      dispatch={this.props.dispatch}
                       layout={Location.ADDRESS}
                       geocode={true}
                       onUpdate={this.updateAddress}
@@ -987,6 +990,9 @@ Relative.defaultProps = {
   EmployerAddress: {},
   HasAffiliation: '',
   EmployerRelationship: {},
+  addressBooks: {},
+  addressBook: 'Relative',
+  dispatch: (action) => {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Relationships/Relatives/Relatives.jsx
+++ b/src/components/Section/Relationships/Relatives/Relatives.jsx
@@ -64,6 +64,8 @@ export default class Relatives extends SubsectionElement {
                    appendTitle={i18n.t('relationships.relatives.collection.appendTitle')}
                    appendLabel={i18n.t('relationships.relatives.collection.append')}>
           <Relative name="Item"
+                    addressBooks={this.props.addressBooks}
+                    dispatch={this.props.dispatch}
                     bind={true}
                     />
         </Accordion>
@@ -79,6 +81,7 @@ Relatives.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'relationships',
   subsection: 'relatives',
+  addressBooks: {},
   dispatch: () => {},
   validator: (state, props) => {
     return new RelativesValidator(props, props).isValid()

--- a/src/components/Section/SubstanceUse/Alcohol/OrderedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/OrderedCounseling.jsx
@@ -199,6 +199,9 @@ export default class OrderedCounseling extends ValidationElement {
                         {...this.props.TreatmentProviderAddress}
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Provider"
+                        dispatch={this.props.dispatch}
                         onUpdate={this.updateTreatmentProviderAddress}
                         onError={this.props.onError}
                         />
@@ -254,5 +257,7 @@ export default class OrderedCounseling extends ValidationElement {
 }
 
 OrderedCounseling.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/SubstanceUse/Alcohol/OrderedCounselings.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/OrderedCounselings.jsx
@@ -100,7 +100,10 @@ export default class OrderedCounselings extends SubsectionElement {
                      description={i18n.t('substance.alcohol.orderedCounseling.collection.description')}
                      appendTitle={i18n.t('substance.alcohol.orderedCounseling.collection.appendTitle')}
                      appendLabel={i18n.t('substance.alcohol.orderedCounseling.collection.appendLabel')}>
-            <OrderedCounseling name="OrderedCounseling" bind={true} />
+            <OrderedCounseling name="OrderedCounseling"
+                               addressBooks={this.props.addressBooks}
+                               dispatch={this.props.dispatch}
+                               bind={true} />
           </Accordion>
         </Show>
       </div>
@@ -114,7 +117,8 @@ OrderedCounselings.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'substance',
   subsection: 'alcohol/ordered',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new AlcoholOrderedCounselingsValidator(props).isValid()
   }

--- a/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounseling.jsx
@@ -82,6 +82,9 @@ export default class VoluntaryCounseling extends ValidationElement {
                     {...this.props.TreatmentProviderAddress}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Provider"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateTreatmentProviderAddress}
                     onError={this.props.onError}
                     />
@@ -124,5 +127,7 @@ export default class VoluntaryCounseling extends ValidationElement {
 }
 
 VoluntaryCounseling.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounselings.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounselings.jsx
@@ -77,7 +77,10 @@ export default class VoluntaryCounselings extends SubsectionElement {
                      description={i18n.t('substance.alcohol.voluntaryCounseling.collection.description')}
                      appendTitle={i18n.t('substance.alcohol.voluntaryCounseling.collection.appendTitle')}
                      appendLabel={i18n.t('substance.alcohol.voluntaryCounseling.collection.appendLabel')}>
-            <VoluntaryCounseling name="VoluntaryCounseling" bind={true} />
+            <VoluntaryCounseling name="VoluntaryCounseling"
+                                 addressBooks={this.props.addressBooks}
+                                 dispatch={this.props.dispatch}
+                                 bind={true} />
           </Accordion>
         </Show>
       </div>
@@ -91,7 +94,8 @@ VoluntaryCounselings.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'substance',
   subsection: 'alcohol/voluntary',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new AlcoholVoluntaryCounselingsValidator(props).isValid()
   }

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -203,6 +203,9 @@ export default class OrderedTreatment extends ValidationElement {
                         {...this.props.TreatmentProviderAddress}
                         layout={Location.ADDRESS}
                         geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Provider"
+                        dispatch={this.props.dispatch}
                         onUpdate={this.updateTreatmentProviderAddress}
                         onError={this.props.onError}
                         />
@@ -261,5 +264,7 @@ export default class OrderedTreatment extends ValidationElement {
 
 OrderedTreatment.defaultProps = {
   OrderedBy: [],
+  addressBooks: {},
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatments.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatments.jsx
@@ -77,7 +77,10 @@ export default class OrderedTreatments extends SubsectionElement {
                      description={i18n.t('substance.drugs.ordered.collection.description')}
                      appendTitle={i18n.t('substance.drugs.ordered.collection.appendTitle')}
                      appendLabel={i18n.t('substance.drugs.ordered.collection.appendLabel')}>
-            <OrderedTreatment name="OrderedTreatment" bind={true} />
+            <OrderedTreatment name="OrderedTreatment"
+                              addressBooks={this.props.addressBooks}
+                              dispatch={this.props.dispatch}
+                              bind={true} />
           </Accordion>
         </Show>
       </div>
@@ -91,7 +94,8 @@ OrderedTreatments.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'substance',
   subsection: 'drugs/ordered',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new DrugOrderedTreatmentsValidator(props).isValid()
   }

--- a/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatment.jsx
@@ -92,6 +92,9 @@ export default class VoluntaryTreatment extends ValidationElement {
                     {...this.props.TreatmentProviderAddress}
                     layout={Location.ADDRESS}
                     geocode={true}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Provider"
+                    dispatch={this.props.dispatch}
                     onUpdate={this.updateTreatmentProviderAddress}
                     onError={this.props.onError}
                     />
@@ -145,5 +148,7 @@ export default class VoluntaryTreatment extends ValidationElement {
 }
 
 VoluntaryTreatment.defaultProps = {
+  addressBooks: {},
+  dispatch: (action) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatments.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatments.jsx
@@ -77,7 +77,10 @@ export default class VoluntaryTreatments extends SubsectionElement {
                      description={i18n.t('substance.drugs.voluntary.collection.description')}
                      appendTitle={i18n.t('substance.drugs.voluntary.collection.appendTitle')}
                      appendLabel={i18n.t('substance.drugs.voluntary.collection.appendLabel')}>
-            <VoluntaryTreatment name="VoluntaryTreatment" bind={true} />
+            <VoluntaryTreatment name="VoluntaryTreatment"
+                                addressBooks={this.props.addressBooks}
+                                dispatch={this.props.dispatch}
+                                bind={true} />
           </Accordion>
         </Show>
       </div>
@@ -91,7 +94,8 @@ VoluntaryTreatments.defaultProps = {
   onError: (value, arr) => { return arr },
   section: 'substance',
   subsection: 'drugs/voluntary',
-  dispatch: () => {},
+  addressBooks: {},
+  dispatch: (action) => {},
   validator: (state, props) => {
     return new DrugVoluntaryTreatmentsValidator(props).isValid()
   }

--- a/src/components/Section/SubstanceUse/SubstanceUse.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.jsx
@@ -175,6 +175,7 @@ class SubstanceUse extends SectionElement {
                        nextLabel={i18n.t('substance.destination.drugs.voluntary')}>
             <OrderedTreatments name="ordered"
                                {...this.props.OrderedTreatments}
+                               addressBooks={this.props.AddressBooks}
                                dispatch={this.props.dispatch}
                                onError={this.handleError}
                                onUpdate={this.updateOrderedTreatments}
@@ -188,6 +189,7 @@ class SubstanceUse extends SectionElement {
                        nextLabel={i18n.t('substance.destination.police.negative')}>
             <VoluntaryTreatments name="voluntary"
                                  {...this.props.VoluntaryTreatments}
+                                 addressBooks={this.props.AddressBooks}
                                  dispatch={this.props.dispatch}
                                  onError={this.handleError}
                                  onUpdate={this.updateVoluntaryTreatments}
@@ -214,6 +216,7 @@ class SubstanceUse extends SectionElement {
                        nextLabel={ i18n.t('substance.destination.police.voluntary') }>
             <OrderedCounselings name="ordered"
                                 {...this.props.OrderedCounselings}
+                                addressBooks={this.props.AddressBooks}
                                 dispatch={this.props.dispatch}
                                 onError={this.handleError}
                                 onUpdate={this.updateOrderedCounselings}
@@ -227,6 +230,7 @@ class SubstanceUse extends SectionElement {
                        nextLabel={ i18n.t('substance.destination.police.additional') }>
             <VoluntaryCounselings name="voluntary"
                                   {...this.props.VoluntaryCounselings}
+                                  addressBooks={this.props.AddressBooks}
                                   dispatch={this.props.dispatch}
                                   onError={this.handleError}
                                   onUpdate={this.updateVoluntaryCounselings}
@@ -359,10 +363,12 @@ class SubstanceUse extends SectionElement {
 }
 
 function mapStateToProps (state) {
-  let app = state.application || {}
-  let substance = app.SubstanceUse || {}
-  let errors = app.Errors || {}
-  let completed = app.Completed || {}
+  const app = state.application || {}
+  const substance = app.SubstanceUse || {}
+  const errors = app.Errors || {}
+  const completed = app.Completed || {}
+  const addressBooks = app.AddressBooks || {}
+
   return {
     SubstanceUse: substance,
     NegativeImpacts: substance.NegativeImpacts || {},
@@ -377,7 +383,8 @@ function mapStateToProps (state) {
     OrderedTreatments: substance.OrderedTreatments || {},
     VoluntaryTreatments: substance.VoluntaryTreatments || {},
     Errors: errors.substance || [],
-    Completed: completed.substance || []
+    Completed: completed.substance || [],
+    AddressBooks: addressBooks
   }
 }
 

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -2961,6 +2961,9 @@ const en = {
           placeholder: 'Enter APO/FPO/DPO'
         }
       }
+    },
+    addressBook: {
+      reuse: 'Choose a previously used address'
     }
   },
   spinner: {
@@ -2982,6 +2985,13 @@ const en = {
       dismiss: 'Keep original address',
       alternate: 'Manually correct this address',
       more: 'Add more information'
+    },
+    addressBook: {
+      title: 'Select previous address',
+      para: 'Choose the desired address from the list below.',
+      label: 'Previous address',
+      use: 'Use this address',
+      dismiss: 'Close address book'
     }
   },
   intro: {
@@ -5105,11 +5115,11 @@ const en = {
           itemType: 'Interest'
         },
         help: {
-            directControl: {
-              title: 'Need help with the term "Direct control"?',
-              message: 'Direct control means there is *no* intermediary or intervening factors between the foreign financial interest and the owner/controller.',
-              note: 'Example: You own a bakery in a foreign country and directly control all aspects of the business such as pricing, baking, etc.'
-            },
+          directControl: {
+            title: 'Need help with the term "Direct control"?',
+            message: 'Direct control means there is *no* intermediary or intervening factors between the foreign financial interest and the owner/controller.',
+            note: 'Example: You own a bakery in a foreign country and directly control all aspects of the business such as pricing, baking, etc.'
+          }
         },
         interest: {
           para: {
@@ -5222,13 +5232,13 @@ const en = {
           appendLabel: 'Add another indirect interest',
           itemType: 'Interest'
         },
-            help: {
-            indirectControl: {
-              title: 'Need help with the term "Indirect control"?',
-              message: 'Indirect control means there *is* intermediary or intervening factors between the foreign financial interest and the owner/controller.',
-              note: 'Example: You own a bakery in a foreign country and have an employee directly control aspects of the business such as pricing, baking, etc.'
-            },
-        },    
+        help: {
+          indirectControl: {
+            title: 'Need help with the term "Indirect control"?',
+            message: 'Indirect control means there *is* intermediary or intervening factors between the foreign financial interest and the owner/controller.',
+            note: 'Example: You own a bakery in a foreign country and have an employee directly control aspects of the business such as pricing, baking, etc.'
+          }
+        },
         interest: {
           para: {
             checkAll: 'Check all that apply',

--- a/src/reducers/application.js
+++ b/src/reducers/application.js
@@ -79,7 +79,8 @@ export default combineReducers({
   SubstanceUse: reducer('SubstanceUse'),
   Releases: reducer('Releases'),
   Completed: errorReducer('Completed'),
-  Errors: errorReducer('Errors')
+  Errors: errorReducer('Errors'),
+  AddressBooks: reducer('AddressBooks')
 })
 
 // Or alternative...


### PR DESCRIPTION
Issue: #1674

In order to access previously used address the `Location` component must be passed the following:

 - `dispatch()`: this is the `redux` dispatcher allowing `Location` to update the address book(s)
 - `addressBooks`: An object from `redux` where each property name is an individual address book
 - `addressBook`: The address book name (**example**: *Court, Relative, ForeignNational, etc.*)