### PR TITLE
Adjust contact information requirements

### DIFF
--- a/src/components/Form/Reference/Reference.jsx
+++ b/src/components/Form/Reference/Reference.jsx
@@ -202,6 +202,7 @@ export default class Reference extends ValidationElement {
         </Field>
 
         <Field title={i18n.t(`${prefix}reference.heading.phone`)}
+               className="override-required"
                help={`${prefix}reference.help.phone`}
                adjustFor="telephone"
                scrollIntoView={this.props.scrollIntoView}>

--- a/src/components/Section/Design/Headings/Headings.jsx
+++ b/src/components/Section/Design/Headings/Headings.jsx
@@ -116,6 +116,7 @@ export default class Headings extends ValidationElement {
                    appendLabel={i18n.t('identification.contacts.collection.phoneNumbers.append')}
                    onUpdate={this.updateList}>
           <Field help="identification.contacts.help.phoneNumber"
+                 className="override-required"
                  optional={true}
                  adjustFor="telephone">
             <Telephone name="Telephone" bind={true} />

--- a/src/components/Section/Financial/Credit/CreditItem.jsx
+++ b/src/components/Section/Financial/Credit/CreditItem.jsx
@@ -59,72 +59,73 @@ export default class CreditItem extends ValidationElement {
     return (
       <div className="credit-item">
         <Field title={i18n.t('financial.credit.heading.explanation')}
-          scrollIntoView={this.props.scrollIntoView}
-          help="financial.credit.help.explanation">
+               scrollIntoView={this.props.scrollIntoView}
+               help="financial.credit.help.explanation">
           <Textarea name="Explanation"
-            {...this.props.Explanation}
-            className="credit-explanation"
-            onUpdate={this.updateExplanation}
-            onError={this.props.onError}
-            required={this.props.required}
-          />
+                    {...this.props.Explanation}
+                    className="credit-explanation"
+                    onUpdate={this.updateExplanation}
+                    onError={this.props.onError}
+                    required={this.props.required}
+                    />
         </Field>
 
         <Field title={i18n.t('financial.credit.heading.name')}
-          scrollIntoView={this.props.scrollIntoView}>
+               scrollIntoView={this.props.scrollIntoView}>
           <Text name="Name"
-            {...this.props.Name}
-            className="credit-name"
-            required={this.props.required}
-            onUpdate={this.updateName}
-            onError={this.props.onError}
-          />
+                {...this.props.Name}
+                className="credit-name"
+                required={this.props.required}
+                onUpdate={this.updateName}
+                onError={this.props.onError}
+                />
         </Field>
 
         <Field title={i18n.t('financial.credit.heading.telephone')}
-          help="financial.credit.help.telephone"
-          scrollIntoView={this.props.scrollIntoView}
-          adjustFor="telephone">
+               className="override-required"
+               help="financial.credit.help.telephone"
+               scrollIntoView={this.props.scrollIntoView}
+               adjustFor="telephone">
           <Telephone name="Telephone"
-            {...this.props.Telephone}
-            className="credit-telephone"
-            required={this.props.required}
-            onUpdate={this.updateTelephone}
-            onError={this.props.onError}
-          />
+                     {...this.props.Telephone}
+                     className="credit-telephone"
+                     required={this.props.required}
+                     onUpdate={this.updateTelephone}
+                     onError={this.props.onError}
+                     />
         </Field>
 
         <Field title={i18n.t('financial.credit.heading.address')}
-          help="financial.credit.help.address"
-          scrollIntoView={this.props.scrollIntoView}
-          adjustFor="label">
+               help="financial.credit.help.address"
+               scrollIntoView={this.props.scrollIntoView}
+               adjustFor="label">
           <Location name="Location"
-            {...this.props.Location}
-            layout={Location.CITY_STATE}
-            className="credit-location"
-            dispatch={this.props.dispatch}
-            addressBooks={this.props.addressBooks}
-            addressBook="Agency"
-            bind={true}
-            help=""
-            statePlaceholder={i18n.t('financial.credit.placeholder.state')}
-            cityPlaceholder={i18n.t('financial.credit.placeholder.city')}
-            required={this.props.required}
-            onUpdate={this.updateLocation}
-            onError={this.props.onError}
-          />
+                    {...this.props.Location}
+                    layout={Location.CITY_STATE}
+                    className="credit-location"
+                    dispatch={this.props.dispatch}
+                    addressBooks={this.props.addressBooks}
+                    addressBook="Agency"
+                    bind={true}
+                    help=""
+                    statePlaceholder={i18n.t('financial.credit.placeholder.state')}
+                    cityPlaceholder={i18n.t('financial.credit.placeholder.city')}
+                    required={this.props.required}
+                    onUpdate={this.updateLocation}
+                    onError={this.props.onError}
+                    />
         </Field>
 
         <Field title={i18n.t('financial.credit.heading.description')}
-          scrollIntoView={this.props.scrollIntoView}
-          help="financial.credit.help.description">
+               scrollIntoView={this.props.scrollIntoView}
+               help="financial.credit.help.description">
           <Textarea name="Description"
-            {...this.props.Description}
-            className="credit-description"
-            required={this.props.required}
-            onUpdate={this.updateDescription}
-            onError={this.props.onError}
-          />
+                    {...this.props.Description}
+                    className="credit-description"
+                    required={this.props.required}
+                    onUpdate={this.updateDescription}
+                    onError={this.props.onError}
+                    />
         </Field>
       </div>
     )

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -295,6 +295,7 @@ export default class EmploymentItem extends ValidationElement {
 
         <Show when={this.showEmployed()}>
           <Field title={i18n.t(`${prefix}.heading.telephone`)}
+                 className="override-required"
                  adjustFor="telephone"
                  scrollIntoView={this.props.scrollIntoView}>
             <Telephone name="Telephone"

--- a/src/components/Section/History/Employment/PhysicalAddress.jsx
+++ b/src/components/Section/History/Employment/PhysicalAddress.jsx
@@ -102,6 +102,7 @@ export default class PhysicalAddress extends ValidationElement {
 
           <Field title={i18n.t('history.employment.default.physicalAddress.heading.telephone')}
                  titleSize="h4"
+                 className="override-required"
                  help="history.employment.default.physicalAddress.telephone.help"
                  adjustFor="telephone"
                  scrollIntoView={this.props.scrollIntoView}>

--- a/src/components/Section/History/Employment/Supervisor.jsx
+++ b/src/components/Section/History/Employment/Supervisor.jsx
@@ -112,6 +112,7 @@ export default class Supervisor extends ValidationElement {
         </Field>
 
         <Field title={i18n.t('history.employment.default.supervisor.heading.telephone')}
+               className="override-required"
                adjustFor="telephone"
                scrollIntoView={this.props.scrollIntoView}>
           <Telephone name="Telephone"

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
@@ -67,14 +67,32 @@ export default class ContactInformation extends SubsectionElement {
     })
   }
 
+  firstItemRequired (item, index, initial, callback) {
+    if (index === 0) {
+      return <span className="required">{callback()}</span>
+    }
+
+    return callback()
+  }
+
   render () {
     const klass = `${this.props.className || ''}`.trim()
-    let phoneNumbers = this.props.shouldFilterEmptyNumbers
-          ? this.props.PhoneNumbers.filter(x => {
-            const item = x.Item || {}
-            return item.number || item.noNumber
-          })
-          : this.props.PhoneNumbers
+    let emails = this.props.Emails
+    let phoneNumbers = this.props.PhoneNumbers
+    if (this.props.shouldFilterEmptyItems) {
+      emails = emails.filter(x => {
+        const item = x.Item || {}
+        return item.value
+      })
+      phoneNumbers = phoneNumbers.filter(x => {
+        const item = x.Item || {}
+        return item.number || item.noNumber
+      })
+    }
+
+    if (emails.length < this.props.minimumEmails) {
+      emails = this.props.Emails.slice(0, this.props.minimumEmails)
+    }
 
     if (phoneNumbers.length < this.props.minimumPhoneNumbers) {
       phoneNumbers = this.props.PhoneNumbers.slice(0, this.props.minimumPhoneNumbers)
@@ -97,20 +115,21 @@ export default class ContactInformation extends SubsectionElement {
         </Field>
 
         <div className={klass + ' email-collection'}>
-          <Accordion minimum={2}
-                     items={this.props.Emails}
+          <Accordion minimum={this.props.minimumEmails}
+                     items={emails}
                      defaultState={this.props.defaultState}
                      onUpdate={this.updateEmails}
                      onError={this.handleError}
                      required={this.props.required}
                      summary={this.emailSummary}
+                     customDetails={this.firstItemRequired}
                      validator={ContactEmailValidator}
                      description={i18n.t('identification.contacts.collection.summary.title')}
                      appendLabel={i18n.t('identification.contacts.collection.append')}>
             <Field title={i18n.t('identification.contacts.label.email')}
                    titleSize="label"
                    scrollIntoView={this.props.scrollIntoView}
-                   adjustFor="labels">
+                   optional={true}>
               <Email name="Item"
                      placeholder={i18n.t('identification.contacts.placeholder.email')}
                      bind={true}
@@ -135,12 +154,13 @@ export default class ContactInformation extends SubsectionElement {
                      onUpdate={this.updatePhoneNumbers}
                      onError={this.handleError}
                      required={this.props.required}
+                     customDetails={this.firstItemRequired}
                      validator={ContactPhoneNumberValidator}
                      summary={this.phoneNumberSummary}
                      description={i18n.t('identification.contacts.collection.phoneNumbers.summary.title')}
                      appendLabel={i18n.t('identification.contacts.collection.phoneNumbers.append')}>
             <Field scrollIntoView={this.props.scrollIntoView}
-                   adjustFor="telephone">
+                   optional={true}>
               <Telephone name="Item"
                          placeholder={i18n.t('identification.contacts.placeholder.telephone')}
                          allowNotApplicable={false}
@@ -159,7 +179,8 @@ ContactInformation.defaultProps = {
   Emails: [],
   PhoneNumbers: [],
   minimumPhoneNumbers: 2,
-  shouldFilterEmptyNumbers: false,
+  minimumEmails: 2,
+  shouldFilterEmptyItems: false,
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   section: 'identification',

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -50,7 +50,8 @@ class Identification extends SectionElement {
             <ContactInformation name="contacts"
                                 {...this.props.Contacts}
                                 minimumPhoneNumbers={1}
-                                shouldFilterEmptyNumbers={true}
+                                minimumEmails={1}
+                                shouldFilterEmptyItems={true}
                                 defaultState={false}
                                 dispatch={this.props.dispatch}
                                 onUpdate={this.handleUpdate.bind(this, 'Contacts')}
@@ -264,6 +265,9 @@ export class IdentificationSections extends React.Component {
         <hr />
         <ContactInformation name="contacts"
                             {...this.props.Contacts}
+                            minimumPhoneNumbers={1}
+                            minimumEmails={1}
+                            shouldFilterEmptyItems={true}
                             defaultState={false}
                             dispatch={this.props.dispatch}
                             onError={this.props.onError}

--- a/src/components/Section/Psychological/Treatment.jsx
+++ b/src/components/Section/Psychological/Treatment.jsx
@@ -56,7 +56,8 @@ export default class Treatment extends ValidationElement {
                 />
         </Field>
 
-        <Field adjustFor="telephone"
+        <Field className="override-required"
+               adjustFor="telephone"
                scrollIntoView={this.props.scrollIntoView}>
           <Telephone name="Phone"
                      label={i18n.t(`psychological.${prefix}.label.phone`)}

--- a/src/components/Section/Relationships/People/Person.jsx
+++ b/src/components/Section/Relationships/People/Person.jsx
@@ -237,7 +237,7 @@ export default class Person extends React.Component {
         </Field>
 
         <Field title={i18n.t('relationships.people.person.heading.mobileTelephone')}
-               className="mobile-telephone"
+               className="mobile-telephone override-required"
                scrollIntoView={this.props.scrollIntoView}
                adjustFor="telephone">
           <Telephone name="MobileTelephone"
@@ -249,7 +249,7 @@ export default class Person extends React.Component {
         </Field>
 
         <Field title={i18n.t('relationships.people.person.heading.otherTelephone')}
-               className="other-telephone"
+               className="other-telephone override-required"
                scrollIntoView={this.props.scrollIntoView}
                adjustFor="telephone">
           <Telephone name="OtherTelephone"

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -357,6 +357,7 @@ export default class CivilUnion extends ValidationElement {
           </Field>
 
           <Field title={i18n.t('relationships.civilUnion.heading.telephone')}
+                 className="override-required"
                  scrollIntoView={this.props.scrollIntoView}
                  adjustFor="telephone">
             <Telephone name="Telephone"

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.jsx
@@ -144,6 +144,7 @@ export default class Divorce extends React.Component {
         </Field>
 
         <Field title={i18n.t('relationships.civilUnion.divorce.heading.telephone')}
+               className="override-required"
                scrollIntoView={this.props.scrollIntoView}
                adjustFor="telephone">
           <Telephone name="Telephone"

--- a/src/components/Section/SubstanceUse/Alcohol/OrderedCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/OrderedCounseling.jsx
@@ -222,7 +222,7 @@ export default class OrderedCounseling extends ValidationElement {
             </Field>
             <Field title={i18n.t('substance.alcohol.orderedCounseling.heading.treatmentProviderTelephone')}
                    help={'substance.alcohol.orderedCounseling.help.treatmentProviderTelephone'}
-                   adjustFor="telephone"
+                   className="override-required"
                    scrollIntoView={this.props.scrollIntoView}>
               <Telephone name="TreatmentProviderTelephone"
                          className="provider-telephone"

--- a/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounseling.jsx
+++ b/src/components/Section/SubstanceUse/Alcohol/VoluntaryCounseling.jsx
@@ -98,7 +98,7 @@ export default class VoluntaryCounseling extends ValidationElement {
         </Field>
         <Field title={i18n.t('substance.alcohol.voluntaryCounseling.heading.treatmentProviderTelephone')}
                help={'substance.alcohol.voluntaryCounseling.help.treatmentProviderTelephone'}
-               adjustFor="telephone"
+               className="override-required"
                scrollIntoView={this.props.scrollIntoView}>
           <Telephone name="TreatmentProviderTelephone"
                      className="provider-telephone"

--- a/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/OrderedTreatment.jsx
@@ -229,7 +229,7 @@ export default class OrderedTreatment extends ValidationElement {
             </Field>
 
             <Field title={i18n.t('substance.drugs.ordered.heading.treatmentProviderTelephone')}
-                   className="treatment-provider-telephone"
+                   className="treatment-provider-telephone override-required"
                    help={'substance.drugs.ordered.help.treatmentProviderTelephone'}
                    adjustFor="telephone"
                    scrollIntoView={this.props.scrollIntoView}>

--- a/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatment.jsx
+++ b/src/components/Section/SubstanceUse/Drugs/VoluntaryTreatment.jsx
@@ -107,7 +107,7 @@ export default class VoluntaryTreatment extends ValidationElement {
                     />
         </Field>
         <Field title={i18n.t('substance.drugs.voluntary.heading.treatmentProviderTelephone')}
-               className="treatment-provider-telephone"
+               className="treatment-provider-telephone override-required"
                help={'substance.drugs.voluntary.help.treatmentProviderTelephone'}
                adjustFor="telephone"
                scrollIntoView={this.props.scrollIntoView}>

--- a/src/validators/identificationcontacts.js
+++ b/src/validators/identificationcontacts.js
@@ -10,18 +10,20 @@ export default class IdentificationContactInformationValidator {
    * Validates a collection of emails
    */
   validEmails () {
-    const required = 2
+    const required = 1
     if (!this.emails || this.emails.length < required) {
       return false
     }
 
+    let successful = 0
     for (const email of this.emails) {
       if (!new ContactEmailValidator(email.Item).isValid()) {
-        return false
+        continue
       }
+      successful++
     }
 
-    return true
+    return successful >= required
   }
 
   /**

--- a/src/validators/identificationcontacts.test.js
+++ b/src/validators/identificationcontacts.test.js
@@ -22,6 +22,12 @@ describe('Contact Information validation', function () {
       },
       {
         state: {
+          Emails: []
+        },
+        expected: false
+      },
+      {
+        state: {
           Emails: [
             {
               Item: {
@@ -30,7 +36,7 @@ describe('Contact Information validation', function () {
             }
           ]
         },
-        expected: false
+        expected: true
       },
       {
         state: {
@@ -45,7 +51,7 @@ describe('Contact Information validation', function () {
             }
           ]
         },
-        expected: false
+        expected: true
       }
     ]
 

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -392,4 +392,30 @@ select {
     color: #981b1e;
     content: '*';
   }
+
+  // Specifically target labels for the requirement token(s).
+  .telephone {
+    .numbers > label,
+    .phonetype > label {
+      &:after {
+        font-family: $eapp-serif;
+        font-size: 1.2rem;
+        font-weight: normal;
+        vertical-align: text-top;
+        margin-left: 0.4rem;
+        color: #981b1e;
+        content: '*';
+      }
+    }
+  }
+
+  // This allows the component to handle its own placement of requirement tokens.
+  // A use case for this is `<Telephone />`. The field title does not have an required token,
+  // but two labels within the component potentially do.
+  &.override-required {
+    .title:after,
+    > label:after {
+      content: none;
+    }
+  }
 }


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2162

Changing email requirements to 1 vice 2. Also, only the first item in
each accordion is to be marked with requirement token (asterisk). This
also required an adjustment to displaying the requirement token on
`Telephone` components in general.

Related to issues
 - truetandem/e-QIP-prototype#2123
 - truetandem/e-QIP-prototype#2096
 - truetandem/e-QIP-prototype#998
 - truetandem/e-QIP-prototype#2079


## Contact Information: Emails

![image](https://user-images.githubusercontent.com/697855/32455328-f39d1d10-c2ef-11e7-9cf3-ce7d3753786e.png)

## Contact Information: Phone Numbers

![image](https://user-images.githubusercontent.com/697855/32455336-fc41ad3c-c2ef-11e7-8fab-f98fce5837a0.png)


## Telephone elsewhere in the application

![image](https://user-images.githubusercontent.com/697855/32455359-09221276-c2f0-11e7-8e77-63edda65b547.png)
