### PR TITLE
Clear error message on telephone IDK

### DIFF
--- a/src/components/Form/Checkbox/Checkbox.jsx
+++ b/src/components/Form/Checkbox/Checkbox.jsx
@@ -82,7 +82,7 @@ export default class Checkbox extends ValidationElement {
    * Execute validation checks on the value.
    */
   handleValidation (event) {
-    this.handleError(this.state.value)
+    this.handleError(this.state.checked)
   }
 
   /**

--- a/src/components/Form/Field/Field.jsx
+++ b/src/components/Form/Field/Field.jsx
@@ -14,7 +14,7 @@ const message = (id) => {
   }
 
   return (
-    <div key={newGuid()}>
+    <div key={newGuid()} data-i18n={id}>
       <h5>{i18n.t(`${id}.title`)}</h5>
       {i18n.m(`${id}.message`)}
       {note}

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -332,11 +332,23 @@ export default class Telephone extends ValidationElement {
       })
     })
 
+    // Zero out any required fields if IDK is selected
+    if (code === 'none' && value === true) {
+      this.errors.filter(err => err.code.indexOf(`.required`) > -1).forEach(err => {
+        err.valid = true
+      })
+    }
+
     // Run the entire component through it's own error checks as a whole
     const requiredErr = this.errors.concat(this.constructor.errors.map(err => {
+      let errProps = {...this.props, ...this.state}
+      if (code === 'none') {
+        errProps.noNumber = value
+      }
+
       return {
         code: `telephone.${err.code}`,
-        valid: err.func(value, {...this.props, ...this.state}),
+        valid: err.func(value, errProps),
         uid: this.state.uid
       }
     }))

--- a/src/components/Section/History/Education/EducationItem.jsx
+++ b/src/components/Section/History/Education/EducationItem.jsx
@@ -266,13 +266,15 @@ export default class EducationItem extends ValidationElement {
             <div className="reference">
               <Field title={i18n.t('history.education.heading.reference')}
                      titleSize="h2"
-                     className="no-margin-bottom">
+                     className="no-margin-bottom"
+                     scrollIntoView={this.props.scrollIntoView}>
                 {i18n.m('history.education.para.reference')}
               </Field>
 
               <Field title={i18n.t('reference.heading.name')}
                      titleSize="h3"
-                     optional={true}>
+                     optional={true}
+                     scrollIntoView={this.props.scrollIntoView}>
                 <NotApplicable name="ReferenceNameNotApplicable"
                                {...this.props.ReferenceNameNotApplicable}
                                label={i18n.t('reference.label.idk')}
@@ -282,6 +284,7 @@ export default class EducationItem extends ValidationElement {
                         prefix={'name'}
                         className="reference-name"
                         {...this.props.ReferenceName}
+                        scrollIntoView={this.props.scrollIntoView}
                         onUpdate={this.updateReferenceName}
                         onError={this.props.onError}
                         required={this.props.required}
@@ -293,7 +296,8 @@ export default class EducationItem extends ValidationElement {
                 <Field title={i18n.t('reference.heading.correspondence')}
                        titleSize="h2"
                        optional={true}
-                       className="no-margin-bottom">
+                       className="no-margin-bottom"
+                       scrollIntoView={this.props.scrollIntoView}>
                   {i18n.m('reference.para.correspondence')}
                 </Field>
 
@@ -313,7 +317,8 @@ export default class EducationItem extends ValidationElement {
 
                 <Field title={i18n.t('reference.heading.email')}
                        help={'reference.help.email'}
-                       adjustFor="label">
+                       adjustFor="label"
+                       scrollIntoView={this.props.scrollIntoView}>
                   <NotApplicable name="ReferenceEmailNotApplicable"
                                  {...this.props.ReferenceEmailNotApplicable}
                                  label={i18n.t('reference.label.idk')}
@@ -332,7 +337,8 @@ export default class EducationItem extends ValidationElement {
                 <Field title={i18n.t('reference.heading.address')}
                        optional={true}
                        help={'reference.help.address'}
-                       adjustFor="address">
+                       adjustFor="address"
+                       scrollIntoView={this.props.scrollIntoView}>
                   <p>{i18n.t('reference.para.address')}</p>
                   <Location name="ReferenceAddress"
                             className="reference-address"

--- a/src/components/Section/History/Employment/EmploymentItem.jsx
+++ b/src/components/Section/History/Employment/EmploymentItem.jsx
@@ -360,16 +360,19 @@ export default class EmploymentItem extends ValidationElement {
             <Field title={i18n.t(`${prefix}.heading.reference`)}
                    titleSize="h2"
                    className="no-margin-bottom"
+                   scrollIntoView={this.props.scrollIntoView}
                    />
 
             <div className="reference">
               <Field title={i18n.t('reference.heading.name')}
                      titleSize="h3"
-                     optional={true}>
+                     optional={true}
+                     scrollIntoView={this.props.scrollIntoView}>
                 <Name name="ReferenceName"
                       prefix={'name'}
                       className="reference-name"
                       {...this.props.ReferenceName}
+                      scrollIntoView={this.props.scrollIntoView}
                       onUpdate={this.updateReferenceName}
                       onError={this.props.onError}
                       required={this.props.required}
@@ -393,7 +396,8 @@ export default class EmploymentItem extends ValidationElement {
               <Field title={i18n.t('reference.heading.address')}
                      optional={true}
                      help={'reference.help.address'}
-                     adjustFor="address">
+                     adjustFor="address"
+                     scrollIntoView={this.props.scrollIntoView}>
                 <p>{i18n.t('reference.para.address')}</p>
                 <Location name="ReferenceAddress"
                           className="reference-address"
@@ -417,7 +421,8 @@ export default class EmploymentItem extends ValidationElement {
             <Field title={i18n.t(`${prefix}.heading.additionalActivity`)}
                    titleSize="h2"
                    optional={true}
-                   className="no-margin-bottom">
+                   className="no-margin-bottom"
+                   scrollIntoView={this.props.scrollIntoView}>
               {i18n.m(`${prefix}.para.additionalActivity`)}
             </Field>
 

--- a/src/components/Section/History/Residence/ResidenceItem.jsx
+++ b/src/components/Section/History/Residence/ResidenceItem.jsx
@@ -296,18 +296,21 @@ export default class ResidenceItem extends ValidationElement {
             <Field title={i18n.t('history.residence.heading.reference')}
                    titleSize="h2"
                    optional={true}
-                   className="no-margin-bottom">
+                   className="no-margin-bottom"
+                   scrollIntoView={this.props.scrollIntoView}>
               {i18n.m('history.residence.para.reference')}
             </Field>
 
             <div className="reference">
               <Field title={i18n.t('reference.heading.name')}
                      titleSize="h3"
-                     optional={true}>
+                     optional={true}
+                     scrollIntoView={this.props.scrollIntoView}>
                 <Name name="ReferenceName"
                       prefix={'name'}
                       className="reference-name"
                       {...this.props.ReferenceName}
+                      scrollIntoView={this.props.scrollIntoView}
                       onUpdate={this.updateReferenceName}
                       onError={this.props.onError}
                       required={this.props.required}
@@ -410,7 +413,8 @@ export default class ResidenceItem extends ValidationElement {
               <Field title={i18n.t('reference.heading.correspondence')}
                      titleSize="h2"
                      optional={true}
-                     className="no-margin-bottom">
+                     className="no-margin-bottom"
+                     scrollIntoView={this.props.scrollIntoView}>
                 {i18n.m('reference.para.correspondence')}
               </Field>
 
@@ -458,7 +462,8 @@ export default class ResidenceItem extends ValidationElement {
 
               <Field title={i18n.t('reference.heading.email')}
                      help={'reference.help.email'}
-                     adjustFor="label">
+                     adjustFor="label"
+                     scrollIntoView={this.props.scrollIntoView}>
                 <NotApplicable name="ReferenceEmailNotApplicable"
                                {...this.props.ReferenceEmailNotApplicable}
                                label={i18n.t('reference.label.idk')}
@@ -477,7 +482,8 @@ export default class ResidenceItem extends ValidationElement {
               <Field title={i18n.t('reference.heading.address')}
                      optional={true}
                      help={'reference.help.address'}
-                     adjustFor="address">
+                     adjustFor="address"
+                     scrollIntoView={this.props.scrollIntoView}>
                 <p>{i18n.t('reference.para.address')}</p>
                 <Location name="ReferenceAddress"
                           className="reference-address"

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -703,6 +703,12 @@ export const error = {
         }
       }
     },
+    numberType: {
+      required: {
+        title: 'There is a problem with this field',
+        message: 'This field is required'
+      }
+    },
     required: {
       title: 'There is a problem with this field',
       message: 'This field is required'


### PR DESCRIPTION
Clear out required errors related to the telephone component when IDK
is selected.

Also added the flag to bypass scrolling on certain fields that were
missing it. This appears to have been when the `Reference` component
was removed and refactored.

Resolves truetandem/e-QIP-prototype#2310
Resolves truetandem/e-QIP-prototype#2314
Resolves truetandem/e-QIP-prototype#2315
Resolves truetandem/e-QIP-prototype#1975
Resolves truetandem/e-QIP-prototype#2094