### PR TITLE
Reapply "optional" text

### DIFF
--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -107,10 +107,13 @@ export default class Field extends ValidationElement {
   /**
    * Render the title as needed
    */
-  title () {
+  title (required = false) {
     if (this.props.title) {
       const klassTitle = `title ${this.props.titleSize}`.trim()
-      return <span className={klassTitle}>{this.props.title}</span>
+      const optional = !required && this.props.optionalText
+            ? <span className="optional">{this.props.optionalText}</span>
+            : null
+      return <span className={klassTitle}>{this.props.title}{optional}</span>
     }
 
     return null
@@ -298,7 +301,7 @@ export default class Field extends ValidationElement {
 
     return (
       <div className={klass} ref="field">
-        {this.title()}
+        {this.title(required)}
         <span className="icon">
           {this.icon()}
         </span>
@@ -342,6 +345,7 @@ Field.defaultProps = {
   commentsAdd: 'comments.add',
   commentsRemove: 'comments.remove',
   optional: false,
+  optionalText: '',
   validate: true,
   shrink: false,
   scrollIntoView: true,

--- a/src/components/Form/Field/Field.test.jsx
+++ b/src/components/Form/Field/Field.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import Field from './Field'
-import Number from '../Number'
 
 describe('The field component', () => {
   it('help renders with default state closed', () => {
@@ -92,5 +91,24 @@ describe('The field component', () => {
     component.find('.comments-button.add').simulate('click')
     expect(component.find('textarea').length).toEqual(1)
     expect(updates).toBe(1)
+  })
+
+  it('does not displays optional text if nothing was specified', () => {
+    const props = {
+      title: 'Test field',
+      optional: true
+    }
+    const component = mount(<Field {...props} />)
+    expect(component.find('.optional').length).toBe(0)
+  })
+
+  it('does displays optional text if specified', () => {
+    const props = {
+      title: 'Test field',
+      optional: true,
+      optionalText: '(Optional)'
+    }
+    const component = mount(<Field {...props} />)
+    expect(component.find('.optional').length).toBe(1)
   })
 })

--- a/src/components/Form/Name/Name.jsx
+++ b/src/components/Form/Name/Name.jsx
@@ -292,7 +292,8 @@ export default class Name extends ValidationElement {
                help="identification.name.suffix.help"
                errorPrefix="name"
                scrollIntoView={this.props.scrollIntoView}
-               optional={true}>
+               optional={true}
+               optionalText={i18n.t(`${prefix}.label.optional`)}>
           <RadioGroup className="option-list suffix" selectedValue={this.props.suffix}>
             <Radio name="suffix"
                    label={i18n.t(`${prefix}.label.jr`)}

--- a/src/components/Form/Street/Street.jsx
+++ b/src/components/Form/Street/Street.jsx
@@ -42,11 +42,24 @@ export default class Street extends ValidationElement {
     return this.props.onError(value, arr)
   }
 
+  label () {
+    if (this.props.label && this.props.optional) {
+      return (
+        <span>
+          {this.props.label}
+          <span className="optional">{i18n.t('address.us.street2.optional')}</span>
+        </span>
+      )
+    }
+
+    return this.props.label
+  }
+
   render () {
     return (
       <Text name={this.props.name}
             className={this.props.className}
-            label={this.props.label}
+            label={this.label()}
             placeholder={this.props.placeholder}
             value={this.state.value}
             onChange={this.handleChange}

--- a/src/components/Form/Street/Street.test.jsx
+++ b/src/components/Form/Street/Street.test.jsx
@@ -18,4 +18,13 @@ describe('The Street component', () => {
     expect(component.find('input').length).toEqual(1)
     expect(component.find('.usa-input-error-label').length).toEqual(0)
   })
+
+  it('displays optional text', () => {
+    const props = {
+      label: 'Apt, suite, building, floor, etc.',
+      optional: true
+    }
+    const component = mount(<Street {...props} />)
+    expect(component.find('label').text()).toContain('(Optional)')
+  })
 })

--- a/src/components/Section/SectionComments.jsx
+++ b/src/components/Section/SectionComments.jsx
@@ -28,6 +28,7 @@ export default class SectionComments extends SubsectionElement {
       <Field title={this.props.title}
              titleSize="h4"
              optional={true}
+             optionalText={i18n.t('app.optional')}
              className="section-comment">
         <Text name="Comments"
               {...this.props.Comments}

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -17,7 +17,8 @@ const en = {
       witty: 'The .gov means it\'s official.',
       extension: 'Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you\'re on a .gov or .mil site by inspecting your browser\'s address (or "location") bar.',
       ssl: 'This site is also protected by an SSL (Secure Sockets Layer) certificate that\'s been signed by the U.S. government. The <strong>https://</strong> means all transmitted data is encrypted  — in other words, any information or browsing history that you provide is transmitted securely.'
-    }
+    },
+    optional: '(Optional)'
   },
   login: {
     title: 'Login',
@@ -93,7 +94,7 @@ const en = {
       noMiddle: 'No middle name',
       other: 'Other',
       suffix: 'Suffix',
-      optional: 'Optional',
+      optional: '(Optional)',
       jr: 'Jr',
       sr: 'Sr',
       i: 'I',


### PR DESCRIPTION
Resolves: truetandem/e-QIP-prototype#2163

This was mainly added to:
 - any name's suffix
 - the second street of an address
 - section comments on review screens