### PR TITLE
Allow display of only one email or telephone number

### DIFF
--- a/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.jsx
@@ -76,6 +76,7 @@ export default class ContactInformation extends SubsectionElement {
     return callback()
   }
 
+
   render () {
     const klass = `${this.props.className || ''}`.trim()
     let emails = this.props.Emails
@@ -95,12 +96,20 @@ export default class ContactInformation extends SubsectionElement {
       phoneNumbers.items = filteredPhoneNumbers
     }
 
-    if (emails.length < this.props.minimumEmails) {
-      emails = this.props.Emails.items.slice(0, this.props.minimumEmails)
+    if (emails.items.length === 0) {
+      if (this.props.shouldFilterEmptyItems) {
+        emails = { items: [{}] }
+      } else {
+        emails = { items: [{}, {}] }
+      }
     }
 
-    if (phoneNumbers.length < this.props.minimumPhoneNumbers) {
-      phoneNumbers = this.props.PhoneNumbers.items.slice(0, this.props.minimumPhoneNumbers)
+    if (phoneNumbers.items.length === 0) {
+      if (this.props.shouldFilterEmptyItems) {
+        phoneNumbers = { items: [{}] }
+      } else {
+        phoneNumbers = { items: [{}, {}] }
+      }
     }
 
     return (
@@ -120,8 +129,7 @@ export default class ContactInformation extends SubsectionElement {
         </Field>
 
         <div className={klass + ' email-collection'}>
-          <Accordion minimum={this.props.minimumEmails}
-                     {...emails}
+          <Accordion {...emails}
                      defaultState={this.props.defaultState}
                      onUpdate={this.updateEmails}
                      onError={this.handleError}
@@ -154,8 +162,7 @@ export default class ContactInformation extends SubsectionElement {
         </Field>
 
         <div className={klass + ' telephone-collection'}>
-          <Accordion minimum={this.props.minimumPhoneNumbers}
-                     {...phoneNumbers}
+          <Accordion {...phoneNumbers}
                      defaultState={this.props.defaultState}
                      onUpdate={this.updatePhoneNumbers}
                      onError={this.handleError}
@@ -185,8 +192,8 @@ export default class ContactInformation extends SubsectionElement {
 ContactInformation.defaultProps = {
   Emails: Accordion.defaultList,
   PhoneNumbers: Accordion.defaultList,
-  minimumPhoneNumbers: 2,
-  minimumEmails: 2,
+  minimumPhoneNumbers: 1,
+  minimumEmails: 1,
   shouldFilterEmptyItems: false,
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },

--- a/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
+++ b/src/components/Section/Identification/ContactInformation/ContactInformation.test.jsx
@@ -70,12 +70,15 @@ describe('The ContactInformation component', () => {
       }
     }
     const component = mount(<ContactInformation {...expected} />)
-    expect(component.find('.index').length).toEqual(5)
-    expect(component.find('.summary strong').at(0).text()).toEqual('(202) 867-5309 x1234')
-    expect(component.find('.summary strong').at(1).text()).toEqual('(202) 867-5309')
-    expect(component.find('.summary strong').at(2).text()).toEqual('867-5309')
-    expect(component.find('.summary strong').at(3).text()).toEqual('+001 1234567890 x1234')
-    expect(component.find('.summary strong').at(4).text()).toEqual('+001 1234567890')
+    // 5 phone numbers and 2 emails
+    expect(component.find('.index').length).toEqual(5 + 2)
+    expect(component.find('.summary strong').at(0).text()).toEqual('Provide your email address below')
+    expect(component.find('.summary strong').at(1).text()).toEqual('Provide your email address below')
+    expect(component.find('.summary strong').at(2).text()).toEqual('(202) 867-5309 x1234')
+    expect(component.find('.summary strong').at(3).text()).toEqual('(202) 867-5309')
+    expect(component.find('.summary strong').at(4).text()).toEqual('867-5309')
+    expect(component.find('.summary strong').at(5).text()).toEqual('+001 1234567890 x1234')
+    expect(component.find('.summary strong').at(6).text()).toEqual('+001 1234567890')
   })
 
   it('formats emails appropriately', () => {
@@ -96,8 +99,20 @@ describe('The ContactInformation component', () => {
       }
     }
     const component = mount(<ContactInformation {...expected} />)
-    expect(component.find('.index').length).toEqual(2)
+    // 2 for emails and 2 for phone numbers
+    expect(component.find('.index').length).toEqual(2 + 2)
     expect(component.find('.summary strong').at(0).text()).toEqual('test@abc.com')
     expect(component.find('.summary strong').at(1).text()).toEqual('Provide your email address below')
+  })
+
+  it('should filter empty items out leaving only the minimum visible', () => {
+    const expected = {
+      shouldFilterEmptyItems: true
+    }
+    const component = mount(<ContactInformation {...expected} />)
+    // 1 for emails and 1 for phone numbers
+    expect(component.find('.index').length).toEqual(1 + 1)
+    expect(component.find('.summary strong').at(0).text()).toEqual('Provide your email address below')
+    expect(component.find('.summary strong').at(1).text()).toEqual('Provide your telephone number below')
   })
 })


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2096

There is a requirement of one (1) per each type of contact
information. However, we have a requirement to initially display
two (2) items per each.

Previously we set the minimum on the accordion to 2 and then made the
requirement of 1 within the validation logic. This was confusing in
usability testing because once one item was removed the accordion
would recreate it to fulfill the minimum to display requirement. This
happens so quickly it appears as if nothing is happening.