### PR TITLE
Allow non-domestic addresses to be stored in the address book

### DIFF
--- a/src/components/Form/Location/AddressSuggestion.jsx
+++ b/src/components/Form/Location/AddressSuggestion.jsx
@@ -6,19 +6,38 @@ import React from 'react'
 export function AddressSuggestion (props) {
   const suggestion = props.suggestion
   const current = props.current
-  return (
-    <div className="address-suggestion">
-      <div>
-        <HighlightedField new={ suggestion.Street || suggestion.street } current={ current.street } />
-      </div>
-      <div>
-        <HighlightedField new={ suggestion.Street2 || suggestion.street2 } current={ current.street2 } />
-      </div>
-      <div>
-        <HighlightedField new={ suggestion.City || suggestion.city } current={ current.city } />, <HighlightedField new={ suggestion.State || suggestion.state } current={ current.state } /> <HighlightedField new={ suggestion.Zipcode || suggestion.zipcode } current={ current.zipcode } />
-      </div>
-    </div>
-  )
+
+  switch (current.country) {
+    case 'United States':
+    case 'POSTOFFICE':
+      return (
+        <div className="address-suggestion">
+          <div>
+            <HighlightedField new={ suggestion.Street || suggestion.street } current={ current.street } />
+          </div>
+          <div>
+            <HighlightedField new={ suggestion.Street2 || suggestion.street2 } current={ current.street2 } />
+          </div>
+          <div>
+            <HighlightedField new={ suggestion.City || suggestion.city } current={ current.city } />, <HighlightedField new={ suggestion.State || suggestion.state } current={ current.state } /> <HighlightedField new={ suggestion.Zipcode || suggestion.zipcode } current={ current.zipcode } />
+          </div>
+        </div>
+      )
+    default:
+      return (
+        <div className="address-suggestion">
+          <div>
+            <HighlightedField new={ suggestion.Street || suggestion.street } current={ current.street } />
+          </div>
+          <div>
+            <HighlightedField new={ suggestion.Street2 || suggestion.street2 } current={ current.street2 } />
+          </div>
+          <div>
+            <HighlightedField new={ suggestion.City || suggestion.city } current={ current.city } />, <HighlightedField new={ suggestion.Country || suggestion.country } current={ current.country } />
+          </div>
+        </div>
+      )
+  }
 }
 
 /**

--- a/src/components/Form/Location/AddressSuggestion.test.jsx
+++ b/src/components/Form/Location/AddressSuggestion.test.jsx
@@ -16,7 +16,8 @@ describe('The AddressSuggestion component', () => {
           street: '123 Some Rd',
           city: 'Arlington',
           state: 'VA',
-          zipcode: '22202'
+          zipcode: '22202',
+          country: 'United States'
         },
         expected: 0
       },
@@ -31,7 +32,8 @@ describe('The AddressSuggestion component', () => {
           street: '123 Some Road',
           city: 'Arlington',
           state: 'VA',
-          zipcode: '22202'
+          zipcode: '22202',
+          country: 'United States'
         },
         expected: 1
       },
@@ -46,7 +48,8 @@ describe('The AddressSuggestion component', () => {
           street: '123 Some Road',
           city: 'A-Town',
           state: 'MD',
-          zipcode: '22201'
+          zipcode: '22201',
+          country: 'United States'
         },
         expected: 4
       }


### PR DESCRIPTION
Issue: #1831

Previously we were only storing validated addresses. Due to only US addresses being verified all other address types were not considered for storage.