### PR TITLE
Added polyfill to entry point in webpack config file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var sasslint = require('@18f/stylelint-rules')
 require('dotenv').config()
 
 var paths = {
-  entry: ['babel-polyfill', './src/boot.jsx'],
+  entry: ['./src/boot.jsx'],
   js: [
     './src/**/*.js*'
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const webpack = require('webpack')
 const path = require('path')
 
 module.exports = {
-  entry: './src/boot.jsx',
+  entry: ['babel-polyfill', './src/boot.jsx'],
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'eqip.js'


### PR DESCRIPTION
Resolves #2184 

Just had to add the poly entry inside of the webpack config. 

Using IE11, I was getting:
![selection_558](https://user-images.githubusercontent.com/5938731/32960201-11dcf804-cb92-11e7-90ae-4edb9ad57177.png)

Once I added the polyfill reference, then it loaded.

![selection_559](https://user-images.githubusercontent.com/5938731/32960210-1ba6ed90-cb92-11e7-98d7-ef2dee1aefe9.png)
