### PR TITLE
Scroll up to the last item even if it may not be added yet

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -130,7 +130,7 @@ export default class Accordion extends ValidationElement {
     this.setState({ initial: false, scrollToId: '' }, () => {
       // Find the item by UUID instead of index because we can't true the index
       // will always be the same
-      const item = this.props.items.filter(x => x.uuid === id)[0]
+      const item = this.props.items.filter(x => x.uuid === id)[0] || { uuid: id }
 
       // Calculate a magic number to phase the timeout value. This always
       // for any CSS keyframe animations or transitions to take place prior


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2061

Turns out the new item was not yet part of `this.props.items` so when this is the case create a mock `item` with the `uuid` specified.