### PR TITLE
Reapplying the currency component to contributions in associations

### DIFF
--- a/src/components/Section/Legal/Associations/MembershipOverthrowItem.jsx
+++ b/src/components/Section/Legal/Associations/MembershipOverthrowItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
-import { ValidationElement, Field, DateRange, Location, Text, Textarea, NotApplicable } from '../../../Form'
+import { ValidationElement, Field, DateRange, Location, Currency, Text, Textarea, NotApplicable } from '../../../Form'
 
 export default class MembershipOverthrowItem extends ValidationElement {
   constructor (props) {
@@ -157,13 +157,13 @@ export default class MembershipOverthrowItem extends ValidationElement {
                          or={i18n.m('legal.associations.overthrow.para.or')}
                          label={i18n.t('legal.associations.overthrow.label.nocontribs')}
                          required={this.props.required}>
-            <Text name="Contributions"
-                  {...this.props.Contributions}
-                  onUpdate={this.updateContributions}
-                  onError={this.props.onError}
-                  className="legal-associations-overthrow-contributions"
-                  required={this.props.required}
-                  />
+            <Currency name="Contributions"
+                      {...this.props.Contributions}
+                      onUpdate={this.updateContributions}
+                      onError={this.props.onError}
+                      className="legal-associations-overthrow-contributions"
+                      required={this.props.required}
+                      />
           </NotApplicable>
         </Field>
 

--- a/src/components/Section/Legal/Associations/MembershipViolenceItem.jsx
+++ b/src/components/Section/Legal/Associations/MembershipViolenceItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { i18n } from '../../../../config'
-import { ValidationElement, Field, DateRange, Location, Text, Textarea, NotApplicable } from '../../../Form'
+import { ValidationElement, Field, DateRange, Location, Currency, Text, Textarea, NotApplicable } from '../../../Form'
 
 export default class MembershipViolenceItem extends ValidationElement {
   constructor (props) {
@@ -157,13 +157,13 @@ export default class MembershipViolenceItem extends ValidationElement {
                          or={i18n.m('legal.associations.violence.para.or')}
                          label={i18n.t('legal.associations.violence.label.nocontribs')}
                          required={this.props.required}>
-            <Text name="Contributions"
-                  {...this.props.Contributions}
-                  onUpdate={this.updateContributions}
-                  onError={this.props.onError}
-                  className="legal-associations-violence-contributions"
-                  required={this.props.required}
-                  />
+            <Currency name="Contributions"
+                      {...this.props.Contributions}
+                      onUpdate={this.updateContributions}
+                      onError={this.props.onError}
+                      className="legal-associations-violence-contributions"
+                      required={this.props.required}
+                      />
           </NotApplicable>
         </Field>
 


### PR DESCRIPTION
It appears the previous changes (cd68f67) were overridden or not valid
once another PR was merged in (445ab9b).

Resolves truetandem/e-QIP-prototype#1849