### PR TITLE
When the viewport is under 800px we remove adjust

### DIFF
--- a/src/components/Form/Consent/Consent.scss
+++ b/src/components/Form/Consent/Consent.scss
@@ -20,6 +20,12 @@
     border: none;
     box-shadow: none;
 
+    @media only screen and (max-height: 800px) {
+      height: 100vh;
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+
     .consent-legal {
       overflow-y: scroll;
       max-height: 84vh;

--- a/src/components/Form/Introduction/Introduction.scss
+++ b/src/components/Form/Introduction/Introduction.scss
@@ -30,6 +30,12 @@
       border: none;
       box-shadow: none;
 
+      @media only screen and (max-height: 800px) {
+        height: 100vh;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+      }
+
       .introduction-legal {
         overflow-y: scroll;
         max-height: 55vh;


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2185

The top & bottom margins of 5vh needed to be removed to allow for
proper amount of space to still be functional