### PR TITLE
Adjustments to summary counters and progress bars

### DIFF
--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { reportCompletion } from '../../../actions/ApplicationActions'
-import { HistoryEducationValidator, EducationValidator } from '../../../validators'
+import { ResidenceValidator, EmploymentValidator, HistoryEducationValidator, EducationValidator, EducationItemValidator } from '../../../validators'
 import { i18n } from '../../../config'
 import { extractApplicantBirthdate } from '../extractors'
 import { SectionViews, SectionView } from '../SectionView'
@@ -154,7 +154,7 @@ class History extends SectionElement {
         continue
       }
 
-      if (i.Item.Dates) {
+      if (new ResidenceValidator(i.Item).isValid()) {
         dates.push(i.Item.Dates)
       }
     }
@@ -176,7 +176,7 @@ class History extends SectionElement {
         continue
       }
 
-      if (i.Item.Dates) {
+      if (new EmploymentValidator(i.Item).isValid()) {
         dates.push(i.Item.Dates)
       }
     }
@@ -195,7 +195,9 @@ class History extends SectionElement {
         continue
       }
 
-      dates.push(i.Item.Dates)
+      if (new EducationItemValidator(i.Item).isValid()) {
+        dates.push(i.Item.Dates)
+      }
     }
 
     return dates
@@ -212,13 +214,17 @@ class History extends SectionElement {
         continue
       }
 
+      if (!new EducationItemValidator(i.Item).isValid()) {
+        continue
+      }
+
       if (i.Item.Diplomas.items) {
         for (const d of i.Item.Diplomas.items) {
-          if (!d.Diploma || !d.Diploma.Date || !d.Diploma.Date.date) {
+          if (!d.Item || !d.Item.Date || !d.Item.Date.date) {
             continue
           }
 
-          dates.push(d.Diploma.Date)
+          dates.push(d.Item.Date)
         }
       }
     }

--- a/src/components/Section/History/SummaryProgress/SummaryProgress.jsx
+++ b/src/components/Section/History/SummaryProgress/SummaryProgress.jsx
@@ -29,11 +29,14 @@ export default class SummaryProgress extends ValidationElement {
         const from = julian(dates.from.date)
         const to = julian(dates.to.date)
 
-        if (dates.from.date >= julianMax || to >= julianMax) {
+        if (from >= julianMax || to >= julianMax) {
           // Meat of the calculations into percentages
           let right = findPercentage(julianNow, julianMax, to)
           left = findPercentage(julianNow, julianMax, from)
-          width = Math.abs(right - left)
+
+          if (right >= 0) {
+            width = right - left
+          }
 
           // Check boundaries
           if (width < 0) {
@@ -65,7 +68,9 @@ export default class SummaryProgress extends ValidationElement {
    */
   completed () {
     const sum = this.ranges().reduce((a, b) => a + b.width, 0)
-    return Math.min(decimalAdjust('floor', this.total() * (sum / 100), 0), this.total())
+    const x = decimalAdjust('round', this.total() * (sum / 100), 0)
+    const y = this.total()
+    return Math.abs(Math.min(x, y))
   }
 
   /**
@@ -79,9 +84,9 @@ export default class SummaryProgress extends ValidationElement {
     return this.ranges().map((range) => {
       const styles = {
         left: '' + range.left + '%',
-        width: '' + range.width + '%'
+        width: '' + Math.abs(range.width) + '%'
       }
-      return <div key={newGuid()} className="filled" style={styles}></div>
+      return <div key={newGuid()} className="filled" style={styles} data-from={range.dates.from.date} data-to={range.dates.to.date}></div>
     })
   }
 

--- a/src/components/Section/History/dateranges.js
+++ b/src/components/Section/History/dateranges.js
@@ -96,7 +96,20 @@ export const fromJulian = (julian) => {
  * Find the percentage/position within a date range a particular value has.
  */
 export const findPercentage = (max, min, value) => {
-  const pos = ((value - min) / (max - min)) * 100
+  let largest = max
+  let smallest = min
+  if (min > largest) {
+    largest = min
+    smallest = max
+  }
+
+  const pos = ((value - smallest) / (largest - smallest)) * 100
+  if (pos < 0) {
+    return 0
+  } else if (pos > 100) {
+    return 100
+  }
+
   return decimalAdjust('round', pos, -2)
 }
 

--- a/src/components/Section/Relationships/People/People.jsx
+++ b/src/components/Section/Relationships/People/People.jsx
@@ -118,7 +118,7 @@ export default class People extends SubsectionElement {
 
   peopleSummaryList () {
     return this.excludeGaps(this.props.List.items).reduce((dates, item) => {
-      if (!item || !item.Item || !item.Item.Dates) {
+      if (!item || !new PersonValidator(item.Item).isValid()) {
         return dates
       }
 
@@ -150,8 +150,7 @@ export default class People extends SubsectionElement {
                            List={this.peopleSummaryList}
                            title={i18n.t('relationships.people.summaryProgress.title')}
                            unit={i18n.t('relationships.people.summaryProgress.unit')}
-                           total={7}
-                           >
+                           total={7}>
             <div className="summary-icon">
               <Svg src="/img/people-who-know-you.svg" />
             </div>

--- a/src/validators/people.js
+++ b/src/validators/people.js
@@ -13,7 +13,10 @@ export default class PeopleValidator {
   }
 
   validCount () {
-    return ((this.list || {}).items || []).length
+    return ((this.list || {}).items || []).reduce((acc, cur) => {
+      const valid = new PersonValidator(cur.Item).isValid()
+      return valid ? acc + 1 : acc
+    }, 0)
   }
 
   validYearRange () {


### PR DESCRIPTION
Only valid items are now used in the metrics. Also, fixed the progress bars to account for negative spaces and other overlaps.

Resolves truetandem/e-QIP-prototype#1635
Resolves truetandem/e-QIP-prototype#2353
Resolves truetandem/e-QIP-prototype#2352
Resolves truetandem/e-QIP-prototype#2312
  