### PR TITLE
Building of xmlsec1 for deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ __snapshots__/
 # Build artifacts
 .gitmessage
 .projectile
+bin
 /api/api
 /build/
 /doc/

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,8 +1,6 @@
 FROM golang:1.8
-RUN apt-get update; apt-get -y install postgresql;
+RUN apt update; apt -y install postgresql xmlsec1;
 RUN go get github.com/derekparker/delve/cmd/dlv;
-RUN apt update; \
-    apt-get -y install xmlsec1;
 RUN go get -u github.com/Masterminds/glide; \
     cd $GOPATH/src/github.com/Masterminds/glide; \
     git checkout tags/$(git describe --tags $(git rev-list --tags --max-count=1)); \

--- a/api/build.sh
+++ b/api/build.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
 
+../bin/compile-xmlsec1.sh
 glide install
 go build -o api

--- a/bin/compile-xmlsec1.sh
+++ b/bin/compile-xmlsec1.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check to see if the file already exists
+if [ ! -f ./bin/xmlsec1 ]
+then
+    # Install prereq's
+    apt update;
+    apt install -y autoconf libtool libtool-bin libxml2-dev libxslt-dev libssl-dev;
+
+    # Pull down the latest source
+    git clone https://github.com/lsh123/xmlsec.git;
+    cd ./xmlsec;
+
+    # Create the configuration and make files
+    ./autogen.sh --enable-static="yes" --enable-shared="no" --enable-static-linking="yes";
+    make;
+
+    # Move the binary to where we need it
+    mkdir -p ../bin;
+    cp ./apps/xmlsec1 ../bin;
+
+    # Perform some clean up and setting permissions
+    cd ..;
+    rm -rf ./xmlsec;
+    chmod -R +755 ./bin;
+    chown -R 1000:users ./bin;
+fi

--- a/manifest-api-dev.yml
+++ b/manifest-api-dev.yml
@@ -12,6 +12,7 @@ applications:
     - eqip-postgres
     - usps-api
   env:
+    PATH: /bin:/usr/bin:$HOME/bin
     GOVERSION: go1.8.5
     ALLOW_2FA_RESET: 1
     DISABLE_2FA: 1

--- a/manifest-api-staging.yml
+++ b/manifest-api-staging.yml
@@ -12,6 +12,7 @@ applications:
     - eqip-postgres
     - usps-api
   env:
+    PATH: /bin:/usr/bin:$HOME/bin
     GOVERSION: go1.8.5
     ALLOW_2FA_RESET: 1
     SAML_ENABLED: 1

--- a/manifest-api.yml
+++ b/manifest-api.yml
@@ -12,4 +12,5 @@ applications:
     - eqip-postgres
     - usps-api
   env:
+    PATH: /bin:/usr/bin:$HOME/bin
     GOVERSION: go1.8.5


### PR DESCRIPTION
The buildpack used for the API does not include `xmlsec1` so we need to deploy it with the application during CI/CD.

 - `bin/compile-xmlsec1.sh` - If a previous binary is not found this will pull down prerequisites, recent source code, and then compile the program needed
 - `api/bin/xmlsec1` - Binary executable resulting from the compilation

Adjustments were made to the `$PATH` environment variables to allow for the `xmlsec1` to be found within the `$HOME/bin` directory.