### PR TITLE
Update to validation logic for ordered treatment item

### DIFF
--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -176,7 +176,7 @@ export default class Telephone extends ValidationElement {
         name: this.props.name,
         timeOfDay: this.state.timeOfDay,
         type: this.state.type,
-        numberType: this.state.numberType,
+        numberType: this.props.showNumberType ? this.state.numberType : 'NA',
         number: this.getFormattedNumber(),
         extension: this.state.extension,
         noNumber: this.state.noNumber,

--- a/src/validators/drugorderedtreatments.js
+++ b/src/validators/drugorderedtreatments.js
@@ -61,9 +61,9 @@ export class DrugOrderedTreatmentValidator {
     switch (this.actionTaken) {
       case 'Yes':
         return validGenericTextfield(this.treatmentProvider) &&
-          new LocationValidator(this.treatmentProviderAddress) &&
+          new LocationValidator(this.treatmentProviderAddress).isValid() &&
           validPhoneNumber(this.treatmentProviderTelephone) &&
-          new DateRangeValidator(this.treatmentDates) &&
+          new DateRangeValidator(this.treatmentDates).isValid() &&
           this.validTreatmentCompleted()
       case 'No':
         return validGenericTextfield(this.noActionTakenExplanation)


### PR DESCRIPTION
Two part:
 1. Creating new instances of `LocationValidator` and
 `DateRangeValidator` but not calling their `isValid()` methods.
 2. Since the telephone number in this case does not show the number
 type no value was present for validation.

For the second issue went ahead and assigned a value of `NA` to
`numberType` when displaying those elements is **disabled**

Resolves truetandem/e-QIP-prototype#2051