### PR TITLE
Added addendum branching to history accordions

### DIFF
--- a/src/components/Section/History/Education/Education.jsx
+++ b/src/components/Section/History/Education/Education.jsx
@@ -49,6 +49,7 @@ export default class Education extends SubsectionElement {
                    byline={this.customEducationByline}
                    customSummary={EducationCustomSummary}
                    description={i18n.t('history.education.collection.school.summary.title')}
+                   appendTitle={i18n.t('history.education.collection.school.appendTitle')}
                    appendLabel={i18n.t('history.education.collection.school.append')}
                    required={this.props.required}
                    scrollIntoView={this.props.scrollIntoView}>
@@ -66,7 +67,7 @@ export default class Education extends SubsectionElement {
 }
 
 Education.defaultProps = {
-  List: { items: [] },
+  List: Accordion.defaultList,
   scrollToTop: '',
   defaultState: true,
   realtime: false,

--- a/src/components/Section/History/Employment/Employment.jsx
+++ b/src/components/Section/History/Employment/Employment.jsx
@@ -133,6 +133,7 @@ export default class Employment extends SubsectionElement {
                    description={i18n.t('history.employment.default.collection.summary.title')}
                    appendTitle={i18n.t('history.employment.default.collection.appendTitle')}
                    appendLabel={i18n.t('history.employment.default.collection.append')}
+                   appendClass="no-margin-bottom"
                    required={this.props.required}
                    scrollIntoView={this.props.scrollIntoView}>
           <EmploymentItem name="Item"
@@ -142,6 +143,7 @@ export default class Employment extends SubsectionElement {
                           required={this.props.required}
                           scrollIntoView={this.props.scrollIntoView} />
         </Accordion>
+        <hr className="section-divider" />
         <Branch label={i18n.t('history.employment.default.employmentRecord.title')}
                 labelSize="h3"
                 {...this.props.EmploymentRecord}

--- a/src/components/Section/History/Employment/Employment.scss
+++ b/src/components/Section/History/Employment/Employment.scss
@@ -1,0 +1,7 @@
+.history {
+  .employment {
+    .addendum {
+      padding-bottom: 2rem;
+    }
+  }
+}

--- a/src/components/Section/History/Federal/Federal.jsx
+++ b/src/components/Section/History/Federal/Federal.jsx
@@ -95,7 +95,7 @@ export default class Federal extends SubsectionElement {
 
 Federal.defaultProps = {
   HasFederalService: {},
-  List: { items: [] },
+  List: Accordion.defaultList,
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   section: 'history',

--- a/src/components/Section/History/History.scss
+++ b/src/components/Section/History/History.scss
@@ -54,7 +54,7 @@
     height: 0;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     border-bottom: 1px solid $eapp-grey;
-    margin: 5rem 8rem 5rem 4rem;
+    margin: 5rem 0;
   }
 
   .not-complete {

--- a/src/components/Section/History/Residence/Residence.jsx
+++ b/src/components/Section/History/Residence/Residence.jsx
@@ -100,6 +100,7 @@ export default class Residence extends SubsectionElement {
                    customSummary={ResidenceCustomSummary}
                    customDetails={this.customResidenceDetails}
                    description={i18n.t('history.residence.collection.summary.title')}
+                   appendTitle={i18n.t('history.residence.collection.appendTitle')}
                    appendLabel={i18n.t('history.residence.collection.append')}
                    required={this.props.required}
                    scrollIntoView={this.props.scrollIntoView}>
@@ -116,7 +117,7 @@ export default class Residence extends SubsectionElement {
 }
 
 Residence.defaultProps = {
-  List: { items: [] },
+  List: Accordion.defaultList,
   scrollToTop: '',
   defaultState: true,
   realtime: false,

--- a/src/config/locales/en.js
+++ b/src/config/locales/en.js
@@ -3632,7 +3632,8 @@ const en = {
           incomplete: 'This residence\'s information is incomplete',
           item2: 'Person'
         },
-        append: 'Add another residence'
+        append: 'Add another residence',
+        appendTitle: 'Do you have an additional residence to report?'
       },
       gap: {
         title: 'Residence gap',
@@ -3716,14 +3717,7 @@ const en = {
         collection: {
           caption: 'Employment activities',
           append: 'Add another employer',
-          appendTitle: 'Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?',
-          appendMessage: [
-            '- Fired from a job?',
-            '- Quit a job after being told you would be fired?',
-            '- Have you left a job by mutual agreement following charges or allegations of misconduct?',
-            '- Left a job by mutual agreement following notice of unsatisfactory performance?',
-            '- Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?'
-          ],
+          appendTitle: 'Do you have an additional employment activity to enter?',
           summary: {
             title: 'Summary of your work history',
             employer: 'Employer',
@@ -3731,6 +3725,17 @@ const en = {
             unknown: '*Provide employer details*',
             item2: 'Title'
           }
+        },
+        employmentRecord: {
+          title: 'Have any of the following happened to you in the last seven (7) years at employment activities that you have not previously listed?',
+          list: [
+            '- Fired from a job?',
+            '- Quit a job after being told you would be fired?',
+            '- Have you left a job by mutual agreement following charges or allegations of misconduct?',
+            '- Left a job by mutual agreement following notice of unsatisfactory performance?',
+            '- Received a written warning, been officially reprimanded, suspended, or disciplined for misconduct in the workplace, such as violation of security policy?'
+          ],
+          para: 'If you answer "Yes", you will be required to add an additional employment record above.'
         },
         activity: {
           title: 'Government employment',
@@ -5079,7 +5084,8 @@ const en = {
             incomplete: 'This education\'s information is incomplete',
             item2: 'Diploma'
           },
-          append: 'Add another school'
+          append: 'Add another school',
+          appendTitle: 'Do you have additional education (include education within the last 10 years, as well as degrees or diplomas more than 10 years ago)?'
         },
         diploma: {
           summary: {

--- a/src/validators/education.js
+++ b/src/validators/education.js
@@ -31,7 +31,7 @@ export default class HistoryEducationValidator {
 
     return validAccordion(this.list, (item) => {
       return new EducationItemValidator(item).isValid()
-    }, true)
+    })
   }
 
   isValid () {

--- a/src/validators/education.test.js
+++ b/src/validators/education.test.js
@@ -381,6 +381,9 @@ describe('Education component validation', function () {
           HasAttended: { value: 'Yes' },
           HasDegree10: { value: 'Yes' },
           List: {
+            branch: {
+              value: 'No'
+            },
             items: [
               {
                 Item: {
@@ -428,6 +431,9 @@ describe('Education component validation', function () {
           HasAttended: { value: 'Yes' },
           HasDegree10: { value: 'Yes' },
           List: {
+            branch: {
+              value: 'No'
+            },
             items: [
               {
                 Item: {

--- a/src/validators/employment.js
+++ b/src/validators/employment.js
@@ -2,20 +2,21 @@ import DateRangeValidator from './daterange'
 import LocationValidator from './location'
 import ReferenceValidator from './reference'
 import { validNotApplicable, validGenericTextfield, validPhoneNumber, validGenericMonthYear,
-         validDateField, withinSevenYears, BranchCollection } from './helpers'
+         validDateField, withinSevenYears, BranchCollection, validAccordion } from './helpers'
 
 export default class HistoryEmploymentValidator {
   constructor (data = {}) {
-    this.list = ((data.List || { items: [] }).items || [])
+    this.list = (data.List || { items: [] })
+    this.employmentRecord = data.EmploymentRecord || {}
   }
 
   isValid () {
-    if (this.list.length === 0) {
+    if (this.employmentRecord.value !== 'No') {
       return false
     }
 
-    return this.list.every(x => {
-      return new EmploymentValidator(x.Item).isValid()
+    return validAccordion(this.list, (item) => {
+      return new EmploymentValidator(item).isValid()
     })
   }
 }

--- a/src/validators/employment.test.js
+++ b/src/validators/employment.test.js
@@ -1,4 +1,4 @@
-import { EmploymentValidator } from './employment'
+import HistoryEmploymentValidator, { EmploymentValidator } from './employment'
 import Location from '../components/Form/Location'
 
 describe('Employment component validation', function () {
@@ -1413,6 +1413,184 @@ describe('Employment component validation', function () {
 
     tests.forEach(test => {
       expect(new EmploymentValidator(test.state, null).validReprimand()).toBe(test.expected)
+    })
+  })
+
+  it('should test for second branch logic involving employment record', () => {
+    const list = {
+      items: [
+        {
+          Item: {
+            EmploymentActivity: {
+              value: 'NationalGuard'
+            },
+            Dates: {
+              from: {
+                date: new Date('1/1/2010')
+              },
+              to: {
+                date: new Date('1/1/2016')
+              },
+              present: false
+            },
+            Status: {
+              value: 'Fulltime'
+            },
+            Title: {
+              value: 'IT Support'
+            },
+            DutyStation: {
+              value: 'Station 1'
+            },
+            Address: {
+              country: { value: 'United States' },
+              street: '1234 Some Rd',
+              city: 'Arlington',
+              state: 'Virginia',
+              zipcode: '22202',
+              layout: Location.ADDRESS
+            },
+            Telephone: {
+              noNumber: '',
+              number: '2028675309',
+              numberType: 'Cell',
+              type: 'Domestic',
+              timeOfDay: 'Day'
+            },
+            Supervisor: {
+              Address: {
+                country: { value: 'United States' },
+                street: '1234 Some Rd',
+                city: 'Arlington',
+                state: 'Virginia',
+                zipcode: '22202',
+                layout: Location.ADDRESS
+              },
+              Email: {
+                value: 'foo@local.dev'
+              },
+              SupervisorName: {
+                value: 'John Doe'
+              },
+              Telephone: {
+                noNumber: '',
+                number: '2021112222',
+                numberType: 'Cell',
+                type: 'Domestic',
+                timeOfDay: 'Day'
+              },
+              Title: {
+                value: 'The Foo'
+              }
+            },
+            ReasonLeft: {
+              Reasons: {
+                items: [
+                  {
+                    Item: {
+                      Has: { value: 'No' },
+                      Reason: 'Fired',
+                      Date: {
+                        date: new Date('1/1/2016'),
+                        day: '1',
+                        month: '1',
+                        year: '2016'
+                      },
+                      Text: {
+                        value: 'Some excuse'
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            Reprimand: {
+              Reasons: {
+                items: [
+                  {
+                    Item: {
+                      Has: { value: 'No' },
+                      Date: {
+                        date: new Date('1/1/2015'),
+                        month: '1',
+                        year: '2015'
+                      },
+                      Text: {
+                        value: 'Foo'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      branch: {
+        value: 'No'
+      }
+    }
+
+    const tests = [
+      {
+        data: {
+          List: list,
+          EmploymentRecord: {
+            value: ''
+          }
+        },
+        expected: false
+      },
+      {
+        data: {
+          List: list,
+          EmploymentRecord: {
+            value: 'Yes'
+          }
+        },
+        expected: false
+      },
+      {
+        data: {
+          List: list,
+          EmploymentRecord: {
+            value: 'No'
+          }
+        },
+        expected: true
+      },
+      {
+        data: {
+          List: {
+            ...list,
+            branch: {
+              value: ''
+            }
+          },
+          EmploymentRecord: {
+            value: 'No'
+          }
+        },
+        expected: false
+      },
+      {
+        data: {
+          List: {
+            ...list,
+            branch: {
+              value: 'Yes'
+            }
+          },
+          EmploymentRecord: {
+            value: 'No'
+          }
+        },
+        expected: false
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(new HistoryEmploymentValidator(test.data).isValid()).toBe(test.expected)
     })
   })
 })

--- a/src/validators/residence.js
+++ b/src/validators/residence.js
@@ -2,7 +2,7 @@ import DateRangeValidator from './daterange'
 import LocationValidator from './location'
 import ReferenceValidator from './reference'
 import { daysAgo, today } from '../components/Section/History/dateranges'
-import { validGenericTextfield } from './helpers'
+import { validAccordion, validGenericTextfield } from './helpers'
 
 // Options for roles
 const roleOptions = ['Other', 'Military', 'Owned', 'Rented']
@@ -17,13 +17,8 @@ export default class HistoryResidenceValidator {
   }
 
   isValid () {
-    const items = this.List.items || []
-    if (items.length === 0) {
-      return false
-    }
-
-    return items.every(x => {
-      return new ResidenceValidator(x.Item, null).isValid()
+    return validAccordion(this.list, (item) => {
+      return new ResidenceValidator(item).isValid()
     })
   }
 }


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#1903

Residence, Employment, and Education now have branch questions at the
end of the accordions. The verbiage was taking from the official
guide.

One difference is the Employment section has a follow-up question to
account for section 13c on the guide. If the answer is "yes" then we
zero out the two final branch questions and add a new item to the
accordion.