### PR TITLE
Disable horizontal resizing of textarea elements

### DIFF
--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -12,6 +12,10 @@ input, textarea, select {
   border-radius: 3px;
 }
 
+textarea {
+  resize: vertical;
+}
+
 /* bring in USWD validation classes and alter for our design */
 input[type='text'], textarea, select {
   padding-right: 3rem;


### PR DESCRIPTION
Allowing the horizontal resizing of elements starts to mess
with the alignment and positioning of other form elements.

truetandem/e-QIP-prototype#2048