### PR TITLE
DateRange and DateControl bug fixes

### DIFF
--- a/src/components/Form/DateRange/DateRange.jsx
+++ b/src/components/Form/DateRange/DateRange.jsx
@@ -107,6 +107,7 @@ export default class DateRange extends ValidationElement {
       if (err.code.indexOf('daterange.to') === -1) {
         return err
       }
+
       return {
         code: err.code,
         valid: null,
@@ -116,15 +117,7 @@ export default class DateRange extends ValidationElement {
     this.errors = errors
 
     this.setState(futureState, () => {
-      if (this.props.onUpdate) {
-        this.props.onUpdate({
-          name: this.props.name,
-          from: this.state.from,
-          to: this.state.to,
-          present: this.state.present,
-          title: this.state.title
-        })
-      }
+      this.update(futureState)
     })
   }
 

--- a/src/components/Form/DateRange/DateRange.test.jsx
+++ b/src/components/Form/DateRange/DateRange.test.jsx
@@ -67,7 +67,11 @@ describe('The date range component', () => {
   it('can click on present', () => {
     let updates = 0
     const props = {
-      onUpdate: () => { updates++ }
+      onUpdate: (values) => {
+        if (values.to && values.to.date) {
+          updates++
+        }
+      }
     }
     const component = mount(<DateRange {...props} />)
     component.find('.present input').simulate('change')

--- a/src/components/Form/Dropdown/Dropdown.jsx
+++ b/src/components/Form/Dropdown/Dropdown.jsx
@@ -228,6 +228,7 @@ export default class Dropdown extends ValidationElement {
 
   onSuggestionSelected (event) {
     this.setState({ focus: false }, () => {
+      this.handleValidation(event)
       this.props.tabNext()
     })
   }


### PR DESCRIPTION

## Fix date range clicking on present not triggering

It appears during a refactoring the click event on present was doing its own `onUpdate` procedures. Moved this to the normal `update` function call so the properties being returned are consistent.  

Issue: #1799

## Fix dropdown not validating if selection is made with a click

Needed to call `handleValidation` on **any** selection change.

Issue: #1793

