### PR TITLE
Capitization rules for suffices

### DIFF
--- a/src/components/Summary/NameSummary.js
+++ b/src/components/Summary/NameSummary.js
@@ -12,9 +12,10 @@ export const NameText = (props, unknown = '') => {
     return unknown
   }
 
-  const suffix = props.suffix && props.suffix === 'Other' ? props.suffixOther : props.suffix
-  const name = `${props.first || ''} ${props.middle || ''} ${props.last || ''} ${suffix || ''}`.trim()
-  return name.length > 0 ? titleCase(name) : unknown
+  const suffix = props.suffix && props.suffix === 'Other' ? titleCase(props.suffixOther) : props.suffix
+  const name = titleCase(`${props.first || ''} ${props.middle || ''} ${props.last || ''}`.trim())
+  const nameAndSuffix = `${name} ${suffix || ''}`.trim()
+  return nameAndSuffix || unknown
 }
 
 const titleCase = (str) => {

--- a/src/components/Summary/NameSummary.test.js
+++ b/src/components/Summary/NameSummary.test.js
@@ -32,4 +32,22 @@ describe('The name summary', () => {
     const summary = NameSummary(item, 'Unknown')
     expect(summary).toEqual(<span className="title-case">Bob Joe Smith</span>)
   })
+
+  it('suffix should be value from selection', () => {
+    const item = { first: 'Bob', middle: 'Joe', last: 'Smith', suffix: 'Sr' }
+    const summary = NameSummary(item, 'Unknown')
+    expect(summary).toEqual(<span className="title-case">Bob Joe Smith Sr</span>)
+  })
+
+  it('suffix should be capitalized', () => {
+    const item = { first: 'Bob', middle: 'Joe', last: 'Smith', suffix: 'IV' }
+    const summary = NameSummary(item, 'Unknown')
+    expect(summary).toEqual(<span className="title-case">Bob Joe Smith IV</span>)
+  })
+
+  it('suffix should be capitalized', () => {
+    const item = { first: 'Bob', middle: 'Joe', last: 'Smith', suffix: 'Other', suffixOther: 'princess of power' }
+    const summary = NameSummary(item, 'Unknown')
+    expect(summary).toEqual(<span className="title-case">Bob Joe Smith Princess Of Power</span>)
+  })
 })


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2419

So according to the rules a suffix or title has sentence casing except
for when it is a roman numeral.