### PR TITLE
Make release headline an h3 and increase white space

### DIFF
--- a/src/components/Section/Submission/ValidForm.jsx
+++ b/src/components/Section/Submission/ValidForm.jsx
@@ -189,7 +189,7 @@ export default class ValidForm extends ValidationElement {
         <BasicAccordion items={accordionItems} />
         <div className="text-right">
           <button onClick={this.submit} className="submit usa-button" disabled={!enableSubmit(this.props)}>
-            Submit your SF-86
+            { i18n.t('submission.validForm.submit') }
             <i className="fa fa-arrow-circle-right" aria-hidden="true"></i>
           </button>
         </div>

--- a/src/components/Section/Submission/ValidForm.scss
+++ b/src/components/Section/Submission/ValidForm.scss
@@ -1,10 +1,14 @@
 .valid-form {
+  padding-top: 1rem;
+
   .submit.usa-button {
     padding: 3rem 6rem 3rem 6rem;
+
     i {
       margin-left: 0.6rem;
     }
   }
+
   .submit.usa-button:disabled {
     background-color: #0071bc;
   }

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -9571,7 +9571,8 @@ const en = {
     validForm: {
       certificationItem: 'Certification',
       generalItem: 'Release of Information & HIPAA',
-      creditItem: 'Credit reporting disclosure'
+      creditItem: 'Credit reporting disclosure',
+      submit: 'Submit your SF-86'
     },
     invalidForm: [
       '### List of incomplete sections',
@@ -9587,7 +9588,7 @@ const en = {
         'Not a guarantee of acceptance, but all required fields are complete.'
       ],
       valid2: [
-        'Please sign the releases below and submit your form.'
+        '### Please sign the releases below and submit your form.'
       ],
       invalid: [
         '## Some required fields are incomplete',


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2198

This converts the "Please sign the releases..." text an H3 (previously
just a paragraph) and adds `1rem` in white space above it.

![image](https://user-images.githubusercontent.com/697855/32953956-c5fedc16-cb7f-11e7-85b8-b87bbacdf4d1.png)
