### PR TITLE
Fix errors when flushing data

### DIFF
--- a/api/model/form/financial.go
+++ b/api/model/form/financial.go
@@ -81,8 +81,14 @@ func (entity *FinancialBankruptcy) Save(context *db.DatabaseContext, account int
 
 	context.Find(&FinancialBankruptcy{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialBankruptcy)
+		if entity.HasBankruptcy == nil {
+			entity.HasBankruptcy = &Branch{}
+		}
 		entity.HasBankruptcyID = previous.HasBankruptcyID
 		entity.HasBankruptcy.ID = previous.HasBankruptcyID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -116,8 +122,14 @@ func (entity *FinancialBankruptcy) Delete(context *db.DatabaseContext, account i
 
 	context.Find(&FinancialBankruptcy{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialBankruptcy)
+		if entity.HasBankruptcy == nil {
+			entity.HasBankruptcy = &Branch{}
+		}
 		entity.HasBankruptcyID = previous.HasBankruptcyID
 		entity.HasBankruptcy.ID = previous.HasBankruptcyID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -254,8 +266,14 @@ func (entity *FinancialGambling) Save(context *db.DatabaseContext, account int) 
 
 	context.Find(&FinancialGambling{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialGambling)
+		if entity.HasGamblingDebt == nil {
+			entity.HasGamblingDebt = &Branch{}
+		}
 		entity.HasGamblingDebtID = previous.HasGamblingDebtID
 		entity.HasGamblingDebt.ID = previous.HasGamblingDebtID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -289,8 +307,14 @@ func (entity *FinancialGambling) Delete(context *db.DatabaseContext, account int
 
 	context.Find(&FinancialGambling{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialGambling)
+		if entity.HasGamblingDebt == nil {
+			entity.HasGamblingDebt = &Branch{}
+		}
 		entity.HasGamblingDebtID = previous.HasGamblingDebtID
 		entity.HasGamblingDebt.ID = previous.HasGamblingDebtID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -427,8 +451,14 @@ func (entity *FinancialTaxes) Save(context *db.DatabaseContext, account int) (in
 
 	context.Find(&FinancialTaxes{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialTaxes)
+		if entity.HasTaxes == nil {
+			entity.HasTaxes = &Branch{}
+		}
 		entity.HasTaxesID = previous.HasTaxesID
 		entity.HasTaxes.ID = previous.HasTaxesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -466,8 +496,14 @@ func (entity *FinancialTaxes) Delete(context *db.DatabaseContext, account int) (
 
 	context.Find(&FinancialTaxes{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialTaxes)
+		if entity.HasTaxes == nil {
+			entity.HasTaxes = &Branch{}
+		}
 		entity.HasTaxesID = previous.HasTaxesID
 		entity.HasTaxes.ID = previous.HasTaxesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -604,8 +640,14 @@ func (entity *FinancialCard) Save(context *db.DatabaseContext, account int) (int
 
 	context.Find(&FinancialCard{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialCard)
+		if entity.HasCardAbuse == nil {
+			entity.HasCardAbuse = &Branch{}
+		}
 		entity.HasCardAbuseID = previous.HasCardAbuseID
 		entity.HasCardAbuse.ID = previous.HasCardAbuseID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -643,8 +685,14 @@ func (entity *FinancialCard) Delete(context *db.DatabaseContext, account int) (i
 
 	context.Find(&FinancialCard{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialCard)
+		if entity.HasCardAbuse == nil {
+			entity.HasCardAbuse = &Branch{}
+		}
 		entity.HasCardAbuseID = previous.HasCardAbuseID
 		entity.HasCardAbuse.ID = previous.HasCardAbuseID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -781,8 +829,14 @@ func (entity *FinancialCredit) Save(context *db.DatabaseContext, account int) (i
 
 	context.Find(&FinancialCredit{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialCredit)
+		if entity.HasCreditCounseling == nil {
+			entity.HasCreditCounseling = &Branch{}
+		}
 		entity.HasCreditCounselingID = previous.HasCreditCounselingID
 		entity.HasCreditCounseling.ID = previous.HasCreditCounselingID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -820,8 +874,14 @@ func (entity *FinancialCredit) Delete(context *db.DatabaseContext, account int) 
 
 	context.Find(&FinancialCredit{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialCredit)
+		if entity.HasCreditCounseling == nil {
+			entity.HasCreditCounseling = &Branch{}
+		}
 		entity.HasCreditCounselingID = previous.HasCreditCounselingID
 		entity.HasCreditCounseling.ID = previous.HasCreditCounselingID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -958,8 +1018,14 @@ func (entity *FinancialDelinquent) Save(context *db.DatabaseContext, account int
 
 	context.Find(&FinancialDelinquent{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialDelinquent)
+		if entity.HasDelinquent == nil {
+			entity.HasDelinquent = &Branch{}
+		}
 		entity.HasDelinquentID = previous.HasDelinquentID
 		entity.HasDelinquent.ID = previous.HasDelinquentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -993,8 +1059,14 @@ func (entity *FinancialDelinquent) Delete(context *db.DatabaseContext, account i
 
 	context.Find(&FinancialDelinquent{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialDelinquent)
+		if entity.HasDelinquent == nil {
+			entity.HasDelinquent = &Branch{}
+		}
 		entity.HasDelinquentID = previous.HasDelinquentID
 		entity.HasDelinquent.ID = previous.HasDelinquentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1131,8 +1203,14 @@ func (entity *FinancialNonpayment) Save(context *db.DatabaseContext, account int
 
 	context.Find(&FinancialNonpayment{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialNonpayment)
+		if entity.HasNonpayment == nil {
+			entity.HasNonpayment = &Branch{}
+		}
 		entity.HasNonpaymentID = previous.HasNonpaymentID
 		entity.HasNonpayment.ID = previous.HasNonpaymentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1166,8 +1244,14 @@ func (entity *FinancialNonpayment) Delete(context *db.DatabaseContext, account i
 
 	context.Find(&FinancialNonpayment{ID: account}, func(result interface{}) {
 		previous := result.(*FinancialNonpayment)
+		if entity.HasNonpayment == nil {
+			entity.HasNonpayment = &Branch{}
+		}
 		entity.HasNonpaymentID = previous.HasNonpaymentID
 		entity.HasNonpayment.ID = previous.HasNonpaymentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})

--- a/api/model/form/foreign.go
+++ b/api/model/form/foreign.go
@@ -161,18 +161,39 @@ func (entity *ForeignPassport) Save(context *db.DatabaseContext, account int) (i
 
 	context.Find(&ForeignPassport{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignPassport)
+		if entity.HasPassports == nil {
+			entity.HasPassports = &Branch{}
+		}
 		entity.HasPassportsID = previous.HasPassportsID
 		entity.HasPassports.ID = previous.HasPassportsID
+		if entity.Name == nil {
+			entity.Name = &Name{}
+		}
 		entity.NameID = previous.NameID
 		entity.Name.ID = previous.NameID
+		if entity.Card == nil {
+			entity.Card = &Radio{}
+		}
 		entity.CardID = previous.CardID
 		entity.Card.ID = previous.CardID
+		if entity.Number == nil {
+			entity.Number = &Text{}
+		}
 		entity.NumberID = previous.NumberID
 		entity.Number.ID = previous.NumberID
+		if entity.Issued == nil {
+			entity.Issued = &DateControl{}
+		}
 		entity.IssuedID = previous.IssuedID
 		entity.Issued.ID = previous.IssuedID
+		if entity.Expiration == nil {
+			entity.Expiration = &DateControl{}
+		}
 		entity.ExpirationID = previous.ExpirationID
 		entity.Expiration.ID = previous.ExpirationID
+		if entity.Comments == nil {
+			entity.Comments = &Textarea{}
+		}
 		entity.CommentsID = previous.CommentsID
 		entity.Comments.ID = previous.CommentsID
 	})
@@ -236,18 +257,39 @@ func (entity *ForeignPassport) Delete(context *db.DatabaseContext, account int) 
 
 	context.Find(&ForeignPassport{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignPassport)
+		if entity.HasPassports == nil {
+			entity.HasPassports = &Branch{}
+		}
 		entity.HasPassportsID = previous.HasPassportsID
 		entity.HasPassports.ID = previous.HasPassportsID
+		if entity.Name == nil {
+			entity.Name = &Name{}
+		}
 		entity.NameID = previous.NameID
 		entity.Name.ID = previous.NameID
+		if entity.Card == nil {
+			entity.Card = &Radio{}
+		}
 		entity.CardID = previous.CardID
 		entity.Card.ID = previous.CardID
+		if entity.Number == nil {
+			entity.Number = &Text{}
+		}
 		entity.NumberID = previous.NumberID
 		entity.Number.ID = previous.NumberID
+		if entity.Issued == nil {
+			entity.Issued = &DateControl{}
+		}
 		entity.IssuedID = previous.IssuedID
 		entity.Issued.ID = previous.IssuedID
+		if entity.Expiration == nil {
+			entity.Expiration = &DateControl{}
+		}
 		entity.ExpirationID = previous.ExpirationID
 		entity.Expiration.ID = previous.ExpirationID
+		if entity.Comments == nil {
+			entity.Comments = &Textarea{}
+		}
 		entity.CommentsID = previous.CommentsID
 		entity.Comments.ID = previous.CommentsID
 	})
@@ -431,8 +473,14 @@ func (entity *ForeignContacts) Save(context *db.DatabaseContext, account int) (i
 
 	context.Find(&ForeignContacts{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignContacts)
+		if entity.HasForeignContacts == nil {
+			entity.HasForeignContacts = &Branch{}
+		}
 		entity.HasForeignContactsID = previous.HasForeignContactsID
 		entity.HasForeignContacts.ID = previous.HasForeignContactsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -466,8 +514,14 @@ func (entity *ForeignContacts) Delete(context *db.DatabaseContext, account int) 
 
 	context.Find(&ForeignContacts{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignContacts)
+		if entity.HasForeignContacts == nil {
+			entity.HasForeignContacts = &Branch{}
+		}
 		entity.HasForeignContactsID = previous.HasForeignContactsID
 		entity.HasForeignContacts.ID = previous.HasForeignContactsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -612,10 +666,19 @@ func (entity *ForeignTravel) Save(context *db.DatabaseContext, account int) (int
 
 	context.Find(&ForeignTravel{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignTravel)
+		if entity.HasForeignTravelOutside == nil {
+			entity.HasForeignTravelOutside = &Branch{}
+		}
 		entity.HasForeignTravelOutsideID = previous.HasForeignTravelOutsideID
 		entity.HasForeignTravelOutside.ID = previous.HasForeignTravelOutsideID
+		if entity.HasForeignTravelOfficial == nil {
+			entity.HasForeignTravelOfficial = &Branch{}
+		}
 		entity.HasForeignTravelOfficialID = previous.HasForeignTravelOfficialID
 		entity.HasForeignTravelOfficial.ID = previous.HasForeignTravelOfficialID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -655,10 +718,19 @@ func (entity *ForeignTravel) Delete(context *db.DatabaseContext, account int) (i
 
 	context.Find(&ForeignTravel{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignTravel)
+		if entity.HasForeignTravelOutside == nil {
+			entity.HasForeignTravelOutside = &Branch{}
+		}
 		entity.HasForeignTravelOutsideID = previous.HasForeignTravelOutsideID
 		entity.HasForeignTravelOutside.ID = previous.HasForeignTravelOutsideID
+		if entity.HasForeignTravelOfficial == nil {
+			entity.HasForeignTravelOfficial = &Branch{}
+		}
 		entity.HasForeignTravelOfficialID = previous.HasForeignTravelOfficialID
 		entity.HasForeignTravelOfficial.ID = previous.HasForeignTravelOfficialID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -798,13 +870,11 @@ func (entity *ForeignActivitiesBenefits) Save(context *db.DatabaseContext, accou
 
 	context.Find(&ForeignActivitiesBenefits{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesBenefits)
-
 		if entity.HasBenefits == nil {
 			entity.HasBenefits = &Branch{}
 		}
 		entity.HasBenefitsID = previous.HasBenefitsID
 		entity.HasBenefits.ID = previous.HasBenefitsID
-
 		if entity.List == nil {
 			entity.List = &Collection{}
 		}
@@ -841,8 +911,14 @@ func (entity *ForeignActivitiesBenefits) Delete(context *db.DatabaseContext, acc
 
 	context.Find(&ForeignActivitiesBenefits{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesBenefits)
+		if entity.HasBenefits == nil {
+			entity.HasBenefits = &Branch{}
+		}
 		entity.HasBenefitsID = previous.HasBenefitsID
 		entity.HasBenefits.ID = previous.HasBenefitsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -971,8 +1047,14 @@ func (entity *ForeignActivitiesDirect) Save(context *db.DatabaseContext, account
 
 	context.Find(&ForeignActivitiesDirect{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesDirect)
+		if entity.HasInterests == nil {
+			entity.HasInterests = &Branch{}
+		}
 		entity.HasInterestsID = previous.HasInterestsID
 		entity.HasInterests.ID = previous.HasInterestsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1006,8 +1088,14 @@ func (entity *ForeignActivitiesDirect) Delete(context *db.DatabaseContext, accou
 
 	context.Find(&ForeignActivitiesDirect{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesDirect)
+		if entity.HasInterests == nil {
+			entity.HasInterests = &Branch{}
+		}
 		entity.HasInterestsID = previous.HasInterestsID
 		entity.HasInterests.ID = previous.HasInterestsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1136,8 +1224,14 @@ func (entity *ForeignActivitiesIndirect) Save(context *db.DatabaseContext, accou
 
 	context.Find(&ForeignActivitiesIndirect{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesIndirect)
+		if entity.HasInterests == nil {
+			entity.HasInterests = &Branch{}
+		}
 		entity.HasInterestsID = previous.HasInterestsID
 		entity.HasInterests.ID = previous.HasInterestsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1171,8 +1265,14 @@ func (entity *ForeignActivitiesIndirect) Delete(context *db.DatabaseContext, acc
 
 	context.Find(&ForeignActivitiesIndirect{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesIndirect)
+		if entity.HasInterests == nil {
+			entity.HasInterests = &Branch{}
+		}
 		entity.HasInterestsID = previous.HasInterestsID
 		entity.HasInterests.ID = previous.HasInterestsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1301,8 +1401,14 @@ func (entity *ForeignActivitiesRealEstate) Save(context *db.DatabaseContext, acc
 
 	context.Find(&ForeignActivitiesRealEstate{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesRealEstate)
+		if entity.HasInterests == nil {
+			entity.HasInterests = &Branch{}
+		}
 		entity.HasInterestsID = previous.HasInterestsID
 		entity.HasInterests.ID = previous.HasInterestsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1336,8 +1442,14 @@ func (entity *ForeignActivitiesRealEstate) Delete(context *db.DatabaseContext, a
 
 	context.Find(&ForeignActivitiesRealEstate{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesRealEstate)
+		if entity.HasInterests == nil {
+			entity.HasInterests = &Branch{}
+		}
 		entity.HasInterestsID = previous.HasInterestsID
 		entity.HasInterests.ID = previous.HasInterestsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1466,8 +1578,14 @@ func (entity *ForeignActivitiesSupport) Save(context *db.DatabaseContext, accoun
 
 	context.Find(&ForeignActivitiesSupport{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesSupport)
+		if entity.HasForeignSupport == nil {
+			entity.HasForeignSupport = &Branch{}
+		}
 		entity.HasForeignSupportID = previous.HasForeignSupportID
 		entity.HasForeignSupport.ID = previous.HasForeignSupportID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1501,8 +1619,14 @@ func (entity *ForeignActivitiesSupport) Delete(context *db.DatabaseContext, acco
 
 	context.Find(&ForeignActivitiesSupport{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignActivitiesSupport)
+		if entity.HasForeignSupport == nil {
+			entity.HasForeignSupport = &Branch{}
+		}
 		entity.HasForeignSupportID = previous.HasForeignSupportID
 		entity.HasForeignSupport.ID = previous.HasForeignSupportID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1631,8 +1755,14 @@ func (entity *ForeignBusinessAdvice) Save(context *db.DatabaseContext, account i
 
 	context.Find(&ForeignBusinessAdvice{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessAdvice)
+		if entity.HasForeignAdvice == nil {
+			entity.HasForeignAdvice = &Branch{}
+		}
 		entity.HasForeignAdviceID = previous.HasForeignAdviceID
 		entity.HasForeignAdvice.ID = previous.HasForeignAdviceID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1666,8 +1796,14 @@ func (entity *ForeignBusinessAdvice) Delete(context *db.DatabaseContext, account
 
 	context.Find(&ForeignBusinessAdvice{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessAdvice)
+		if entity.HasForeignAdvice == nil {
+			entity.HasForeignAdvice = &Branch{}
+		}
 		entity.HasForeignAdviceID = previous.HasForeignAdviceID
 		entity.HasForeignAdvice.ID = previous.HasForeignAdviceID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1796,8 +1932,14 @@ func (entity *ForeignBusinessConferences) Save(context *db.DatabaseContext, acco
 
 	context.Find(&ForeignBusinessConferences{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessConferences)
+		if entity.HasForeignConferences == nil {
+			entity.HasForeignConferences = &Branch{}
+		}
 		entity.HasForeignConferencesID = previous.HasForeignConferencesID
 		entity.HasForeignConferences.ID = previous.HasForeignConferencesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1831,8 +1973,14 @@ func (entity *ForeignBusinessConferences) Delete(context *db.DatabaseContext, ac
 
 	context.Find(&ForeignBusinessConferences{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessConferences)
+		if entity.HasForeignConferences == nil {
+			entity.HasForeignConferences = &Branch{}
+		}
 		entity.HasForeignConferencesID = previous.HasForeignConferencesID
 		entity.HasForeignConferences.ID = previous.HasForeignConferencesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1961,8 +2109,14 @@ func (entity *ForeignBusinessContact) Save(context *db.DatabaseContext, account 
 
 	context.Find(&ForeignBusinessContact{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessContact)
+		if entity.HasForeignContact == nil {
+			entity.HasForeignContact = &Branch{}
+		}
 		entity.HasForeignContactID = previous.HasForeignContactID
 		entity.HasForeignContact.ID = previous.HasForeignContactID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1996,8 +2150,14 @@ func (entity *ForeignBusinessContact) Delete(context *db.DatabaseContext, accoun
 
 	context.Find(&ForeignBusinessContact{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessContact)
+		if entity.HasForeignContact == nil {
+			entity.HasForeignContact = &Branch{}
+		}
 		entity.HasForeignContactID = previous.HasForeignContactID
 		entity.HasForeignContact.ID = previous.HasForeignContactID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2126,8 +2286,14 @@ func (entity *ForeignBusinessEmployment) Save(context *db.DatabaseContext, accou
 
 	context.Find(&ForeignBusinessEmployment{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessEmployment)
+		if entity.HasForeignEmployment == nil {
+			entity.HasForeignEmployment = &Branch{}
+		}
 		entity.HasForeignEmploymentID = previous.HasForeignEmploymentID
 		entity.HasForeignEmployment.ID = previous.HasForeignEmploymentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2161,8 +2327,14 @@ func (entity *ForeignBusinessEmployment) Delete(context *db.DatabaseContext, acc
 
 	context.Find(&ForeignBusinessEmployment{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessEmployment)
+		if entity.HasForeignEmployment == nil {
+			entity.HasForeignEmployment = &Branch{}
+		}
 		entity.HasForeignEmploymentID = previous.HasForeignEmploymentID
 		entity.HasForeignEmployment.ID = previous.HasForeignEmploymentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2291,8 +2463,14 @@ func (entity *ForeignBusinessFamily) Save(context *db.DatabaseContext, account i
 
 	context.Find(&ForeignBusinessFamily{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessFamily)
+		if entity.HasForeignFamily == nil {
+			entity.HasForeignFamily = &Branch{}
+		}
 		entity.HasForeignFamilyID = previous.HasForeignFamilyID
 		entity.HasForeignFamily.ID = previous.HasForeignFamilyID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2326,8 +2504,14 @@ func (entity *ForeignBusinessFamily) Delete(context *db.DatabaseContext, account
 
 	context.Find(&ForeignBusinessFamily{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessFamily)
+		if entity.HasForeignFamily == nil {
+			entity.HasForeignFamily = &Branch{}
+		}
 		entity.HasForeignFamilyID = previous.HasForeignFamilyID
 		entity.HasForeignFamily.ID = previous.HasForeignFamilyID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2456,8 +2640,14 @@ func (entity *ForeignBusinessPolitical) Save(context *db.DatabaseContext, accoun
 
 	context.Find(&ForeignBusinessPolitical{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessPolitical)
+		if entity.HasForeignPolitical == nil {
+			entity.HasForeignPolitical = &Branch{}
+		}
 		entity.HasForeignPoliticalID = previous.HasForeignPoliticalID
 		entity.HasForeignPolitical.ID = previous.HasForeignPoliticalID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2491,8 +2681,14 @@ func (entity *ForeignBusinessPolitical) Delete(context *db.DatabaseContext, acco
 
 	context.Find(&ForeignBusinessPolitical{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessPolitical)
+		if entity.HasForeignPolitical == nil {
+			entity.HasForeignPolitical = &Branch{}
+		}
 		entity.HasForeignPoliticalID = previous.HasForeignPoliticalID
 		entity.HasForeignPolitical.ID = previous.HasForeignPoliticalID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2621,8 +2817,14 @@ func (entity *ForeignBusinessSponsorship) Save(context *db.DatabaseContext, acco
 
 	context.Find(&ForeignBusinessSponsorship{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessSponsorship)
+		if entity.HasForeignSponsorship == nil {
+			entity.HasForeignSponsorship = &Branch{}
+		}
 		entity.HasForeignSponsorshipID = previous.HasForeignSponsorshipID
 		entity.HasForeignSponsorship.ID = previous.HasForeignSponsorshipID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2656,8 +2858,14 @@ func (entity *ForeignBusinessSponsorship) Delete(context *db.DatabaseContext, ac
 
 	context.Find(&ForeignBusinessSponsorship{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessSponsorship)
+		if entity.HasForeignSponsorship == nil {
+			entity.HasForeignSponsorship = &Branch{}
+		}
 		entity.HasForeignSponsorshipID = previous.HasForeignSponsorshipID
 		entity.HasForeignSponsorship.ID = previous.HasForeignSponsorshipID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2786,8 +2994,14 @@ func (entity *ForeignBusinessVentures) Save(context *db.DatabaseContext, account
 
 	context.Find(&ForeignBusinessVentures{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessVentures)
+		if entity.HasForeignVentures == nil {
+			entity.HasForeignVentures = &Branch{}
+		}
 		entity.HasForeignVenturesID = previous.HasForeignVenturesID
 		entity.HasForeignVentures.ID = previous.HasForeignVenturesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2821,8 +3035,14 @@ func (entity *ForeignBusinessVentures) Delete(context *db.DatabaseContext, accou
 
 	context.Find(&ForeignBusinessVentures{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessVentures)
+		if entity.HasForeignVentures == nil {
+			entity.HasForeignVentures = &Branch{}
+		}
 		entity.HasForeignVenturesID = previous.HasForeignVenturesID
 		entity.HasForeignVentures.ID = previous.HasForeignVenturesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2951,8 +3171,14 @@ func (entity *ForeignBusinessVoting) Save(context *db.DatabaseContext, account i
 
 	context.Find(&ForeignBusinessVoting{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessVoting)
+		if entity.HasForeignVoting == nil {
+			entity.HasForeignVoting = &Branch{}
+		}
 		entity.HasForeignVotingID = previous.HasForeignVotingID
 		entity.HasForeignVoting.ID = previous.HasForeignVotingID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2986,8 +3212,14 @@ func (entity *ForeignBusinessVoting) Delete(context *db.DatabaseContext, account
 
 	context.Find(&ForeignBusinessVoting{ID: account}, func(result interface{}) {
 		previous := result.(*ForeignBusinessVoting)
+		if entity.HasForeignVoting == nil {
+			entity.HasForeignVoting = &Branch{}
+		}
 		entity.HasForeignVotingID = previous.HasForeignVotingID
 		entity.HasForeignVoting.ID = previous.HasForeignVotingID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})

--- a/api/model/form/history.go
+++ b/api/model/form/history.go
@@ -56,6 +56,9 @@ func (entity *HistoryResidence) Save(context *db.DatabaseContext, account int) (
 
 	context.Find(&HistoryResidence{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryResidence)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -83,6 +86,9 @@ func (entity *HistoryResidence) Delete(context *db.DatabaseContext, account int)
 
 	context.Find(&HistoryResidence{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryResidence)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -184,6 +190,9 @@ func (entity *HistoryEmployment) Save(context *db.DatabaseContext, account int) 
 
 	context.Find(&HistoryEmployment{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryEmployment)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -211,6 +220,9 @@ func (entity *HistoryEmployment) Delete(context *db.DatabaseContext, account int
 
 	context.Find(&HistoryEmployment{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryEmployment)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -340,10 +352,19 @@ func (entity *HistoryEducation) Save(context *db.DatabaseContext, account int) (
 
 	context.Find(&HistoryEducation{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryEducation)
+		if entity.HasAttended == nil {
+			entity.HasAttended = &Branch{}
+		}
 		entity.HasAttendedID = previous.HasAttendedID
 		entity.HasAttended.ID = previous.HasAttendedID
+		if entity.HasDegree10 == nil {
+			entity.HasDegree10 = &Branch{}
+		}
 		entity.HasDegree10ID = previous.HasDegree10ID
 		entity.HasDegree10.ID = previous.HasDegree10ID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -383,10 +404,19 @@ func (entity *HistoryEducation) Delete(context *db.DatabaseContext, account int)
 
 	context.Find(&HistoryEducation{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryEducation)
+		if entity.HasAttended == nil {
+			entity.HasAttended = &Branch{}
+		}
 		entity.HasAttendedID = previous.HasAttendedID
 		entity.HasAttended.ID = previous.HasAttendedID
+		if entity.HasDegree10 == nil {
+			entity.HasDegree10 = &Branch{}
+		}
 		entity.HasDegree10ID = previous.HasDegree10ID
 		entity.HasDegree10.ID = previous.HasDegree10ID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -526,8 +556,14 @@ func (entity *HistoryFederal) Save(context *db.DatabaseContext, account int) (in
 
 	context.Find(&HistoryFederal{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryFederal)
+		if entity.HasFederalService == nil {
+			entity.HasFederalService = &Branch{}
+		}
 		entity.HasFederalServiceID = previous.HasFederalServiceID
 		entity.HasFederalService.ID = previous.HasFederalServiceID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -561,8 +597,14 @@ func (entity *HistoryFederal) Delete(context *db.DatabaseContext, account int) (
 
 	context.Find(&HistoryFederal{ID: account}, func(result interface{}) {
 		previous := result.(*HistoryFederal)
+		if entity.HasFederalService == nil {
+			entity.HasFederalService = &Branch{}
+		}
 		entity.HasFederalServiceID = previous.HasFederalServiceID
 		entity.HasFederalService.ID = previous.HasFederalServiceID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})

--- a/api/model/form/legal.go
+++ b/api/model/form/legal.go
@@ -73,8 +73,14 @@ func (entity *LegalCourt) Save(context *db.DatabaseContext, account int) (int, e
 
 	context.Find(&LegalCourt{ID: account}, func(result interface{}) {
 		previous := result.(*LegalCourt)
+		if entity.HasCourtActions == nil {
+			entity.HasCourtActions = &Branch{}
+		}
 		entity.HasCourtActionsID = previous.HasCourtActionsID
 		entity.HasCourtActions.ID = previous.HasCourtActionsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -108,8 +114,14 @@ func (entity *LegalCourt) Delete(context *db.DatabaseContext, account int) (int,
 
 	context.Find(&LegalCourt{ID: account}, func(result interface{}) {
 		previous := result.(*LegalCourt)
+		if entity.HasCourtActions == nil {
+			entity.HasCourtActions = &Branch{}
+		}
 		entity.HasCourtActionsID = previous.HasCourtActionsID
 		entity.HasCourtActions.ID = previous.HasCourtActionsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -239,8 +251,14 @@ func (entity *LegalPoliceOffenses) Save(context *db.DatabaseContext, account int
 
 	context.Find(&LegalPoliceOffenses{ID: account}, func(result interface{}) {
 		previous := result.(*LegalPoliceOffenses)
+		if entity.HasOffenses == nil {
+			entity.HasOffenses = &Branch{}
+		}
 		entity.HasOffensesID = previous.HasOffensesID
 		entity.HasOffenses.ID = previous.HasOffensesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -274,8 +292,14 @@ func (entity *LegalPoliceOffenses) Delete(context *db.DatabaseContext, account i
 
 	context.Find(&LegalPoliceOffenses{ID: account}, func(result interface{}) {
 		previous := result.(*LegalPoliceOffenses)
+		if entity.HasOffenses == nil {
+			entity.HasOffenses = &Branch{}
+		}
 		entity.HasOffensesID = previous.HasOffensesID
 		entity.HasOffenses.ID = previous.HasOffensesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -405,8 +429,14 @@ func (entity *LegalPoliceAdditionalOffenses) Save(context *db.DatabaseContext, a
 
 	context.Find(&LegalPoliceAdditionalOffenses{ID: account}, func(result interface{}) {
 		previous := result.(*LegalPoliceAdditionalOffenses)
+		if entity.HasOtherOffenses == nil {
+			entity.HasOtherOffenses = &Branch{}
+		}
 		entity.HasOtherOffensesID = previous.HasOtherOffensesID
 		entity.HasOtherOffenses.ID = previous.HasOtherOffensesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -440,8 +470,14 @@ func (entity *LegalPoliceAdditionalOffenses) Delete(context *db.DatabaseContext,
 
 	context.Find(&LegalPoliceAdditionalOffenses{ID: account}, func(result interface{}) {
 		previous := result.(*LegalPoliceAdditionalOffenses)
+		if entity.HasOtherOffenses == nil {
+			entity.HasOtherOffenses = &Branch{}
+		}
 		entity.HasOtherOffensesID = previous.HasOtherOffensesID
 		entity.HasOtherOffenses.ID = previous.HasOtherOffensesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -555,6 +591,9 @@ func (entity *LegalPoliceDomesticViolence) Save(context *db.DatabaseContext, acc
 
 	context.Find(&LegalPoliceDomesticViolence{ID: account}, func(result interface{}) {
 		previous := result.(*LegalPoliceDomesticViolence)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -582,6 +621,9 @@ func (entity *LegalPoliceDomesticViolence) Delete(context *db.DatabaseContext, a
 
 	context.Find(&LegalPoliceDomesticViolence{ID: account}, func(result interface{}) {
 		previous := result.(*LegalPoliceDomesticViolence)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -700,8 +742,14 @@ func (entity *LegalInvestigationsDebarred) Save(context *db.DatabaseContext, acc
 
 	context.Find(&LegalInvestigationsDebarred{ID: account}, func(result interface{}) {
 		previous := result.(*LegalInvestigationsDebarred)
+		if entity.HasDebarment == nil {
+			entity.HasDebarment = &Branch{}
+		}
 		entity.HasDebarmentID = previous.HasDebarmentID
 		entity.HasDebarment.ID = previous.HasDebarmentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -735,8 +783,14 @@ func (entity *LegalInvestigationsDebarred) Delete(context *db.DatabaseContext, a
 
 	context.Find(&LegalInvestigationsDebarred{ID: account}, func(result interface{}) {
 		previous := result.(*LegalInvestigationsDebarred)
+		if entity.HasDebarment == nil {
+			entity.HasDebarment = &Branch{}
+		}
 		entity.HasDebarmentID = previous.HasDebarmentID
 		entity.HasDebarment.ID = previous.HasDebarmentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -866,8 +920,14 @@ func (entity *LegalInvestigationsHistory) Save(context *db.DatabaseContext, acco
 
 	context.Find(&LegalInvestigationsHistory{ID: account}, func(result interface{}) {
 		previous := result.(*LegalInvestigationsHistory)
+		if entity.HasHistory == nil {
+			entity.HasHistory = &Branch{}
+		}
 		entity.HasHistoryID = previous.HasHistoryID
 		entity.HasHistory.ID = previous.HasHistoryID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -901,8 +961,14 @@ func (entity *LegalInvestigationsHistory) Delete(context *db.DatabaseContext, ac
 
 	context.Find(&LegalInvestigationsHistory{ID: account}, func(result interface{}) {
 		previous := result.(*LegalInvestigationsHistory)
+		if entity.HasHistory == nil {
+			entity.HasHistory = &Branch{}
+		}
 		entity.HasHistoryID = previous.HasHistoryID
 		entity.HasHistory.ID = previous.HasHistoryID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1032,8 +1098,14 @@ func (entity *LegalInvestigationsRevoked) Save(context *db.DatabaseContext, acco
 
 	context.Find(&LegalInvestigationsRevoked{ID: account}, func(result interface{}) {
 		previous := result.(*LegalInvestigationsRevoked)
+		if entity.HasRevocations == nil {
+			entity.HasRevocations = &Branch{}
+		}
 		entity.HasRevocationsID = previous.HasRevocationsID
 		entity.HasRevocations.ID = previous.HasRevocationsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1067,8 +1139,14 @@ func (entity *LegalInvestigationsRevoked) Delete(context *db.DatabaseContext, ac
 
 	context.Find(&LegalInvestigationsRevoked{ID: account}, func(result interface{}) {
 		previous := result.(*LegalInvestigationsRevoked)
+		if entity.HasRevocations == nil {
+			entity.HasRevocations = &Branch{}
+		}
 		entity.HasRevocationsID = previous.HasRevocationsID
 		entity.HasRevocations.ID = previous.HasRevocationsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1198,8 +1276,14 @@ func (entity *LegalTechnologyManipulating) Save(context *db.DatabaseContext, acc
 
 	context.Find(&LegalTechnologyManipulating{ID: account}, func(result interface{}) {
 		previous := result.(*LegalTechnologyManipulating)
+		if entity.HasManipulating == nil {
+			entity.HasManipulating = &Branch{}
+		}
 		entity.HasManipulatingID = previous.HasManipulatingID
 		entity.HasManipulating.ID = previous.HasManipulatingID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1233,8 +1317,14 @@ func (entity *LegalTechnologyManipulating) Delete(context *db.DatabaseContext, a
 
 	context.Find(&LegalTechnologyManipulating{ID: account}, func(result interface{}) {
 		previous := result.(*LegalTechnologyManipulating)
+		if entity.HasManipulating == nil {
+			entity.HasManipulating = &Branch{}
+		}
 		entity.HasManipulatingID = previous.HasManipulatingID
 		entity.HasManipulating.ID = previous.HasManipulatingID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1364,8 +1454,14 @@ func (entity *LegalTechnologyUnauthorized) Save(context *db.DatabaseContext, acc
 
 	context.Find(&LegalTechnologyUnauthorized{ID: account}, func(result interface{}) {
 		previous := result.(*LegalTechnologyUnauthorized)
+		if entity.HasUnauthorized == nil {
+			entity.HasUnauthorized = &Branch{}
+		}
 		entity.HasUnauthorizedID = previous.HasUnauthorizedID
 		entity.HasUnauthorized.ID = previous.HasUnauthorizedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1399,8 +1495,14 @@ func (entity *LegalTechnologyUnauthorized) Delete(context *db.DatabaseContext, a
 
 	context.Find(&LegalTechnologyUnauthorized{ID: account}, func(result interface{}) {
 		previous := result.(*LegalTechnologyUnauthorized)
+		if entity.HasUnauthorized == nil {
+			entity.HasUnauthorized = &Branch{}
+		}
 		entity.HasUnauthorizedID = previous.HasUnauthorizedID
 		entity.HasUnauthorized.ID = previous.HasUnauthorizedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1530,8 +1632,14 @@ func (entity *LegalTechnologyUnlawful) Save(context *db.DatabaseContext, account
 
 	context.Find(&LegalTechnologyUnlawful{ID: account}, func(result interface{}) {
 		previous := result.(*LegalTechnologyUnlawful)
+		if entity.HasUnlawful == nil {
+			entity.HasUnlawful = &Branch{}
+		}
 		entity.HasUnlawfulID = previous.HasUnlawfulID
 		entity.HasUnlawful.ID = previous.HasUnlawfulID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1565,8 +1673,14 @@ func (entity *LegalTechnologyUnlawful) Delete(context *db.DatabaseContext, accou
 
 	context.Find(&LegalTechnologyUnlawful{ID: account}, func(result interface{}) {
 		previous := result.(*LegalTechnologyUnlawful)
+		if entity.HasUnlawful == nil {
+			entity.HasUnlawful = &Branch{}
+		}
 		entity.HasUnlawfulID = previous.HasUnlawfulID
 		entity.HasUnlawful.ID = previous.HasUnlawfulID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1696,8 +1810,14 @@ func (entity *LegalAssociationsActivitiesToOverthrow) Save(context *db.DatabaseC
 
 	context.Find(&LegalAssociationsActivitiesToOverthrow{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsActivitiesToOverthrow)
+		if entity.HasActivities == nil {
+			entity.HasActivities = &Branch{}
+		}
 		entity.HasActivitiesID = previous.HasActivitiesID
 		entity.HasActivities.ID = previous.HasActivitiesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1731,8 +1851,14 @@ func (entity *LegalAssociationsActivitiesToOverthrow) Delete(context *db.Databas
 
 	context.Find(&LegalAssociationsActivitiesToOverthrow{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsActivitiesToOverthrow)
+		if entity.HasActivities == nil {
+			entity.HasActivities = &Branch{}
+		}
 		entity.HasActivitiesID = previous.HasActivitiesID
 		entity.HasActivities.ID = previous.HasActivitiesID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1862,8 +1988,14 @@ func (entity *LegalAssociationsAdvocating) Save(context *db.DatabaseContext, acc
 
 	context.Find(&LegalAssociationsAdvocating{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsAdvocating)
+		if entity.HasAdvocated == nil {
+			entity.HasAdvocated = &Branch{}
+		}
 		entity.HasAdvocatedID = previous.HasAdvocatedID
 		entity.HasAdvocated.ID = previous.HasAdvocatedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1897,8 +2029,14 @@ func (entity *LegalAssociationsAdvocating) Delete(context *db.DatabaseContext, a
 
 	context.Find(&LegalAssociationsAdvocating{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsAdvocating)
+		if entity.HasAdvocated == nil {
+			entity.HasAdvocated = &Branch{}
+		}
 		entity.HasAdvocatedID = previous.HasAdvocatedID
 		entity.HasAdvocated.ID = previous.HasAdvocatedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2028,8 +2166,14 @@ func (entity *LegalAssociationsEngagedInTerrorism) Save(context *db.DatabaseCont
 
 	context.Find(&LegalAssociationsEngagedInTerrorism{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsEngagedInTerrorism)
+		if entity.HasEngaged == nil {
+			entity.HasEngaged = &Branch{}
+		}
 		entity.HasEngagedID = previous.HasEngagedID
 		entity.HasEngaged.ID = previous.HasEngagedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2063,8 +2207,14 @@ func (entity *LegalAssociationsEngagedInTerrorism) Delete(context *db.DatabaseCo
 
 	context.Find(&LegalAssociationsEngagedInTerrorism{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsEngagedInTerrorism)
+		if entity.HasEngaged == nil {
+			entity.HasEngaged = &Branch{}
+		}
 		entity.HasEngagedID = previous.HasEngagedID
 		entity.HasEngaged.ID = previous.HasEngagedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2194,8 +2344,14 @@ func (entity *LegalAssociationsMembershipOverthrow) Save(context *db.DatabaseCon
 
 	context.Find(&LegalAssociationsMembershipOverthrow{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsMembershipOverthrow)
+		if entity.HasOverthrow == nil {
+			entity.HasOverthrow = &Branch{}
+		}
 		entity.HasOverthrowID = previous.HasOverthrowID
 		entity.HasOverthrow.ID = previous.HasOverthrowID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2229,8 +2385,14 @@ func (entity *LegalAssociationsMembershipOverthrow) Delete(context *db.DatabaseC
 
 	context.Find(&LegalAssociationsMembershipOverthrow{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsMembershipOverthrow)
+		if entity.HasOverthrow == nil {
+			entity.HasOverthrow = &Branch{}
+		}
 		entity.HasOverthrowID = previous.HasOverthrowID
 		entity.HasOverthrow.ID = previous.HasOverthrowID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2360,8 +2522,14 @@ func (entity *LegalAssociationsMembershipViolence) Save(context *db.DatabaseCont
 
 	context.Find(&LegalAssociationsMembershipViolence{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsMembershipViolence)
+		if entity.HasViolence == nil {
+			entity.HasViolence = &Branch{}
+		}
 		entity.HasViolenceID = previous.HasViolenceID
 		entity.HasViolence.ID = previous.HasViolenceID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2395,8 +2563,14 @@ func (entity *LegalAssociationsMembershipViolence) Delete(context *db.DatabaseCo
 
 	context.Find(&LegalAssociationsMembershipViolence{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsMembershipViolence)
+		if entity.HasViolence == nil {
+			entity.HasViolence = &Branch{}
+		}
 		entity.HasViolenceID = previous.HasViolenceID
 		entity.HasViolence.ID = previous.HasViolenceID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2526,8 +2700,14 @@ func (entity *LegalAssociationsTerrorismAssociation) Save(context *db.DatabaseCo
 
 	context.Find(&LegalAssociationsTerrorismAssociation{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsTerrorismAssociation)
+		if entity.HasTerrorism == nil {
+			entity.HasTerrorism = &Branch{}
+		}
 		entity.HasTerrorismID = previous.HasTerrorismID
 		entity.HasTerrorism.ID = previous.HasTerrorismID
+		if entity.Explanation == nil {
+			entity.Explanation = &Textarea{}
+		}
 		entity.ExplanationID = previous.ExplanationID
 		entity.Explanation.ID = previous.ExplanationID
 	})
@@ -2561,8 +2741,14 @@ func (entity *LegalAssociationsTerrorismAssociation) Delete(context *db.Database
 
 	context.Find(&LegalAssociationsTerrorismAssociation{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsTerrorismAssociation)
+		if entity.HasTerrorism == nil {
+			entity.HasTerrorism = &Branch{}
+		}
 		entity.HasTerrorismID = previous.HasTerrorismID
 		entity.HasTerrorism.ID = previous.HasTerrorismID
+		if entity.Explanation == nil {
+			entity.Explanation = &Textarea{}
+		}
 		entity.ExplanationID = previous.ExplanationID
 		entity.Explanation.ID = previous.ExplanationID
 	})
@@ -2692,8 +2878,14 @@ func (entity *LegalAssociationsTerroristOrganization) Save(context *db.DatabaseC
 
 	context.Find(&LegalAssociationsTerroristOrganization{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsTerroristOrganization)
+		if entity.HasTerrorist == nil {
+			entity.HasTerrorist = &Branch{}
+		}
 		entity.HasTerroristID = previous.HasTerroristID
 		entity.HasTerrorist.ID = previous.HasTerroristID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -2727,8 +2919,14 @@ func (entity *LegalAssociationsTerroristOrganization) Delete(context *db.Databas
 
 	context.Find(&LegalAssociationsTerroristOrganization{ID: account}, func(result interface{}) {
 		previous := result.(*LegalAssociationsTerroristOrganization)
+		if entity.HasTerrorist == nil {
+			entity.HasTerrorist = &Branch{}
+		}
 		entity.HasTerroristID = previous.HasTerroristID
 		entity.HasTerrorist.ID = previous.HasTerroristID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})

--- a/api/model/form/military.go
+++ b/api/model/form/military.go
@@ -115,12 +115,24 @@ func (entity *MilitarySelective) Save(context *db.DatabaseContext, account int) 
 
 	context.Find(&MilitarySelective{ID: account}, func(result interface{}) {
 		previous := result.(*MilitarySelective)
+		if entity.WasBornAfter == nil {
+			entity.WasBornAfter = &Branch{}
+		}
 		entity.WasBornAfterID = previous.WasBornAfterID
 		entity.WasBornAfter.ID = previous.WasBornAfterID
+		if entity.HasRegistered == nil {
+			entity.HasRegistered = &Branch{}
+		}
 		entity.HasRegisteredID = previous.HasRegisteredID
 		entity.HasRegistered.ID = previous.HasRegisteredID
+		if entity.RegistrationNumber == nil {
+			entity.RegistrationNumber = &Text{}
+		}
 		entity.RegistrationNumberID = previous.RegistrationNumberID
 		entity.RegistrationNumber.ID = previous.RegistrationNumberID
+		if entity.Explanation == nil {
+			entity.Explanation = &Textarea{}
+		}
 		entity.ExplanationID = previous.ExplanationID
 		entity.Explanation.ID = previous.ExplanationID
 	})
@@ -166,12 +178,24 @@ func (entity *MilitarySelective) Delete(context *db.DatabaseContext, account int
 
 	context.Find(&MilitarySelective{ID: account}, func(result interface{}) {
 		previous := result.(*MilitarySelective)
+		if entity.WasBornAfter == nil {
+			entity.WasBornAfter = &Branch{}
+		}
 		entity.WasBornAfterID = previous.WasBornAfterID
 		entity.WasBornAfter.ID = previous.WasBornAfterID
+		if entity.HasRegistered == nil {
+			entity.HasRegistered = &Branch{}
+		}
 		entity.HasRegisteredID = previous.HasRegisteredID
 		entity.HasRegistered.ID = previous.HasRegisteredID
+		if entity.RegistrationNumber == nil {
+			entity.RegistrationNumber = &Text{}
+		}
 		entity.RegistrationNumberID = previous.RegistrationNumberID
 		entity.RegistrationNumber.ID = previous.RegistrationNumberID
+		if entity.Explanation == nil {
+			entity.Explanation = &Textarea{}
+		}
 		entity.ExplanationID = previous.ExplanationID
 		entity.Explanation.ID = previous.ExplanationID
 	})
@@ -330,8 +354,14 @@ func (entity *MilitaryHistory) Save(context *db.DatabaseContext, account int) (i
 
 	context.Find(&MilitaryHistory{ID: account}, func(result interface{}) {
 		previous := result.(*MilitaryHistory)
+		if entity.HasServed == nil {
+			entity.HasServed = &Branch{}
+		}
 		entity.HasServedID = previous.HasServedID
 		entity.HasServed.ID = previous.HasServedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -365,8 +395,14 @@ func (entity *MilitaryHistory) Delete(context *db.DatabaseContext, account int) 
 
 	context.Find(&MilitaryHistory{ID: account}, func(result interface{}) {
 		previous := result.(*MilitaryHistory)
+		if entity.HasServed == nil {
+			entity.HasServed = &Branch{}
+		}
 		entity.HasServedID = previous.HasServedID
 		entity.HasServed.ID = previous.HasServedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -503,8 +539,14 @@ func (entity *MilitaryDisciplinary) Save(context *db.DatabaseContext, account in
 
 	context.Find(&MilitaryDisciplinary{ID: account}, func(result interface{}) {
 		previous := result.(*MilitaryDisciplinary)
+		if entity.HasDisciplinary == nil {
+			entity.HasDisciplinary = &Branch{}
+		}
 		entity.HasDisciplinaryID = previous.HasDisciplinaryID
 		entity.HasDisciplinary.ID = previous.HasDisciplinaryID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -538,8 +580,14 @@ func (entity *MilitaryDisciplinary) Delete(context *db.DatabaseContext, account 
 
 	context.Find(&MilitaryDisciplinary{ID: account}, func(result interface{}) {
 		previous := result.(*MilitaryDisciplinary)
+		if entity.HasDisciplinary == nil {
+			entity.HasDisciplinary = &Branch{}
+		}
 		entity.HasDisciplinaryID = previous.HasDisciplinaryID
 		entity.HasDisciplinary.ID = previous.HasDisciplinaryID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -658,6 +706,9 @@ func (entity *MilitaryForeign) Save(context *db.DatabaseContext, account int) (i
 
 	context.Find(&MilitaryForeign{ID: account}, func(result interface{}) {
 		previous := result.(*MilitaryForeign)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -685,6 +736,9 @@ func (entity *MilitaryForeign) Delete(context *db.DatabaseContext, account int) 
 
 	context.Find(&MilitaryForeign{ID: account}, func(result interface{}) {
 		previous := result.(*MilitaryForeign)
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})

--- a/api/model/form/psychological.go
+++ b/api/model/form/psychological.go
@@ -81,8 +81,14 @@ func (entity *PsychologicalCompetence) Save(context *db.DatabaseContext, account
 
 	context.Find(&PsychologicalCompetence{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalCompetence)
+		if entity.IsIncompetent == nil {
+			entity.IsIncompetent = &Branch{}
+		}
 		entity.IsIncompetentID = previous.IsIncompetentID
 		entity.IsIncompetent.ID = previous.IsIncompetentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -116,8 +122,14 @@ func (entity *PsychologicalCompetence) Delete(context *db.DatabaseContext, accou
 
 	context.Find(&PsychologicalCompetence{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalCompetence)
+		if entity.IsIncompetent == nil {
+			entity.IsIncompetent = &Branch{}
+		}
 		entity.IsIncompetentID = previous.IsIncompetentID
 		entity.IsIncompetent.ID = previous.IsIncompetentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -254,8 +266,14 @@ func (entity *PsychologicalConsultations) Save(context *db.DatabaseContext, acco
 
 	context.Find(&PsychologicalConsultations{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalConsultations)
+		if entity.Consulted == nil {
+			entity.Consulted = &Branch{}
+		}
 		entity.ConsultedID = previous.ConsultedID
 		entity.Consulted.ID = previous.ConsultedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -289,8 +307,14 @@ func (entity *PsychologicalConsultations) Delete(context *db.DatabaseContext, ac
 
 	context.Find(&PsychologicalConsultations{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalConsultations)
+		if entity.Consulted == nil {
+			entity.Consulted = &Branch{}
+		}
 		entity.ConsultedID = previous.ConsultedID
 		entity.Consulted.ID = previous.ConsultedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -477,14 +501,29 @@ func (entity *PsychologicalDiagnoses) Save(context *db.DatabaseContext, account 
 
 	context.Find(&PsychologicalDiagnoses{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalDiagnoses)
+		if entity.Diagnosed == nil {
+			entity.Diagnosed = &Branch{}
+		}
 		entity.DiagnosedID = previous.DiagnosedID
 		entity.Diagnosed.ID = previous.DiagnosedID
+		if entity.DidNotConsult == nil {
+			entity.DidNotConsult = &Branch{}
+		}
 		entity.DidNotConsultID = previous.DidNotConsultID
 		entity.DidNotConsult.ID = previous.DidNotConsultID
+		if entity.DiagnosisList == nil {
+			entity.DiagnosisList = &Collection{}
+		}
 		entity.DiagnosisListID = previous.DiagnosisListID
 		entity.DiagnosisList.ID = previous.DiagnosisListID
+		if entity.InTreatment == nil {
+			entity.InTreatment = &Branch{}
+		}
 		entity.InTreatmentID = previous.InTreatmentID
 		entity.InTreatment.ID = previous.InTreatmentID
+		if entity.TreatmentList == nil {
+			entity.TreatmentList = &Collection{}
+		}
 		entity.TreatmentListID = previous.TreatmentListID
 		entity.TreatmentList.ID = previous.TreatmentListID
 	})
@@ -536,14 +575,29 @@ func (entity *PsychologicalDiagnoses) Delete(context *db.DatabaseContext, accoun
 
 	context.Find(&PsychologicalDiagnoses{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalDiagnoses)
+		if entity.Diagnosed == nil {
+			entity.Diagnosed = &Branch{}
+		}
 		entity.DiagnosedID = previous.DiagnosedID
 		entity.Diagnosed.ID = previous.DiagnosedID
+		if entity.DidNotConsult == nil {
+			entity.DidNotConsult = &Branch{}
+		}
 		entity.DidNotConsultID = previous.DidNotConsultID
 		entity.DidNotConsult.ID = previous.DidNotConsultID
+		if entity.DiagnosisList == nil {
+			entity.DiagnosisList = &Collection{}
+		}
 		entity.DiagnosisListID = previous.DiagnosisListID
 		entity.DiagnosisList.ID = previous.DiagnosisListID
+		if entity.InTreatment == nil {
+			entity.InTreatment = &Branch{}
+		}
 		entity.InTreatmentID = previous.InTreatmentID
 		entity.InTreatment.ID = previous.InTreatmentID
+		if entity.TreatmentList == nil {
+			entity.TreatmentList = &Collection{}
+		}
 		entity.TreatmentListID = previous.TreatmentListID
 		entity.TreatmentList.ID = previous.TreatmentListID
 	})
@@ -713,8 +767,14 @@ func (entity *PsychologicalHospitalizations) Save(context *db.DatabaseContext, a
 
 	context.Find(&PsychologicalHospitalizations{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalHospitalizations)
+		if entity.Hospitalized == nil {
+			entity.Hospitalized = &Branch{}
+		}
 		entity.HospitalizedID = previous.HospitalizedID
 		entity.Hospitalized.ID = previous.HospitalizedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -748,8 +808,14 @@ func (entity *PsychologicalHospitalizations) Delete(context *db.DatabaseContext,
 
 	context.Find(&PsychologicalHospitalizations{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalHospitalizations)
+		if entity.Hospitalized == nil {
+			entity.Hospitalized = &Branch{}
+		}
 		entity.HospitalizedID = previous.HospitalizedID
 		entity.Hospitalized.ID = previous.HospitalizedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -956,16 +1022,34 @@ func (entity *PsychologicalExisting) Save(context *db.DatabaseContext, account i
 
 	context.Find(&PsychologicalExisting{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalExisting)
+		if entity.HasCondition == nil {
+			entity.HasCondition = &Branch{}
+		}
 		entity.HasConditionID = previous.HasConditionID
 		entity.HasCondition.ID = previous.HasConditionID
+		if entity.ReceivedTreatment == nil {
+			entity.ReceivedTreatment = &Radio{}
+		}
 		entity.ReceivedTreatmentID = previous.ReceivedTreatmentID
 		entity.ReceivedTreatment.ID = previous.ReceivedTreatmentID
+		if entity.Explanation == nil {
+			entity.Explanation = &Textarea{}
+		}
 		entity.ExplanationID = previous.ExplanationID
 		entity.Explanation.ID = previous.ExplanationID
+		if entity.TreatmentList == nil {
+			entity.TreatmentList = &Collection{}
+		}
 		entity.TreatmentListID = previous.TreatmentListID
 		entity.TreatmentList.ID = previous.TreatmentListID
+		if entity.DidNotFollow == nil {
+			entity.DidNotFollow = &Branch{}
+		}
 		entity.DidNotFollowID = previous.DidNotFollowID
 		entity.DidNotFollow.ID = previous.DidNotFollowID
+		if entity.DidNotFollowExplanation == nil {
+			entity.DidNotFollowExplanation = &Textarea{}
+		}
 		entity.DidNotFollowExplanationID = previous.DidNotFollowExplanationID
 		entity.DidNotFollowExplanation.ID = previous.DidNotFollowExplanationID
 	})
@@ -1023,16 +1107,34 @@ func (entity *PsychologicalExisting) Delete(context *db.DatabaseContext, account
 
 	context.Find(&PsychologicalExisting{ID: account}, func(result interface{}) {
 		previous := result.(*PsychologicalExisting)
+		if entity.HasCondition == nil {
+			entity.HasCondition = &Branch{}
+		}
 		entity.HasConditionID = previous.HasConditionID
 		entity.HasCondition.ID = previous.HasConditionID
+		if entity.ReceivedTreatment == nil {
+			entity.ReceivedTreatment = &Radio{}
+		}
 		entity.ReceivedTreatmentID = previous.ReceivedTreatmentID
 		entity.ReceivedTreatment.ID = previous.ReceivedTreatmentID
+		if entity.Explanation == nil {
+			entity.Explanation = &Textarea{}
+		}
 		entity.ExplanationID = previous.ExplanationID
 		entity.Explanation.ID = previous.ExplanationID
+		if entity.TreatmentList == nil {
+			entity.TreatmentList = &Collection{}
+		}
 		entity.TreatmentListID = previous.TreatmentListID
 		entity.TreatmentList.ID = previous.TreatmentListID
+		if entity.DidNotFollow == nil {
+			entity.DidNotFollow = &Branch{}
+		}
 		entity.DidNotFollowID = previous.DidNotFollowID
 		entity.DidNotFollow.ID = previous.DidNotFollowID
+		if entity.DidNotFollowExplanation == nil {
+			entity.DidNotFollowExplanation = &Textarea{}
+		}
 		entity.DidNotFollowExplanationID = previous.DidNotFollowExplanationID
 		entity.DidNotFollowExplanation.ID = previous.DidNotFollowExplanationID
 	})

--- a/api/model/form/submission.go
+++ b/api/model/form/submission.go
@@ -649,7 +649,7 @@ func (entity *SubmissionMedical) Save(context *db.DatabaseContext, account int) 
 		return entity.ID, err
 	}
 
-	context.Find(&SubmissionCredit{ID: account}, func(result interface{}) {
+	context.Find(&SubmissionMedical{ID: account}, func(result interface{}) {
 		previous := result.(*SubmissionMedical)
 		if entity.Signature == nil {
 			entity.Signature = &Signature{}

--- a/api/model/form/substance.go
+++ b/api/model/form/substance.go
@@ -81,8 +81,14 @@ func (entity *SubstanceDrugUsage) Save(context *db.DatabaseContext, account int)
 
 	context.Find(&SubstanceDrugUsage{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugUsage)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -116,8 +122,14 @@ func (entity *SubstanceDrugUsage) Delete(context *db.DatabaseContext, account in
 
 	context.Find(&SubstanceDrugUsage{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugUsage)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -254,8 +266,14 @@ func (entity *SubstanceDrugPurchase) Save(context *db.DatabaseContext, account i
 
 	context.Find(&SubstanceDrugPurchase{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugPurchase)
+		if entity.Involved == nil {
+			entity.Involved = &Branch{}
+		}
 		entity.InvolvedID = previous.InvolvedID
 		entity.Involved.ID = previous.InvolvedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -289,8 +307,14 @@ func (entity *SubstanceDrugPurchase) Delete(context *db.DatabaseContext, account
 
 	context.Find(&SubstanceDrugPurchase{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugPurchase)
+		if entity.Involved == nil {
+			entity.Involved = &Branch{}
+		}
 		entity.InvolvedID = previous.InvolvedID
 		entity.Involved.ID = previous.InvolvedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -427,8 +451,14 @@ func (entity *SubstanceDrugClearance) Save(context *db.DatabaseContext, account 
 
 	context.Find(&SubstanceDrugClearance{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugClearance)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -462,8 +492,14 @@ func (entity *SubstanceDrugClearance) Delete(context *db.DatabaseContext, accoun
 
 	context.Find(&SubstanceDrugClearance{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugClearance)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -600,8 +636,14 @@ func (entity *SubstanceDrugPublicSafety) Save(context *db.DatabaseContext, accou
 
 	context.Find(&SubstanceDrugPublicSafety{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugPublicSafety)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -635,8 +677,14 @@ func (entity *SubstanceDrugPublicSafety) Delete(context *db.DatabaseContext, acc
 
 	context.Find(&SubstanceDrugPublicSafety{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugPublicSafety)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -773,8 +821,14 @@ func (entity *SubstanceDrugMisuse) Save(context *db.DatabaseContext, account int
 
 	context.Find(&SubstanceDrugMisuse{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugMisuse)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -808,8 +862,14 @@ func (entity *SubstanceDrugMisuse) Delete(context *db.DatabaseContext, account i
 
 	context.Find(&SubstanceDrugMisuse{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugMisuse)
+		if entity.UsedDrugs == nil {
+			entity.UsedDrugs = &Branch{}
+		}
 		entity.UsedDrugsID = previous.UsedDrugsID
 		entity.UsedDrugs.ID = previous.UsedDrugsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -946,8 +1006,14 @@ func (entity *SubstanceDrugOrdered) Save(context *db.DatabaseContext, account in
 
 	context.Find(&SubstanceDrugOrdered{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugOrdered)
+		if entity.Involved == nil {
+			entity.Involved = &Branch{}
+		}
 		entity.InvolvedID = previous.InvolvedID
 		entity.Involved.ID = previous.InvolvedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -981,8 +1047,14 @@ func (entity *SubstanceDrugOrdered) Delete(context *db.DatabaseContext, account 
 
 	context.Find(&SubstanceDrugOrdered{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugOrdered)
+		if entity.Involved == nil {
+			entity.Involved = &Branch{}
+		}
 		entity.InvolvedID = previous.InvolvedID
 		entity.Involved.ID = previous.InvolvedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1119,8 +1191,14 @@ func (entity *SubstanceDrugVoluntary) Save(context *db.DatabaseContext, account 
 
 	context.Find(&SubstanceDrugVoluntary{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugVoluntary)
+		if entity.Involved == nil {
+			entity.Involved = &Branch{}
+		}
 		entity.InvolvedID = previous.InvolvedID
 		entity.Involved.ID = previous.InvolvedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1154,8 +1232,14 @@ func (entity *SubstanceDrugVoluntary) Delete(context *db.DatabaseContext, accoun
 
 	context.Find(&SubstanceDrugVoluntary{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceDrugVoluntary)
+		if entity.Involved == nil {
+			entity.Involved = &Branch{}
+		}
 		entity.InvolvedID = previous.InvolvedID
 		entity.Involved.ID = previous.InvolvedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1292,8 +1376,14 @@ func (entity *SubstanceAlcoholNegative) Save(context *db.DatabaseContext, accoun
 
 	context.Find(&SubstanceAlcoholNegative{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholNegative)
+		if entity.HasImpacts == nil {
+			entity.HasImpacts = &Branch{}
+		}
 		entity.HasImpactsID = previous.HasImpactsID
 		entity.HasImpacts.ID = previous.HasImpactsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1327,8 +1417,14 @@ func (entity *SubstanceAlcoholNegative) Delete(context *db.DatabaseContext, acco
 
 	context.Find(&SubstanceAlcoholNegative{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholNegative)
+		if entity.HasImpacts == nil {
+			entity.HasImpacts = &Branch{}
+		}
 		entity.HasImpactsID = previous.HasImpactsID
 		entity.HasImpacts.ID = previous.HasImpactsID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1465,8 +1561,14 @@ func (entity *SubstanceAlcoholOrdered) Save(context *db.DatabaseContext, account
 
 	context.Find(&SubstanceAlcoholOrdered{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholOrdered)
+		if entity.HasBeenOrdered == nil {
+			entity.HasBeenOrdered = &Branch{}
+		}
 		entity.HasBeenOrderedID = previous.HasBeenOrderedID
 		entity.HasBeenOrdered.ID = previous.HasBeenOrderedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1500,8 +1602,14 @@ func (entity *SubstanceAlcoholOrdered) Delete(context *db.DatabaseContext, accou
 
 	context.Find(&SubstanceAlcoholOrdered{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholOrdered)
+		if entity.HasBeenOrdered == nil {
+			entity.HasBeenOrdered = &Branch{}
+		}
 		entity.HasBeenOrderedID = previous.HasBeenOrderedID
 		entity.HasBeenOrdered.ID = previous.HasBeenOrderedID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1638,8 +1746,14 @@ func (entity *SubstanceAlcoholVoluntary) Save(context *db.DatabaseContext, accou
 
 	context.Find(&SubstanceAlcoholVoluntary{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholVoluntary)
+		if entity.SoughtTreatment == nil {
+			entity.SoughtTreatment = &Branch{}
+		}
 		entity.SoughtTreatmentID = previous.SoughtTreatmentID
 		entity.SoughtTreatment.ID = previous.SoughtTreatmentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1673,8 +1787,14 @@ func (entity *SubstanceAlcoholVoluntary) Delete(context *db.DatabaseContext, acc
 
 	context.Find(&SubstanceAlcoholVoluntary{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholVoluntary)
+		if entity.SoughtTreatment == nil {
+			entity.SoughtTreatment = &Branch{}
+		}
 		entity.SoughtTreatmentID = previous.SoughtTreatmentID
 		entity.SoughtTreatment.ID = previous.SoughtTreatmentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1811,8 +1931,14 @@ func (entity *SubstanceAlcoholAdditional) Save(context *db.DatabaseContext, acco
 
 	context.Find(&SubstanceAlcoholAdditional{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholAdditional)
+		if entity.ReceivedTreatment == nil {
+			entity.ReceivedTreatment = &Branch{}
+		}
 		entity.ReceivedTreatmentID = previous.ReceivedTreatmentID
 		entity.ReceivedTreatment.ID = previous.ReceivedTreatmentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})
@@ -1846,8 +1972,14 @@ func (entity *SubstanceAlcoholAdditional) Delete(context *db.DatabaseContext, ac
 
 	context.Find(&SubstanceAlcoholAdditional{ID: account}, func(result interface{}) {
 		previous := result.(*SubstanceAlcoholAdditional)
+		if entity.ReceivedTreatment == nil {
+			entity.ReceivedTreatment = &Branch{}
+		}
 		entity.ReceivedTreatmentID = previous.ReceivedTreatmentID
 		entity.ReceivedTreatment.ID = previous.ReceivedTreatmentID
+		if entity.List == nil {
+			entity.List = &Collection{}
+		}
 		entity.ListID = previous.ListID
 		entity.List.ID = previous.ListID
 	})

--- a/api/model/form/treatment.go
+++ b/api/model/form/treatment.go
@@ -83,10 +83,19 @@ func (entity *Treatment) Save(context *db.DatabaseContext, account int) (int, er
 
 	context.Find(&Treatment{ID: entity.ID}, func(result interface{}) {
 		previous := result.(*Treatment)
+		if entity.Name == nil {
+			entity.Name = &Text{}
+		}
 		entity.NameID = previous.NameID
 		entity.Name.ID = previous.NameID
+		if entity.Phone == nil {
+			entity.Phone = &Telephone{}
+		}
 		entity.PhoneID = previous.PhoneID
 		entity.Phone.ID = previous.PhoneID
+		if entity.Address == nil {
+			entity.Address = &Location{}
+		}
 		entity.AddressID = previous.AddressID
 		entity.Address.ID = previous.AddressID
 	})
@@ -123,10 +132,19 @@ func (entity *Treatment) Delete(context *db.DatabaseContext, account int) (int, 
 
 	context.Find(&Treatment{ID: entity.ID}, func(result interface{}) {
 		previous := result.(*Treatment)
+		if entity.Name == nil {
+			entity.Name = &Text{}
+		}
 		entity.NameID = previous.NameID
 		entity.Name.ID = previous.NameID
+		if entity.Phone == nil {
+			entity.Phone = &Telephone{}
+		}
 		entity.PhoneID = previous.PhoneID
 		entity.Phone.ID = previous.PhoneID
+		if entity.Address == nil {
+			entity.Address = &Location{}
+		}
 		entity.AddressID = previous.AddressID
 		entity.Address.ID = previous.AddressID
 	})


### PR DESCRIPTION
When flushing the data on logon `nil` errors where raised in some sections because a field was not defined in some circumstances. This may have affected some other areas of persistence because similar behavior was found elsewhere.