### PR TITLE
Digital signature tweaks from usability testing

### DIFF
--- a/src/components/Section/Releases/Signature.jsx
+++ b/src/components/Section/Releases/Signature.jsx
@@ -51,19 +51,20 @@ export default class Signature extends ValidationElement {
 
   render () {
     const name = (this.props.LegalName || {}).Name
+    const signed = this.props.Date && this.props.Date.value
+    const button = <button className="add" onClick={this.addSignature}>{i18n.t('signature.add')}</button>
+    const nameSummary = signed ? NameSummary(name) : button
+    const dateSummary = signed ? DateSummary(this.props.Date, '', true) : ''
     return (
       <div className="signature">
-        <Show when={!this.props.Date || !this.props.Date.value}>
-          <button className="add" onClick={this.addSignature}>{i18n.t('signature.add')}</button>
-        </Show>
-        <Show when={this.props.Date && this.props.Date.value}>
-          <span className="name wet">{NameSummary(name)}</span>
-          <span className="spacer"></span>
-          <span className="date wet">{DateSummary(this.props.Date, '', true)}</span>
+        <span className="name wet">{nameSummary}</span>
+        <span className="spacer"></span>
+        <span className="date wet">{dateSummary}</span>
 
-          <span className="name muted">{i18n.t('signature.name')}</span>
-          <span className="spacer"></span>
-          <span className="date muted">{i18n.t('signature.date')}</span>
+        <span className="name muted">{i18n.t('signature.name')}</span>
+        <span className="spacer"></span>
+        <span className="date muted">{i18n.t('signature.date')}</span>
+        <Show when={signed}>
           <a href="javascript:;;" onClick={this.removeSignature} className="remove">
             <span>{i18n.t('signature.remove')}</span>
             <i className="fa fa-times-circle"></i>

--- a/src/components/Section/Releases/Signature.scss
+++ b/src/components/Section/Releases/Signature.scss
@@ -3,8 +3,10 @@
 
 .signature {
   .wet {
-    font-family: $eapp-cursive;
-    font-size: 26pt;
+    position: relative;
+    font-family: $eapp-sans;
+    font-size: 14pt;
+    font-weight: 600;
     line-height: 1;
     margin-bottom: -2rem;
   }
@@ -30,6 +32,11 @@
     border-top: 1px #000 solid;
     margin-top: -1rem;
     font-size: 11pt;
+  }
+
+  .add {
+    position: absolute;
+    top: -6.25rem;
   }
 
   .remove {


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2199

 - Remove the cursive font for a more boring one
 - Always display the "signature lines"
 - Place the "click to sign button" where the wet signature would go

## Without signature

![image](https://user-images.githubusercontent.com/697855/32953453-3bb374f0-cb7e-11e7-94a6-b55a29a307cb.png)

## With signature

![image](https://user-images.githubusercontent.com/697855/32953458-40f9342c-cb7e-11e7-9c51-9223675cc2d0.png)
