### PR TITLE
Resolution to multiple change events trigger on radio buttons

### DIFF
--- a/src/components/Form/Branch/Branch.jsx
+++ b/src/components/Form/Branch/Branch.jsx
@@ -20,7 +20,7 @@ export default class Branch extends React.Component {
       // When a `warning` should be displayed AND they do no approve the change then
       // set the old value back to "Yes".
       if (this.props.warning && window.confirm(this.props.confirmation) === false) {
-        values.value = this.props.yesValue
+        return
       }
     }
 


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2373

> The concept of skipping an update was brought about by the unnatural way
> people think a radio button should behave (this was found through a year's
> worth of usability testing).
> 
> Expected behavior:
>   - a click/keypress on the radio button should toggle its checked value
>   - key presses may be enter, space, and browser default
> 
> When a mouse click event is fired we make a change to the value of the radio
> button thus causing another change event. This second event we need to account
> for and skip further processing.