### PR TITLE
Updated RadioGroup to properly pass down disabled props

### DIFF
--- a/src/components/Form/RadioGroup/RadioGroup.jsx
+++ b/src/components/Form/RadioGroup/RadioGroup.jsx
@@ -69,7 +69,13 @@ export default class RadioGroup extends ValidationElement {
       }
 
       return (
-        <child.type {...child.props} name={name || child.props.name} checked={checked} onUpdate={onUpdate}></child.type>
+        <child.type
+          {...child.props}
+          name={name || child.props.name}
+          disabled={this.props.disabled}
+          checked={checked}
+          onUpdate={onUpdate}>
+        </child.type>
       )
     })
 

--- a/src/components/Section/Legal/Investigations/HistoryItem.jsx
+++ b/src/components/Section/Legal/Investigations/HistoryItem.jsx
@@ -222,6 +222,7 @@ export default class HistoryItem extends ValidationElement {
 }
 
 HistoryItem.defaultProps = {
+  required: false,
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   AgencyNotApplicable: {


### PR DESCRIPTION
Resolves #1800. WIth RadioGroup passing down disabled props, options are disabled within `NotApplicable` component.