### PR TITLE
Financial record review screen dropping user part way down instead of at the top

### DIFF
--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -235,6 +235,7 @@ export default class Bankruptcy extends ValidationElement {
 
         <Field title={i18n.t('financial.bankruptcy.heading.nameDebt')}
                titleSize="h3"
+               scrollIntoView={this.props.scrollIntoView}
                optional={true}>
           <Name name="NameDebt"
                 className="namedebt"

--- a/src/components/Section/Financial/Delinquent/Delinquent.scss
+++ b/src/components/Section/Financial/Delinquent/Delinquent.scss
@@ -1,6 +1,8 @@
 .delinquent {
   .delinquent-infractions {
-    z-index: 1;
+    input[type='checkbox'] + label {
+      z-index: 1;
+    }
 
     .block {
       display: block !important;

--- a/src/components/Section/Financial/Nonpayment/Nonpayment.scss
+++ b/src/components/Section/Financial/Nonpayment/Nonpayment.scss
@@ -1,6 +1,8 @@
 .nonpayment {
   .nonpayment-infractions {
-    z-index: 1;
+    input[type='checkbox'] + label {
+      z-index: 1;
+    }
 
     .block {
       display: block !important;


### PR DESCRIPTION
Resolves #2553. Seemed like Bankruptcy was the culprit for the scrolling into view on review screen. Also updated css for infractions. The native checkboxes weren't showing up.