### PR TITLE
Do not add address to book if not "validated"

### DIFF
--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -89,10 +89,17 @@ export default class Location extends ValidationElement {
     this.props.onUpdate(values)
 
     // If there is an associated address book then push the updates there
-    if (this.props.addressBook) {
+    if (this.props.addressBook && values.validated) {
       const updatedBook = this.appendToAddressBook(this.props.addressBooks, this.props.addressBook, values)
       this.props.dispatch(updateApplication('AddressBooks', this.props.addressBook, updatedBook))
+    } else {
+      const updatedBook = this.removeFromAddressBook(this.props.addressBooks, this.props.addressBook, values)
+      this.props.dispatch(updateApplication('AddressBooks', this.props.addressBook, updatedBook))
     }
+  }
+
+  removeFromAddressBook (books, name, address) {
+    return (books[name] || []).filter(a => a.uid !== address.uid)
   }
 
   appendToAddressBook (books, name, address) {
@@ -255,9 +262,7 @@ export default class Location extends ValidationElement {
             return
           }
 
-          this.setState({ geocodeResult: r }, () => {
-            this.update({ validated: true })
-          })
+          this.setState({ geocodeResult: r })
         })
         .then(() => {
           // Trigger the spinner to complete final animations
@@ -615,7 +620,7 @@ export default class Location extends ValidationElement {
       return (
         <span>
           <p>{i18n.t(`${e}.para`)}</p>
-          <button className="suggestion-btn" onClick={this.onSuggestionDismiss.bind(this)}>
+          <button className="suggestion-btn" onClick={this.onSuggestionDismiss.bind(this, 'alternate')}>
             <span>{i18n.t('suggestions.address.more')}</span>
             <i className="fa fa-arrow-circle-right"></i>
           </button>
@@ -638,10 +643,10 @@ export default class Location extends ValidationElement {
     return null
   }
 
-  onSuggestionDismiss () {
+  onSuggestionDismiss (action) {
     this.setState({ spinner: false, suggestions: false, geocodeResult: {} }, () => {
       this.update({
-        validated: true
+        validated: action === 'dismiss'
       })
     })
   }

--- a/src/components/Form/Suggestions/Suggestions.jsx
+++ b/src/components/Form/Suggestions/Suggestions.jsx
@@ -19,8 +19,8 @@ export default class Suggestions extends React.Component {
    * This allows the user to bypass the suggestions and add something else
    * we have never seen before.
    */
-  dismissSuggestions () {
-    this.props.onDismiss()
+  dismissSuggestions (action = 'dismiss') {
+    this.props.onDismiss(action)
   }
 
   /**
@@ -48,7 +48,7 @@ export default class Suggestions extends React.Component {
   alternate () {
     if (this.props.suggestionDismissAlternate) {
       return (
-        <a href="javascript:;;" className="right" onClick={this.dismissSuggestions}>
+        <a href="javascript:;;" className="right" onClick={this.dismissSuggestions.bind(this, 'alternate')}>
           <span>{this.props.suggestionDismissAlternate}</span>
           <i className="fa fa-arrow-circle-right"></i>
         </a>
@@ -66,7 +66,7 @@ export default class Suggestions extends React.Component {
     return (
       <Modal show={this.props.show}
              closeable={true}
-             onDismiss={this.dismissSuggestions}
+             onDismiss={this.dismissSuggestions.bind(this, 'modal')}
              className="suggestions">
         <h3>{this.props.suggestionTitle}</h3>
         {this.props.suggestionParagraph}
@@ -75,7 +75,7 @@ export default class Suggestions extends React.Component {
           {this.suggestions()}
           <div className="dismiss">
             {this.props.suggestionDismissContent}
-            <a href="javascript:;;" onClick={this.dismissSuggestions}>
+            <a href="javascript:;;" onClick={this.dismissSuggestions.bind(this, 'dismiss')}>
               <span>{this.props.suggestionDismissLabel}</span>
               <i className="fa fa-arrow-circle-right"></i>
             </a>


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2000

Instead of creating multiple callbacks for each type of "dismiss" handler we added an **action** string which helps the callback function determine what was actually clicked. Possible values:

 - `dismiss` (default)
 - `modal`
 - `alternate`