### PR TITLE
Allow longer top-level domain names

### DIFF
--- a/src/components/Form/Email/Email.jsx
+++ b/src/components/Form/Email/Email.jsx
@@ -70,7 +70,7 @@ export default class Email extends ValidationElement {
 
 Email.defaultProps = {
   // pattern: `^([A-z0-9_\.-]+)@([A-z0-9\.-]+)\.+([A-z\.]{2,6})$`,
-  pattern: /^([A-z0-9_\.-]+)@([A-z0-9\.-]+)\.+([A-z\.]{2,6})$/,
+  pattern: /^([A-z0-9_\.-]+)@([A-z0-9\.-]+)\.+([A-z\.]{2,63})$/,
   value: '',
   spellcheck: false,
   autocapitalize: false,

--- a/src/components/Form/Email/Email.test.jsx
+++ b/src/components/Form/Email/Email.test.jsx
@@ -71,6 +71,10 @@ describe('The Email component', () => {
       {
         address: 't j@123.com',
         valid: false
+      },
+      {
+        address: 'j@stonewall.support',
+        valid: true
       }
     ]
 


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#1710

The maximum length (63) was applied per the following article:
https://en.wikipedia.org/wiki/Domain_Name_System

> A label may contain zero to 63 characters. The null label, of
> length zero, is reserved for the root zone. The full domain
> name may not exceed the length of 253 characters in its textual
> representation. In the internal binary representation of the DNS
> the maximum length requires 255 octets of storage, as it also
> stores the length of the name.

We opted to not include zero-length labels at this time.

The minimum length (2) was decided upon by reviewing active top-level
domain names found at:
https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains