### PR TITLE
Apply APO/FPO/DPO as dropdown instead of free-text

### DIFF
--- a/src/components/Form/ApoFpo/ApoFpo.jsx
+++ b/src/components/Form/ApoFpo/ApoFpo.jsx
@@ -44,19 +44,6 @@ export default class ApoFpo extends ValidationElement {
     )
   }
 }
-      // <Text name={this.props.name}
-      //       label={this.props.label}
-      //       className={klass}
-      //       placeholder={this.props.placeholder}
-      //       maxlength="2"
-      //       pattern="[a-zA-Z]{2}"
-      //       value={this.props.value}
-      //       onChange={this.props.onChange}
-      //       onError={this.handleError}
-      //       tabBack={this.props.tabBack}
-      //       tabNext={this.props.tabNext}
-      //       required={this.props.required}
-      //       />
 
 ApoFpo.defaultProps = {
   tabBack: () => {},

--- a/src/components/Form/ApoFpo/ApoFpo.jsx
+++ b/src/components/Form/ApoFpo/ApoFpo.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ValidationElement from '../ValidationElement'
-import Text from '../Text'
+import Dropdown from '../Dropdown'
 
 export default class ApoFpo extends ValidationElement {
   constructor (props) {
@@ -11,7 +11,7 @@ export default class ApoFpo extends ValidationElement {
   handleError (value, arr) {
     arr = arr.map(err => {
       return {
-        code: `address.apofpo.${err.code}`,
+        code: `apofpo.${err.code}`,
         valid: err.valid,
         uid: err.uid
       }
@@ -23,22 +23,40 @@ export default class ApoFpo extends ValidationElement {
   render () {
     const klass = `apofpo ${this.props.className || ''}`.trim()
     return (
-      <Text name={this.props.name}
-            label={this.props.label}
-            className={klass}
-            placeholder={this.props.placeholder}
-            maxlength="2"
-            pattern="[a-zA-Z]{2}"
-            value={this.props.value}
-            onChange={this.props.onChange}
-            onError={this.handleError}
-            tabBack={this.props.tabBack}
-            tabNext={this.props.tabNext}
-            required={this.props.required}
-            />
+      <Dropdown name={this.props.name}
+                label={this.props.label}
+                placeholder={this.props.placeholder}
+                className={this.props.className}
+                disabled={this.props.disabled}
+                onChange={this.props.onChange}
+                onError={this.handleError}
+                onBlur={this.props.onBlur}
+                onFocus={this.props.onFocus}
+                value={this.props.value}
+                required={this.props.required}
+                tabBack={this.props.tabBack}
+                tabNext={this.props.tabNext}
+                receiveProps={false}>
+        <option key="AA" value="AA">AA</option>
+        <option key="AE" value="AE">AE</option>
+        <option key="AP" value="AP">AP</option>
+      </Dropdown>
     )
   }
 }
+      // <Text name={this.props.name}
+      //       label={this.props.label}
+      //       className={klass}
+      //       placeholder={this.props.placeholder}
+      //       maxlength="2"
+      //       pattern="[a-zA-Z]{2}"
+      //       value={this.props.value}
+      //       onChange={this.props.onChange}
+      //       onError={this.handleError}
+      //       tabBack={this.props.tabBack}
+      //       tabNext={this.props.tabNext}
+      //       required={this.props.required}
+      //       />
 
 ApoFpo.defaultProps = {
   tabBack: () => {},

--- a/src/components/Form/ApoFpo/ApoFpo.scss
+++ b/src/components/Form/ApoFpo/ApoFpo.scss
@@ -1,0 +1,5 @@
+.apofpo.dropdown {
+  input {
+    text-transform: uppercase;
+  }
+}

--- a/src/components/Form/State/State.scss
+++ b/src/components/Form/State/State.scss
@@ -1,0 +1,5 @@
+.state.dropdown {
+  input {
+    text-transform: uppercase;
+  }
+}

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -541,7 +541,7 @@ const en = {
           }
         },
         apofpo: {
-          pattern: {
+          notfound: {
             title: 'There is a problem with the State Code',
             message: 'APO/FPO state code must be 2 letters',
             note: 'Note: Typically the value is either AA, AE, or AP.'
@@ -595,7 +595,7 @@ const en = {
           }
         },
         apofpo: {
-          pattern: {
+          notfound: {
             title: 'There is a problem with the State Code',
             message: 'APO/FPO state code must be 2 letters',
             note: 'Note: Typically the value is either AA, AE, or AP.'


### PR DESCRIPTION
As pointed out there are only a handful of valid state code in this
scenario. By switching it to a dropdown we intend to reduce the amount
of errors.

Resolves truetandem/e-QIP-prototype#1769