### PR TITLE
Fix for time of day not changing

### DIFF
--- a/src/components/Form/Radio/Radio.jsx
+++ b/src/components/Form/Radio/Radio.jsx
@@ -26,7 +26,9 @@ export default class Radio extends ValidationElement {
       return
     }
 
-    this.setState({ checked: newProps.checked })
+    if (this.state.checked !== newProps.checked) {
+      this.setState({ checked: newProps.checked })
+    }
   }
 
   /**
@@ -44,7 +46,6 @@ export default class Radio extends ValidationElement {
         checked: futureChecked
       })
 
-
       // Toggling the focus of the element serves two purposes
       //  1. On a value change it removes the race condition caused
       //     when passing the updates via `onUpdate` and passing values
@@ -59,6 +60,7 @@ export default class Radio extends ValidationElement {
   }
 
   handleClick (event) {
+    event.persist()
     this.handleChange(event)
   }
 
@@ -180,12 +182,14 @@ export default class Radio extends ValidationElement {
         <div className={this.divClass()}>
           <input className={this.inputClass()}
                  id={this.state.uid}
-                 name={this.props.name}
+                 name={this.state.uid}
                  type="radio"
+                 ref="radio"
                  disabled={this.props.disabled}
                  readOnly={this.props.readonly}
                  value={this.state.value}
                  onChange={this.handleChange}
+                 onKeyDown={this.handleKeyPress}
                  onFocus={this.handleFocus}
                  onBlur={this.handleBlur}
                  checked={this.state.checked}

--- a/src/components/Form/RadioGroup/RadioGroup.jsx
+++ b/src/components/Form/RadioGroup/RadioGroup.jsx
@@ -46,19 +46,20 @@ export default class RadioGroup extends ValidationElement {
   }
 
   render () {
-    const name = this.props.name ? `${this.state.uid}-${this.props.name}` : null
-    const children = React.Children.map(this.props.children, (child) => {
+    const self = this
+    const name = self.props.name ? `${self.state.uid}-${self.props.name}` : null
+    const children = React.Children.map(self.props.children, (child) => {
       // If type is not Radio, stop
       if (child.type !== Radio) {
         return child
       }
 
       // Check if current value matches one of the child radio options
-      let checked = (child.props.value === this.props.selectedValue)
+      let checked = (child.props.value === self.props.selectedValue)
 
       // Use function when you want custom behavior
       if (this.props.selectedValueFunc) {
-        checked = this.props.selectedValueFunc(child.props)
+        checked = self.props.selectedValueFunc(child.props)
       }
       const onUpdate = (option) => {
         if (child.props.onUpdate) {
@@ -71,15 +72,15 @@ export default class RadioGroup extends ValidationElement {
         <child.type
           {...child.props}
           name={name || child.props.name}
-          disabled={this.props.disabled}
+          disabled={self.props.disabled}
           checked={checked}
           onUpdate={onUpdate}>
         </child.type>
       )
     })
 
-    const errorClass = ((this.state.error === true && this.props.disabled === false) ? 'usa-input-error' : '')
-    const classes = ['blocks', this.props.className, errorClass].join(' ').trim()
+    const errorClass = ((self.state.error === true && self.props.disabled === false) ? 'usa-input-error' : '')
+    const classes = ['blocks', self.props.className, errorClass].join(' ').trim()
     return (
       <div className={classes}>{children}</div>
     )


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2261
Resolves truetandem/e-QIP-prototype#2304

Couple of issues:
 - A native radio element was not using the proper name which causes
 issues when rendered after state changes
 - A native radio element did not have the appropriate reference for
 toggling focus
 - On component receiving props the radio component updated the
 checked state every time instead of only when necessary