### PR TITLE
Clear Foreign Contacts name info when NA selected

### DIFF
--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -76,6 +76,7 @@ export default class ForeignNational extends ValidationElement {
 
   updateNameNotApplicable (value) {
     this.update({
+      Name: null,
       NameNotApplicable: value
     })
   }


### PR DESCRIPTION
While validating this issue, I noticed that the name information wasn't being cleared if NA was selected. #2409.