### PR TITLE
Updated checkbox values to persist

### DIFF
--- a/src/components/Section/Financial/Delinquent/Infractions.jsx
+++ b/src/components/Section/Financial/Delinquent/Infractions.jsx
@@ -10,7 +10,7 @@ export default class Infractions extends ValidationElement {
 
   update (event) {
     let selected = event.target.value
-    let list = [...(this.props.value || [])]
+    let list = [...(this.props.values || [])]
 
     if (list.includes(selected)) {
       list.splice(list.indexOf(selected), 1)
@@ -21,7 +21,7 @@ export default class Infractions extends ValidationElement {
     if (this.props.onUpdate) {
       this.props.onUpdate({
         name: this.props.name,
-        value: list
+        values: list
       })
     }
   }
@@ -31,7 +31,7 @@ export default class Infractions extends ValidationElement {
       <div>
         {i18n.m('financial.delinquent.para.checkAll')}
         <CheckboxGroup className={`option-list ${this.props.className || ''}`.trim()}
-                      selectedValues={this.props.value}>
+                      selectedValues={this.props.values}>
           <Checkbox label={i18n.m('financial.delinquent.para.alimony')}
                     value="Alimony"
                     className="delinquent-alimony"
@@ -67,6 +67,6 @@ export default class Infractions extends ValidationElement {
 }
 
 Infractions.defaultProps = {
-  value: [],
+  values: [],
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Financial/Delinquent/Infractions.test.jsx
+++ b/src/components/Section/Financial/Delinquent/Infractions.test.jsx
@@ -7,9 +7,9 @@ describe('The infractions component', () => {
     let values = ['Alimony']
     const expected = {
       name: 'infractions',
-      value: values,
+      values: values,
       onUpdate: (obj) => {
-        values = obj.value
+        values = obj.values
       }
     }
     const component = mount(<Infractions {...expected} />)
@@ -22,9 +22,9 @@ describe('The infractions component', () => {
     let values = ['Alimony']
     const expected = {
       name: 'infractions',
-      value: values,
+      values: values,
       onUpdate: (obj) => {
-        values = obj.value
+        values = obj.values
       }
     }
     const component = mount(<Infractions {...expected} />)

--- a/src/components/Section/Financial/Nonpayment/Infractions.jsx
+++ b/src/components/Section/Financial/Nonpayment/Infractions.jsx
@@ -10,7 +10,7 @@ export default class Infractions extends ValidationElement {
 
   update (event) {
     let selected = event.target.value
-    let list = [...(this.props.value || [])]
+    let list = [...(this.props.values || [])]
 
     if (list.includes(selected)) {
       list.splice(list.indexOf(selected), 1)
@@ -21,7 +21,7 @@ export default class Infractions extends ValidationElement {
     if (this.props.onUpdate) {
       this.props.onUpdate({
         name: this.props.name,
-        value: list
+        values: list
       })
     }
   }
@@ -31,7 +31,7 @@ export default class Infractions extends ValidationElement {
       <div>
         {i18n.m('financial.nonpayment.para.checkAll')}
         <CheckboxGroup className={`option-list ${this.props.className || ''}`.trim()}
-                      selectedValues={this.props.value}>
+                      selectedValues={this.props.values}>
           <Checkbox label={i18n.m('financial.nonpayment.para.repo')}
                     value="Repossession"
                     className="nonpayment-repossession"
@@ -95,6 +95,6 @@ export default class Infractions extends ValidationElement {
 }
 
 Infractions.defaultProps = {
-  value: [],
+  values: [],
   onError: (value, arr) => { return arr }
 }

--- a/src/components/Section/Financial/Nonpayment/Infractions.test.jsx
+++ b/src/components/Section/Financial/Nonpayment/Infractions.test.jsx
@@ -7,9 +7,9 @@ describe('The infractions component', () => {
     let values = ['Repossession']
     const expected = {
       name: 'infractions',
-      value: values,
+      values: values,
       onUpdate: (obj) => {
-        values = obj.value
+        values = obj.values
       }
     }
     const component = mount(<Infractions {...expected} />)
@@ -22,9 +22,9 @@ describe('The infractions component', () => {
     let values = ['Repossession']
     const expected = {
       name: 'infractions',
-      value: values,
+      values: values,
       onUpdate: (obj) => {
-        values = obj.value
+        values = obj.values
       }
     }
     const component = mount(<Infractions {...expected} />)


### PR DESCRIPTION
Resolves #2555.
- Bankruptcy (Full section). *I couldn't simulate this behavior. It was persisting for me. I wonder if another update resolved this.*
- Delinquent payments: checkboxes for Did/does this financial issue include any of the following:
- Non-payment consequence: checkboxes for Did/does this financial issue include any of the following: