### PR TITLE
Fix open section(s) bug in navigation

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -9,14 +9,29 @@ import { ToggleItem } from './ToggleItem'
 class Navigation extends React.Component {
   constructor (props) {
     super(props)
+
     this.state = {
       selected: navigation[0].name
     }
 
     this.onToggle = this.onToggle.bind(this)
+    this.location = null
+    this.uselocation = true
+  }
+
+  componentDidMount() {
+    this.unlisten = this.props.history().listen((location, action) => {
+      this.uselocation = true
+      this.location = location.pathname
+    })
+  }
+
+  componentDidUnmount () {
+    this.unlisten()
   }
 
   onToggle (item) {
+    this.uselocation = false
     this.setState({ selected: item.visible ? item.title : '' })
   }
 
@@ -151,7 +166,9 @@ class Navigation extends React.Component {
 
       // Collapsed state properties
       if (section.subsections) {
-        const visible = this.state.selected === section.name
+        const visible = this.uselocation
+              ? isActive(url, this.location || '')
+              : this.state.selected === section.name
         return (
           <ToggleItem title={section.name}
                       section={true}
@@ -189,6 +206,9 @@ class Navigation extends React.Component {
 }
 
 Navigation.defaultProps = {
+  history: () => {
+    return env.History()
+  },
   location: () => {
     return env.History().location
   }


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2375

The navigation menu items should be displayed as open when receiving
push state notifications. Also, the items should be opened when
general browsing is being performed.

However, there should only ever be one section expanded.