### PR TITLE
Foreign Contacts - Othernames and birthplace (part 2)

### DIFF
--- a/api/db/migrations/20180202094026_location_country_comments.sql
+++ b/api/db/migrations/20180202094026_location_country_comments.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE locations ADD COLUMN country_comments text;
+
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE locations DROP COLUMN country_comments;

--- a/api/model/form/location.go
+++ b/api/model/form/location.go
@@ -29,16 +29,17 @@ const (
 
 // Location is a basic input.
 type Location struct {
-	ID        int    `json:"-"`
-	Layout    string `json:"layout"`
-	Street1   string `json:"street,omitempty"`
-	Street2   string `json:"street2,omitempty"`
-	City      string `json:"city,omitempty"`
-	State     string `json:"state,omitempty"`
-	Zipcode   string `json:"zipcode,omitempty"`
-	County    string `json:"county,omitempty"`
-	Country   string `json:"country,omitempty"`
-	Validated bool   `json:"validated,omitempty"`
+	ID              int    `json:"-"`
+	Layout          string `json:"layout"`
+	Street1         string `json:"street,omitempty"`
+	Street2         string `json:"street2,omitempty"`
+	City            string `json:"city,omitempty"`
+	State           string `json:"state,omitempty"`
+	Zipcode         string `json:"zipcode,omitempty"`
+	County          string `json:"county,omitempty"`
+	Country         string `json:"country,omitempty"`
+	CountryComments string `json:"countryComments,omitempty"`
+	Validated       bool   `json:"validated,omitempty"`
 }
 
 // Unmarshal bytes in to the entity properties.

--- a/src/components/Form/Country/Country.jsx
+++ b/src/components/Form/Country/Country.jsx
@@ -11,7 +11,6 @@ export default class Country extends ValidationElement {
     super(props)
 
     this.state = {
-      value: props.simpleValue,
       showComents: props.showComments
     }
 

--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -80,6 +80,7 @@ export default class Address extends ValidationElement {
   updateCountry (values) {
     this.update({
       country: values,
+      countryComments: values.comments,
       validated: this.props.validated && countryString(values) === countryString(this.props.country)
     })
   }

--- a/src/components/Form/Location/Address.jsx
+++ b/src/components/Form/Location/Address.jsx
@@ -13,6 +13,7 @@ import Show from '../Show'
 import Suggestions from '../Suggestions'
 import { AddressSuggestion } from './AddressSuggestion'
 import { countryString } from '../../../validators/location'
+import { countryValueResolver } from './Location'
 
 export default class Address extends ValidationElement {
   constructor (props) {
@@ -380,7 +381,7 @@ export default class Address extends ValidationElement {
                 <Country name="country"
                          className="required"
                          label={this.props.countryLabel}
-                         {...this.props.country}
+                         {...countryValueResolver(this.props)}
                          excludeUnitedStates="true"
                          onUpdate={this.updateCountry}
                          onError={this.handleError}

--- a/src/components/Form/Location/Location.jsx
+++ b/src/components/Form/Location/Location.jsx
@@ -38,6 +38,18 @@ export const country = (obj) => {
   return obj
 }
 
+export const countryValueResolver = (props) => {
+  if (typeof props.country === 'string') {
+    let valueArr = props.country ? [props.country] : []
+    let comments = props.countryComments || ''
+    return {
+      value: valueArr,
+      comments: comments
+    }
+  }
+  return props.country
+}
+
 export default class Location extends ValidationElement {
   constructor (props) {
     super(props)
@@ -80,6 +92,7 @@ export default class Location extends ValidationElement {
       state: this.props.state,
       county: this.props.county,
       country: this.props.country,
+      countryComments: this.props.countryComments,
       layout: this.props.layout,
       validated: this.props.validated,
       ...queue
@@ -314,6 +327,7 @@ export default class Location extends ValidationElement {
   updateCountry (values) {
     this.update({
       country: values,
+      countryComments: values.comments,
       validated: this.props.validated && countryString(values) === countryString(this.props.country)
     })
   }
@@ -339,6 +353,7 @@ export default class Location extends ValidationElement {
       zipcode: location.zipcode,
       county: location.county,
       country: location.country,
+      countryComments: location.countryComments,
       validated: false
     })
   }
@@ -456,7 +471,7 @@ export default class Location extends ValidationElement {
       case 'country':
         return (
           <Country name="country"
-                   {...this.props.country}
+                   {...countryValueResolver(this.props)}
                    className="country"
                    key={field}
                    label={this.props.countryLabel}

--- a/src/components/Form/Location/Location.test.jsx
+++ b/src/components/Form/Location/Location.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import Location, { timeout } from './Location'
+import Location, { timeout, countryValueResolver } from './Location'
 
 describe('The Address component', () => {
   it('Renders without errors', () => {
@@ -200,5 +200,45 @@ describe('The Address component', () => {
     const w = null
     timeout(null, 0, w)
     expect(called).toBe(false)
+  })
+
+  it('can handle various country inputs', () => {
+    const tests = [
+      {
+        props: {
+          country: {
+            value: ['Germany'],
+            comments: 'My comment'
+          }
+        },
+        expect: {
+          value: ['Germany'],
+          comments: 'My comment'
+        }
+      },
+      {
+        props: {
+          country: 'Germany',
+          countryComments: 'My comment'
+        },
+        expect: {
+          value: ['Germany'],
+          comments: 'My comment'
+        }
+      },
+      {
+        props: {
+          country: ''
+        },
+        expect: {
+          value: [],
+          comments: ''
+        }
+      }
+    ]
+
+    tests.forEach(test => {
+      expect(countryValueResolver(test.props)).toEqual(test.expect)
+    })
   })
 })

--- a/src/components/Form/Location/ToggleableLocation.jsx
+++ b/src/components/Form/Location/ToggleableLocation.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { env } from '../../../config'
-import { newGuid } from '../ValidationElement'
 import ValidationElement from '../ValidationElement'
 import Street from '../Street'
 import MilitaryState from '../MilitaryState'
@@ -11,7 +10,7 @@ import ZipCode from '../ZipCode'
 import Show from '../Show'
 import Radio from '../Radio'
 import RadioGroup from '../RadioGroup'
-import { country } from './Location'
+import { country, countryValueResolver } from './Location'
 import { countryString } from '../../../validators/location'
 
 const mappingWarning = (property) => {
@@ -48,6 +47,7 @@ export default class ToggleableLocation extends ValidationElement {
         zipcode: this.props.zipcode,
         state: this.props.state,
         country: this.props.country,
+        countryComments: this.props.countryComments,
         county: this.props.county,
         domestic: this.props.domestic,
         domesticFields: this.props.domesticFields,
@@ -58,11 +58,11 @@ export default class ToggleableLocation extends ValidationElement {
   }
 
   updateStreet (values) {
-    this.update({ street: values.value})
+    this.update({street: values.value})
   }
 
   updateCity (values) {
-    this.update({ city: values.value})
+    this.update({city: values.value})
   }
 
   updateState (values) {
@@ -70,7 +70,10 @@ export default class ToggleableLocation extends ValidationElement {
   }
 
   updateCountry (values) {
-    this.update({country: values})
+    this.update({
+      country: values,
+      countryComments: values.comments
+    })
   }
 
   updateCounty (values) {
@@ -220,7 +223,7 @@ export default class ToggleableLocation extends ValidationElement {
           <Country name="country"
                    key={key}
                    label={this.props.countryLabel}
-                   {...this.props.country}
+                   {...countryValueResolver(this.props)}
                    className="country"
                    placeholder={this.props.countryPlaceholder}
                    excludeUnitedStates="true"

--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { i18n } from '../../../../config'
 import { ValidationElement, Field, Name, Textarea, DateControl,
          CheckboxGroup, Checkbox, RadioGroup, Radio, Country,
-         Text, NotApplicable, Show, BranchCollection, Location } from '../../../Form'
+         Text, NotApplicable, Show, BranchCollection, Location, AccordionItem } from '../../../Form'
+
 
 export default class ForeignNational extends ValidationElement {
   constructor (props) {
@@ -124,14 +125,6 @@ export default class ForeignNational extends ValidationElement {
   }
 
   updateRelationship (values) {
-    //let selected = values.value
-    //let list = [...(this.props.Relationship || [])]
-
-    //if (list.includes(selected)) {
-      //list.splice(list.indexOf(selected), 1)
-    //} else {
-      //list.push(selected)
-    //}
     const list = Checkbox.select(values, this.props.Relationship)
     this.update({
       Relationship: { values: list }
@@ -489,11 +482,13 @@ export default class ForeignNational extends ValidationElement {
                           required={this.props.required}
                           onError={this.props.onError}
                           scrollIntoView={this.props.scrollIntoView}>
-          <Field title={i18n.t('foreign.contacts.heading.aliasname')}
-                 optional={true}
-                 scrollIntoView={this.props.scrollIntoView}>
-            <Name name="Alias" bind={true} required={this.props.required} scrollIntoView={this.props.scrollIntoView} />
-          </Field>
+          <AccordionItem scrollIntoView={this.props.scrollIntoView}>
+              <Field title={i18n.t('foreign.contacts.heading.aliasname')}
+                     optional={true}
+                     scrollIntoView={this.props.scrollIntoView}>
+                <Name name="Alias" bind={true} required={this.props.required} scrollIntoView={this.props.scrollIntoView} />
+            </Field>
+          </AccordionItem>
         </BranchCollection>
 
         <Field title={i18n.t('foreign.contacts.heading.citizenship')}


### PR DESCRIPTION
Refactored country handling based on discussion in PR #2549. Just created a new branch to start fresh. Resolves #2536.

- Foreign national other names used inputs are not being saved
- Foreign national's place of birth - country not being saved 
  - This seemed to be site wide. There are instances where we only have a simple string country value. The Location component wasn't handling this case so countries would be blank.