### PR TITLE
Refresh web tokens

### DIFF
--- a/api/handlers/root.go
+++ b/api/handlers/root.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -18,5 +19,29 @@ var (
 func RootHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Eqip-Media-Type", fmt.Sprintf("%s.%s", APIName, APIVersion))
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{}`))
+
+	// TODO: Update the structure to include HTTP verbs
+	json.NewEncoder(w).Encode(struct {
+		Endpoints map[string]string `json:"endpoints"`
+	}{
+		Endpoints: map[string]string{
+			"root":                                     "/",
+			"web token refresh":                        "/refresh",
+			"two factor authentication":                "/2fa",
+			"two factor authentication for an account": "/2fa/{account}",
+			"verification":                             "/2fa/{account}/verify",
+			"email":                                    "/2fa/{account}/email",
+			"reset":                                    "/2fa/{account}/reset",
+			"authentication":                           "/auth",
+			"basic authentication":                     "/auth/basic",
+			"oauth entrypoint":                         "/auth/{service}",
+			"oauth callback":                           "/auth/{service}/callback",
+			"me":                                       "/me",
+			"validation":                               "/me/validate",
+			"save":                                     "/save",
+			"store attachment":                         "/attachment",
+			"get attachment":                           "/attachment/{id}",
+			"delete attachment":                        "/attachment/{id}/delete",
+		},
+	})
 }

--- a/api/main.go
+++ b/api/main.go
@@ -44,10 +44,13 @@ func main() {
 	// Account specific actions
 	a := r.PathPrefix("/me").Subrouter().Inject(handlers.JwtTokenValidatorHandler)
 	a.HandleFunc("/validate", handlers.Validate).Methods("POST")
-	a.HandleFunc("/save", handlers.Save).Methods("POST")
+	a.HandleFunc("/save", handlers.Save).Methods("POST", "PUT")
 	a.HandleFunc("/attachment", handlers.SaveAttachment).Methods("POST")
 	a.HandleFunc("/attachment/{id}", handlers.GetAttachment)
 	a.HandleFunc("/attachment/{id}/delete", handlers.DeleteAttachment).Methods("POST")
+
+	// Handle refreshing web tokens
+	r.HandleFunc("/refresh", handlers.JwtTokenRefresh).Methods("POST")
 
 	log.Println("Starting API server")
 	fmt.Println(http.ListenAndServe(cf.PublicAddress(), handlers.CORS(r)))

--- a/api/model/account.go
+++ b/api/model/account.go
@@ -15,7 +15,7 @@ var (
 	JwtSecret         = []byte("more secrets!")
 	Issuer            = "eqip"
 	BasicAuthAudience = "Basic"
-	Expiration        = time.Hour * 24
+	Expiration        = time.Hour * 1
 
 	// ErrPasswordDoesNotMatch is an error when a user inputs an invalid password
 	ErrPasswordDoesNotMatch = errors.New("Password does not match")

--- a/src/boot.jsx
+++ b/src/boot.jsx
@@ -33,8 +33,8 @@ ReactDOM.render(
  */
 function onEnter () {
   const token = api.getToken()
-  if (token) {
-    store.dispatch(handleLoginSuccess(token))
+  if (token.length) {
+    store.dispatch(handleLoginSuccess())
     store.dispatch(handleTwoFactorSuccess())
   }
 }

--- a/src/components/Form/Introduction/Introduction.test.jsx
+++ b/src/components/Form/Introduction/Introduction.test.jsx
@@ -7,6 +7,8 @@ import { mount } from 'enzyme'
 import AuthenticatedIntroduction, { Introduction } from './Introduction'
 
 describe('The Introduction component', () => {
+  window.token = 'fake-token'
+
   it('logout if "No" is selected', () => {
     let dispatched = 0
     const props = {
@@ -67,6 +69,7 @@ describe('The Introduction component', () => {
   })
 
   it('hidden if not authenticated', () => {
+    window.token = ''
     const middlewares = [thunk]
     const mockStore = configureMockStore(middlewares)
     const store = mockStore({
@@ -79,5 +82,6 @@ describe('The Introduction component', () => {
     })
     const component = mount(<Provider store={store}><AuthenticatedIntroduction /></Provider>)
     expect(component.find('.introduction-modal').length).toBe(0)
+    window.token = 'fake-token'
   })
 })

--- a/src/components/Navigation/Navigation.test.jsx
+++ b/src/components/Navigation/Navigation.test.jsx
@@ -8,13 +8,16 @@ import Navigation from './Navigation'
 
 describe('The navigation component', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: {} })
     const component = mount(<Provider store={store}><Navigation /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Navigation/NavigationToggle.test.jsx
+++ b/src/components/Navigation/NavigationToggle.test.jsx
@@ -7,6 +7,8 @@ import { mount } from 'enzyme'
 import AuthenticatedNavigationToggle, { NavigationToggle } from './NavigationToggle'
 
 describe('The navigation toggle component', () => {
+  window.token = 'fake-token'
+
   it('can logout', () => {
     let dispatched = 0
     const props = {
@@ -62,6 +64,7 @@ describe('The navigation toggle component', () => {
   })
 
   it('hidden when not authenticated and mobile', () => {
+    window.token = ''
     const middlewares = [ thunk ]
     const mockStore = configureMockStore(middlewares)
     const store = mockStore({
@@ -74,5 +77,6 @@ describe('The navigation toggle component', () => {
     })
     const component = mount(<Provider store={store}><AuthenticatedNavigationToggle /></Provider>)
     expect(component.find('.navigation-override').length).toBe(0)
+    window.token = 'fake-token'
   })
 })

--- a/src/components/ProgressBar/ProgressBar.test.jsx
+++ b/src/components/ProgressBar/ProgressBar.test.jsx
@@ -8,13 +8,16 @@ import ProgressBar from './ProgressBar'
 
 describe('The progress bar component', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [] })
     const component = mount(<Provider store={store}><ProgressBar /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/SavedIndicator/SavedIndicator.test.jsx
+++ b/src/components/SavedIndicator/SavedIndicator.test.jsx
@@ -8,13 +8,16 @@ import SavedIndicator, { bits } from './SavedIndicator'
 
 describe('The saved indicator component', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [] })
     const component = mount(<Provider store={store}><SavedIndicator /></Provider>)
     expect(component.find('button').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/ScoreCard/ScoreCard.test.jsx
+++ b/src/components/ScoreCard/ScoreCard.test.jsx
@@ -8,13 +8,16 @@ import { mount } from 'enzyme'
 
 describe('The score card component', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [] })
     const component = mount(<Provider store={store}><ScoreCard /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Citizenship/Citizenship.test.jsx
+++ b/src/components/Section/Citizenship/Citizenship.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The citizenship section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Citizenship /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Design/Design.test.jsx
+++ b/src/components/Section/Design/Design.test.jsx
@@ -8,13 +8,16 @@ import Design from './Design'
 
 describe('The citizenship section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: {} })
     const component = mount(<Provider store={store}><Design /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Financial/Financial.test.jsx
+++ b/src/components/Section/Financial/Financial.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The financial section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Financial /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Foreign/Foreign.test.jsx
+++ b/src/components/Section/Foreign/Foreign.test.jsx
@@ -19,13 +19,16 @@ const applicationState2 = {
 
 describe('The foreign section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Foreign /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/History/History.test.jsx
+++ b/src/components/Section/History/History.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The History section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><History /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Identification/Identification.test.jsx
+++ b/src/components/Section/Identification/Identification.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The identification section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Identification /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Legal/Legal.test.jsx
+++ b/src/components/Section/Legal/Legal.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The legal section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Legal /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Military/Military.test.jsx
+++ b/src/components/Section/Military/Military.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The military section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Military /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Psychological/Psychological.test.jsx
+++ b/src/components/Section/Psychological/Psychological.test.jsx
@@ -10,15 +10,18 @@ const applicationState = {
   Psychological: {}
 }
 
-describe('The legal section', () => {
+describe('The psych section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Psychological /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Relationships/Relationships.test.jsx
+++ b/src/components/Section/Relationships/Relationships.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The family and friends section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Relationships /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Releases/Releases.test.jsx
+++ b/src/components/Section/Releases/Releases.test.jsx
@@ -12,13 +12,16 @@ const applicationState = {
 
 describe('The legal section', () => {
   // Setup
+  window.token = 'fake-token'
   const middlewares = [ thunk ]
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><Releases /></Provider>)
     expect(component.find('div').length).toEqual(0)
+    window.token = 'fake-token'
   })
 
   it('visible when authenticated', () => {

--- a/src/components/Section/Section.test.jsx
+++ b/src/components/Section/Section.test.jsx
@@ -18,7 +18,8 @@ describe('The section component', () => {
   })
 
   it('visible when authenticated', () => {
-    const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
+    window.token = 'fake-token'
+    const store = mockStore({ authentication: { authenticated: true, twofactor: true, token: 'fake-token' } })
     const component = mount(<Provider store={store}><Section /></Provider>)
     expect(component.find('div').length > 0).toBe(true)
   })

--- a/src/components/Section/SubstanceUse/SubstanceUse.test.jsx
+++ b/src/components/Section/SubstanceUse/SubstanceUse.test.jsx
@@ -15,24 +15,28 @@ describe('The substance use section', () => {
   const mockStore = configureMockStore(middlewares)
 
   it('hidden when not authenticated', () => {
+    window.token = ''
     const store = mockStore({ authentication: [], application: applicationState })
     const component = mount(<Provider store={store}><SubstanceUse /></Provider>)
     expect(component.find('div').length).toEqual(0)
   })
 
   it('visible when authenticated', () => {
+    window.token = 'fake-token'
     const store = mockStore({ authentication: { authenticated: true, twofactor: true, application: applicationState } })
     const component = mount(<Provider store={store}><SubstanceUse /></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 
   it('can review all subsections', () => {
+    window.token = 'fake-token'
     const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
     const component = mount(<Provider store={store}><SubstanceUse subsection="review" /></Provider>)
     expect(component.find('div').length).toBeGreaterThan(0)
   })
 
   it('can go to each subsection', () => {
+    window.token = 'fake-token'
     const sections = ['police', 'review']
     const store = mockStore({ authentication: { authenticated: true, twofactor: true } })
 

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -20,8 +20,13 @@ class Env {
     return url
   }
 
+  IsTest () {
+    return process.env.NODE_ENV === 'test'
+  }
+
   AllowTwoFactorReset () { return process.env.ALLOW_2FA_RESET || false }
   EndpointBasicAuthentication () { return '/auth/basic' }
+  EndpointRefresh () { return '/refresh' }
   EndpointTwoFactor (account) { return `/2fa/${account}` }
   EndpointTwoFactorVerify (account) { return `/2fa/${account}/verify` }
   EndpointTwoFactorReset (account) { return `/2fa/${account}/reset` }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -71,6 +71,10 @@ class Api {
       token = this.getQueryValue('token')
     }
 
+    if (env.IsTest()) {
+      token = window.token
+    }
+
     return token
   }
 
@@ -109,6 +113,10 @@ class Api {
 
   login (username, password) {
     return this.proxy.post(env.EndpointBasicAuthentication(), { username: username, password: password })
+  }
+
+  refresh () {
+    return this.proxy.post(env.EndpointRefresh(), {}, { headers: { 'Authorization': `Bearer ${this.getToken()}` } })
   }
 
   save (payload) {

--- a/src/views/AuthenticatedView.js
+++ b/src/views/AuthenticatedView.js
@@ -12,11 +12,6 @@ import { push } from '../middleware/history'
  */
 function AuthenticatedView (WrappedComponent) {
   return connect(mapStateToProps)(class RequiresAuth extends React.Component {
-
-    constructor (props) {
-      super(props)
-    }
-
     componentWillReceiveProps (nextProps) {
       this.checkAuthentication()
     }
@@ -26,16 +21,14 @@ function AuthenticatedView (WrappedComponent) {
     }
 
     checkAuthentication () {
-      if (!this.props.authenticated || !this.props.twofactor) {
+      if (!api.getToken() || !this.props.authenticated || !this.props.twofactor) {
         this.props.dispatch(push('/login'))
       }
     }
 
     render () {
-      if (this.props.authenticated && this.props.twofactor) {
-        return (
-          <WrappedComponent {...this.props} />
-        )
+      if (api.getToken() && this.props.authenticated && this.props.twofactor) {
+        return (<WrappedComponent {...this.props} />)
       }
       return null
     }
@@ -46,8 +39,7 @@ function mapStateToProps (state) {
   const auth = state.authentication
   return {
     authenticated: auth.authenticated,
-    twofactor: auth.twofactor,
-    token: auth.token
+    twofactor: auth.twofactor
   }
 }
 


### PR DESCRIPTION
Refreshes the web token as an individual moves between authenticated views. If the expiration (currently set to 1 hour) has expired then redirect to log in to the system again.