### PR TITLE
Adjust date limits for biological parents

### DIFF
--- a/src/components/Section/Relationships/Relatives/Relative.jsx
+++ b/src/components/Section/Relationships/Relatives/Relative.jsx
@@ -295,6 +295,7 @@ export default class Relative extends ValidationElement {
   render () {
     const validator = new RelativeValidator(this.props, null)
     const mother = (this.props.Relation || {}).value === 'Mother'
+    const father = (this.props.Relation || {}).value === 'Father'
     const immediateFamily = ['Father', 'Mother', 'Child', 'Stepchild', 'Brother', 'Sister', 'Half-brother', 'Half-sister', 'Stepbrother', 'Stepsister', 'Stepmother', 'Stepfather'].includes((this.props.Relation || {}).value)
 
     return (
@@ -442,6 +443,7 @@ export default class Relative extends ValidationElement {
           <DateControl name="Birthdate"
                        className="relative-birthdate"
                        {...this.props.Birthdate}
+                       prefix={(mother || father) ? 'parent.dob' : ''}
                        relationship={(this.props.Relation || {}).value}
                        onError={this.props.onError}
                        onUpdate={this.updateBirthdate}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -969,6 +969,18 @@ export const error = {
       }
     }
   },
+  parent: {
+    dob: {
+      max: {
+        title: 'There is a problem with the date',
+        message: 'The date can\'t be in the future and must be before your date of birth.'
+      },
+      min: {
+        title: 'There is a problem with the date',
+        message: 'The age may not exceed 200 years.'
+      }
+    }
+  },
   required: {
     title: 'There is a problem with this field',
     message: 'This field is required'

--- a/src/validators/datecontrol.js
+++ b/src/validators/datecontrol.js
@@ -50,7 +50,7 @@ export default class DateControlValidator {
     }
 
     const date = new Date(`${this.month}/${this.day}/${this.year}`)
-    return date <= this.maxDate
+    return date < this.maxDate
   }
 
   validMinDate () {
@@ -65,7 +65,7 @@ export default class DateControlValidator {
     }
 
     const date = new Date(`${this.month}/${this.day}/${this.year}`)
-    return date >= this.minDate
+    return date > this.minDate
   }
 
   isValid () {
@@ -96,12 +96,12 @@ export const dateLimits = (relationship, birthdate) => {
   switch (relationship) {
   case 'Self':
     max = daysAgo(today, 365 * 16)
-    min = daysAgo(today, 365 * 130)
+    min = daysAgo(today, (365 * 130) + 1)
     break
   case 'Mother':
   case 'Father':
     max = min
-    min = daysAgo(today, 365 * 200)
+    min = daysAgo(today, (365 * 200) + 1)
     break
   case 'Child':
     break
@@ -119,12 +119,12 @@ export const dateLimits = (relationship, birthdate) => {
   case 'Mother-in-law':
   case 'Guardian':
   case 'Other':
-    min = daysAgo(today, 365 * 200)
+    min = daysAgo(today, (365 * 200) + 1)
     break
   default:
     // Everything else just uses the defaults
     if (!min) {
-      min = daysAgo(today, 365 * 200)
+      min = daysAgo(today, (365 * 200) + 1)
     }
   }
 

--- a/src/validators/datecontrol.test.js
+++ b/src/validators/datecontrol.test.js
@@ -63,7 +63,7 @@ describe('date control validator', function () {
           year: '2005',
           maxDate: new Date('1/1/2005')
         },
-        expected: true
+        expected: false
       },
       {
         data: {
@@ -142,10 +142,10 @@ describe('date control validator', function () {
           month: '1',
           day: '1',
           year: '2004',
-          minDate: new Date('1/8/2004'),
+          minDate: new Date('1/1/2004'),
           hideDay: true
         },
-        expected: true
+        expected: false
       }
     ]
 


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2506

Instead of using `>=` and `<=` we have removed the `=` portions and adjusted where necessary in the calculations. Also, updated the error messages to speak to the special date limits for mother and father relationship types.