### PR TITLE
Identifying Information persistence

### DIFF
--- a/src/schema/section/identification-birthdate.js
+++ b/src/schema/section/identification-birthdate.js
@@ -2,6 +2,6 @@ import * as form from '../form'
 
 export const identificationBirthdate = (data = {}) => {
   return {
-    Date: form.datecontrol(data.date)
+    Date: form.datecontrol(data.Date)
   }
 }

--- a/src/schema/section/identification-contacts.js
+++ b/src/schema/section/identification-contacts.js
@@ -13,7 +13,7 @@ export const identificationContacts = (data = {}) => {
     const xitem = x.Item || {}
     return {
       Item: {
-        PhoneNumber: form.telephone(xitem.PhoneNumber)
+        Telephone: form.telephone(xitem.Telephone)
       }
     }
   })

--- a/src/schema/section/identification-contacts.test.js
+++ b/src/schema/section/identification-contacts.test.js
@@ -16,7 +16,7 @@ describe('Schema for financial taxes', () => {
         branch: null,
         items: [{
           Item: {
-            PhoneNumber: {}
+            Telephone: {}
           }
         }]
       }


### PR DESCRIPTION
Resolves #2417 *except for the section comment block*. This is probably a broader question because those comment blocks are currently on review sections. From what I saw, we currently do not persist any information from the review screen. If we were to start allowing that, would we save only the comment block? Or would we save everything? Should we create another issue to address all comment blocks?