### PR TITLE
Explicitly setting gen'd perms

### DIFF
--- a/bin/gen-test-certificates.sh
+++ b/bin/gen-test-certificates.sh
@@ -12,9 +12,11 @@ rm -f "$WS_CER"
 openssl genrsa -out "$WS_KEY" 2048
 openssl pkcs8 -topk8 -inform PEM -in "$WS_KEY" -outform DER -nocrypt -out "$WS_PKCS"
 openssl req -new -x509 -subj "$SUBJ" -days 365 -key "$WS_KEY" -out "$WS_CER" -sha256
-# chmod 0600 "$WS_KEY"
-# chmod 0640 "$WS_PKCS"
-# chmod 0640 "$WS_CER"
+
+# User=rw Group=r Other=r
+chmod 0600 "$WS_KEY"
+chmod 0640 "$WS_PKCS"
+chmod 0640 "$WS_CER"
 
 SAML_KEY=./api/eapp.key
 SAML_CER=./api/eapp.crt
@@ -24,5 +26,7 @@ rm -f "$SAML_CER"
 
 openssl genrsa -out "$SAML_KEY" 2048
 openssl req -new -x509 -subj "$SUBJ" -days 365 -key "$SAML_KEY" -out "$SAML_CER" -sha256
-# chmod 0600 "$SAML_KEY"
-# chmod 0640 "$SAML_CER"
+
+# User=rw Group=r Other=r
+chmod 0644 "$SAML_KEY"
+chmod 0644 "$SAML_CER"


### PR DESCRIPTION
Each environment may be different so by explicitly stating the desired
permissions we can rule out some edge cases.