### PR TITLE
Update error message for incorrect email format

### DIFF
--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -770,7 +770,7 @@ const en = {
     email: {
       pattern: {
         title: 'This email isn\'t valid',
-        message: 'Check for any spelling mistakes in your email address.',
+        message: 'Check for any spelling and/or format mistakes in your email address.',
         note: 'Example of valid email format: name@domain.com'
       },
       required: {


### PR DESCRIPTION
Originally the message just stated there was a spelling
mistake. However, this more aligns with a formatting error than
spelling.

truetandem/e-QIP-prototype#1954