### PR TITLE
Display explanation when 'Other' or 'Obligations' are selected

### DIFF
--- a/src/components/Section/Foreign/Contacts/ForeignNational.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.jsx
@@ -336,7 +336,7 @@ export default class ForeignNational extends ValidationElement {
           </CheckboxGroup>
         </Field>
 
-        <Show when={((this.props.Methods || {}).value || []).some(x => x === 'Other')}>
+        <Show when={((this.props.Methods || {}).values || []).some(x => x === 'Other')}>
           <Field title={i18n.t('foreign.contacts.heading.explanation')}
                  titleSize="label"
                  scrollIntoView={this.props.scrollIntoView}>
@@ -351,7 +351,7 @@ export default class ForeignNational extends ValidationElement {
         </Show>
 
         <Field title={i18n.t('foreign.contacts.heading.frequency')}
-               className={this.props.Frequency === 'Other' ? 'no-margin-bottom' : ''}
+               className={(this.props.Frequency || {}).value === 'Other' ? 'no-margin-bottom' : ''}
                adjustFor="big-buttons"
                scrollIntoView={this.props.scrollIntoView}>
           <RadioGroup className="frequency"
@@ -419,7 +419,7 @@ export default class ForeignNational extends ValidationElement {
         </Show>
 
         <Field title={i18n.t('foreign.contacts.heading.relationship')}
-               className={((this.props.Relationship || {}).values || []).some(x => x === 'Other') ? 'no-margin-bottom' : ''}
+               className={((this.props.Relationship || {}).values || []).some(x => x === 'Other' || x === 'Obligation') ? 'no-margin-bottom' : ''}
                adjustFor="p"
                scrollIntoView={this.props.scrollIntoView}>
           {i18n.m('foreign.contacts.para.checkall')}
@@ -458,7 +458,7 @@ export default class ForeignNational extends ValidationElement {
           </CheckboxGroup>
         </Field>
 
-        <Show when={((this.props.Relationship || {}).value || []).some(x => x === 'Other' || x === 'Obligation')}>
+        <Show when={((this.props.Relationship || {}).values || []).some(x => x === 'Other' || x === 'Obligation')}>
           <Field title={i18n.t('foreign.contacts.heading.explanation')}
                  titleSize="label"
                  adjustFor="textarea"

--- a/src/components/Section/Foreign/Contacts/ForeignNational.test.jsx
+++ b/src/components/Section/Foreign/Contacts/ForeignNational.test.jsx
@@ -16,7 +16,7 @@ describe('The foreign national component', () => {
   it('display explanation if we have methods of "other"', () => {
     const expected = {
       name: 'foreign-national',
-      Methods: { value: ['Other'] }
+      Methods: { values: ['Other'] }
     }
     const component = mount(<ForeignNational {...expected} />)
     expect(component.find('.methods-explanation').length).toBe(1)
@@ -34,7 +34,7 @@ describe('The foreign national component', () => {
   it('display explanation if we have relation of "other"', () => {
     const expected = {
       name: 'foreign-national',
-      Relationship: { value: ['Other'] }
+      Relationship: { values: ['Other'] }
     }
     const component = mount(<ForeignNational {...expected} />)
     expect(component.find('.relationship-explanation').length).toBe(1)
@@ -45,7 +45,7 @@ describe('The foreign national component', () => {
   it('display explanation if we have relation of "obligation"', () => {
     const expected = {
       name: 'foreign-national',
-      Relationship: { value: ['Obligation'] }
+      Relationship: { values: ['Obligation'] }
     }
     const component = mount(<ForeignNational {...expected} />)
     expect(component.find('.relationship-explanation').length).toBe(1)
@@ -65,9 +65,9 @@ describe('The foreign national component', () => {
     const expected = {
       name: 'foreign-national',
       NameNotApplicable: { applicable: false },
-      Methods: { value: ['Other'] },
+      Methods: { values: ['Other'] },
       Frequency: { value: 'Other' },
-      Relationship: { value: ['Other'] },
+      Relationship: { values: ['Other'] },
       Aliases: {
         items: [{ Item: { Has: { value: 'No' } } }]
       },


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2534

Updated a couple of  references of `value` to `values` (since they are a `CheckboxGroup`) as well as some associated styles to bring the explanations closer to the group options.