### PR TITLE
Fix boolean check for resetting MFA for an account

### DIFF
--- a/api/handlers/2fa.go
+++ b/api/handlers/2fa.go
@@ -125,7 +125,7 @@ func TwofactorResetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cf.TwofactorResettable() {
+	if !cf.TwofactorResettable() {
 		http.Error(w, "Reset two-factor authentication not allowed on this server", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
During a refactoring this must have been removed.