### PR TITLE
History SVG were being shrunken by old style rules

### DIFF
--- a/src/components/Section/History/History.scss
+++ b/src/components/Section/History/History.scss
@@ -1,23 +1,6 @@
 @import 'eqip-colors';
 
 .history {
-  .accordion {
-    .svg {
-      height: 1.6rem;
-      width: auto;
-      margin-right: 1rem;
-      margin-left: -2.6rem;
-    }
-
-    .incomplete {
-      padding: 1rem 2rem;
-      background: $eapp-red-lightest;
-      border: 2px solid $eapp-red-light;
-      border-radius: 6px;
-      max-width: 64rem;
-    }
-  }
-
   .add-options {
     margin-top: 5rem;
     margin-bottom: 10rem;

--- a/src/components/Section/History/summaries.jsx
+++ b/src/components/Section/History/summaries.jsx
@@ -56,7 +56,7 @@ export const ResidenceSummary = (item, errors, open) => {
   const address = AddressSummary(item.Address, i18n.m('history.residence.collection.summary.unknown'))
   const dates = DateSummary(item.Dates, i18n.t('history.employment.default.noDate.label'))
   const svg = errors && !open
-        ? <Svg src="/img/exclamation-point.svg" />
+        ? <Svg src="/img/exclamation-point.svg" className="incomplete" />
         : null
 
   return (
@@ -126,7 +126,7 @@ export const EmploymentSummary = (item, errors, open) => {
         : i18n.m('history.employment.default.collection.summary.unknown')
   const dates = DateSummary(item.Dates, i18n.t('history.employment.default.noDate.label'))
   const svg = errors && !open
-        ? <Svg src="/img/exclamation-point.svg" />
+        ? <Svg src="/img/exclamation-point.svg" className="incomplete" />
         : null
 
   return (
@@ -200,7 +200,7 @@ export const EducationSummary = (item, errors, open) => {
   const school = (item.Name && item.Name.value ? item.Name.value : i18n.m('history.education.collection.school.summary.unknown'))
   const dates = DateSummary(item.Dates, i18n.t('history.employment.default.noDate.label'))
   const svg = errors && !open
-        ? <Svg src="/img/exclamation-point.svg" />
+        ? <Svg src="/img/exclamation-point.svg" className="incomplete" />
         : null
 
   return (


### PR DESCRIPTION
Some legacy styling was still around which aimed to handle the
incomplete icon in the accordion summary. However, the ruling was
applied to all SVGs of the accordion which obviously had side affects.

Issue: #1899


![image](https://user-images.githubusercontent.com/697855/30223445-dfe53a26-9498-11e7-8305-01c714e3f2ee.png)
