### PR TITLE
Fix branching and name summary for foreign business contacts

### DIFF
--- a/src/components/Section/Foreign/Business/Contact.jsx
+++ b/src/components/Section/Foreign/Business/Contact.jsx
@@ -42,13 +42,14 @@ export default class Contact extends SubsectionElement {
     const obj = ((item && item.Item) || {})
     const date = DateSummary(obj.Date)
     const name = NameSummary(obj.Name)
-    const govt = ((obj.Governments || {}).value || []).map(x => x.name).join(', ')
+    const govt = ((obj.Governments || {}).value || []).join(', ')
     const govtParen = name && govt ? ` (${govt})` : ''
+    const nameAndGovt = <span>{name}{govtParen}</span>
 
     return Summary({
       type: i18n.t('foreign.business.contact.collection.summary.item'),
       index: index,
-      left: `${name}${govtParen}`,
+      left: nameAndGovt,
       right: date,
       placeholder: i18n.m('foreign.business.contact.collection.summary.unknown')
     })
@@ -101,7 +102,7 @@ export default class Contact extends SubsectionElement {
 Contact.defaultProps = {
   name: 'Contact',
   HasForeignContact: {},
-  List: {},
+  List: Accordion.defaultList,
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   section: 'foreign',

--- a/src/components/Section/Foreign/Business/ContactItem.jsx
+++ b/src/components/Section/Foreign/Business/ContactItem.jsx
@@ -194,6 +194,14 @@ export default class ContactItem extends ValidationElement {
 }
 
 ContactItem.defaultProps = {
+  Name: {},
+  Location: {},
+  Date: {},
+  Governments: {},
+  Establishment: {},
+  Representatives: {},
+  Purpose: {},
+  SubsequentContacts: {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Business/SubsequentContacts.jsx
+++ b/src/components/Section/Foreign/Business/SubsequentContacts.jsx
@@ -28,7 +28,7 @@ export default class SubsequentContacts extends ValidationElement {
                           appendLabel={i18n.t('foreign.business.contact.heading.hassubsequent2')}
                           help="foreign.business.contact.help.hassubsequent"
                           className="has-foreign-contacts"
-                          items={this.props.List}
+                          {...this.props.List}
                           onUpdate={this.updateList}
                           required={this.props.required}
                           onError={this.props.onError}
@@ -73,7 +73,7 @@ export default class SubsequentContacts extends ValidationElement {
 
 SubsequentContacts.defaultProps = {
   name: 'SubsequentContacts',
-  List: [],
+  List: {},
   onUpdate: (queue) => {},
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Foreign/Business/SubsequentContacts.test.jsx
+++ b/src/components/Section/Foreign/Business/SubsequentContacts.test.jsx
@@ -7,7 +7,9 @@ describe('The foreign business contact subsequent contacts component', () => {
     let updates = 0
     const expected = {
       name: 'foreign-business-contact-subsequentcontacts',
-      List: [{ Item: { Has: { value: 'Yes' } } }],
+      List: {
+        items: [{ Item: { Has: { value: 'Yes' } } }]
+      },
       onUpdate: () => { updates++ }
     }
     const component = mount(<SubsequentContacts {...expected} />)


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2279

The `SubsequentContacts` child `BranchCollection` had the old style
of passing properties in which was throwing errors. Also, the name
summary was having issues mainly due to the data structure change
involved in the `Country` response value(s).