### PR TITLE
Updated location validation

### DIFF
--- a/api/model/form/location.go
+++ b/api/model/form/location.go
@@ -98,7 +98,7 @@ func (entity *Location) Valid() (bool, error) {
 	}
 
 	var stack model.ErrorStack
-	domestic := entity.Country == "United States"
+	domestic := entity.Country == "United States" || entity.Layout == LayoutUSAddress
 	postoffice := entity.Country == "POSTOFFICE"
 	international := !domestic && !postoffice
 


### PR DESCRIPTION
Resolves #2074. All `US_ADDRESS` layouts were not validating. Just needed minor update to account for the fact that `US_ADDRESS` is an implied domestic address.