### PR TITLE
Adjust webtoken audience settings and apply to all actions in API

### DIFF
--- a/api/handlers/basic_auth.go
+++ b/api/handlers/basic_auth.go
@@ -36,6 +36,10 @@ func BasicAuth(w http.ResponseWriter, r *http.Request) {
 
 	// Associate with a database context.
 	account.WithContext(db.NewDB())
+	if err := account.Get(); err != nil {
+		Error(w, r, err)
+		return
+	}
 
 	// Validate the user name and password combination
 	if err := account.BasicAuthentication(respBody.Password); err != nil {
@@ -44,7 +48,7 @@ func BasicAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Generate jwt token
-	signedToken, _, err := account.NewJwtToken()
+	signedToken, _, err := account.NewJwtToken(model.BasicAuthAudience)
 	if err != nil {
 		Error(w, r, err)
 		return

--- a/api/handlers/jwt.go
+++ b/api/handlers/jwt.go
@@ -27,7 +27,7 @@ func JwtTokenValidatorHandler(w http.ResponseWriter, r *http.Request) error {
 	account := model.Account{}
 	account.WithContext(db.NewDB())
 
-	if valid, err := account.ValidJwtToken(token); !valid {
+	if valid, err := account.ValidJwtToken(token, model.TwoFactorAudience); !valid {
 		return fmt.Errorf("Invalid authorization token: %v", err)
 	}
 
@@ -49,13 +49,13 @@ func JwtTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	token := matches[1]
 	account := model.Account{}
 	account.WithContext(db.NewDB())
-	if valid, err := account.ValidJwtToken(token); !valid {
+	if valid, err := account.ValidJwtToken(token, model.TwoFactorAudience); !valid {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	// Generate a new token
-	signedToken, _, err := account.NewJwtToken()
+	signedToken, _, err := account.NewJwtToken(model.TwoFactorAudience)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/api/handlers/save.go
+++ b/api/handlers/save.go
@@ -23,7 +23,7 @@ func Save(w http.ResponseWriter, r *http.Request) {
 
 	// Validate the JWT token and populate the account ID
 	account := &model.Account{}
-	if ok, err := account.ValidJwtToken(token); !ok {
+	if ok, err := account.ValidJwtToken(token, model.TwoFactorAudience); !ok {
 		EncodeErrJSON(w, err)
 		return
 	}

--- a/api/model/account_test.go
+++ b/api/model/account_test.go
@@ -59,17 +59,17 @@ func TestJwtToken(t *testing.T) {
 		ID: 1,
 	}
 
-	token, _, err := a.NewJwtToken()
+	token, _, err := a.NewJwtToken(BasicAuthAudience)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	valid, _ := a.ValidJwtToken(token)
+	valid, _ := a.ValidJwtToken(token, BasicAuthAudience)
 	if !valid {
 		t.Fatalf("Expected Jwt Token to be valid")
 	}
 
-	valid, _ = a.ValidJwtToken("badtoken")
+	valid, _ = a.ValidJwtToken("badtoken", BasicAuthAudience)
 	if valid {
 		t.Fatalf("Expected Jwt Token to be invalid")
 	}

--- a/src/actions/AuthActions.js
+++ b/src/actions/AuthActions.js
@@ -11,8 +11,9 @@ export function login (username, password) {
   return function (dispatch, getState) {
     return api
       .login(username, password)
-      .then(r => {
-        dispatch(handleLoginSuccess(r.data))
+      .then(response => {
+        api.setToken(response.data)
+        dispatch(handleLoginSuccess(response.data))
       })
       .catch(error => {
         switch (error.response.status) {
@@ -29,7 +30,6 @@ export function login (username, password) {
 export function logout () {
   return function (dispatch, getState) {
     api.setToken('')
-    // TODO server side call to invalidate token
     dispatch({
       type: AuthConstants.LOGOUT
     })
@@ -52,7 +52,7 @@ export function twofactor (account, token) {
     return api
       .twoFactor(account, token)
       .then(response => {
-        api.setToken(getState().authentication.token)
+        api.setToken(response.data)
         dispatch(handleTwoFactorSuccess())
         dispatch(push('/form/identification/name'))
       })
@@ -68,7 +68,7 @@ export function twofactorreset (account) {
     return api
       .twoFactorReset(account)
       .then(response => {
-        api.setToken('')
+        api.setToken(response.data)
         dispatch(handleTwoFactorError('Two factor authentication reset'))
         dispatch(qrcode(account))
       })

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -99,16 +99,15 @@ class Api {
   }
 
   twoFactor (account, token) {
-    // TODO: Fix secure proxy
     if (token) {
-      return this.proxy.post(env.EndpointTwoFactorVerify(account), { token: token })
+      return this.proxy.post(env.EndpointTwoFactorVerify(account), { token: token }, { headers: { 'Authorization': `Bearer ${this.getToken()}` } })
     }
 
-    return this.proxy.get(env.EndpointTwoFactor(account))
+    return this.proxy.get(env.EndpointTwoFactor(account), { headers: { 'Authorization': `Bearer ${this.getToken()}` } })
   }
 
   twoFactorReset (account) {
-    return this.proxy.get(env.EndpointTwoFactorReset(account))
+    return this.proxy.get(env.EndpointTwoFactorReset(account), { headers: { 'Authorization': `Bearer ${this.getToken()}` } })
   }
 
   login (username, password) {


### PR DESCRIPTION
This was brought about when working with Melissa to log in. She was always resetting the 2FA and starting fresh. When the web tokens were refactored it appears the resetting was setting the token to `null` and  kicking her out.

While investigating this we realized the tokens should differ based on the stage of their life cycle. For example, we wanted a web token for 2FA to verify this is a valid request however we didn't want all web tokens to be the same once initially issued. To remedy this different `audience` values were set in the claim indicating what stage the token was issued and then verified on the backend processing. This means the token validates several properties:

 1. It is present and exists
 2. Not expired
 3. Aimed at the appropriate audience
 4. Is associated to an account
