### PR TITLE
Reduce number of callbacks performed within the Print component

### DIFF
--- a/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcies.jsx
@@ -99,6 +99,7 @@ Bankruptcies.defaultProps = {
   List: Accordion.defaultList,
   HasBankruptcy: {},
   addressBooks: {},
+  onUpdate: (queue) => {},
   onError: (value, arr) => { return arr },
   section: 'financial',
   subsection: 'bankruptcy',

--- a/src/components/Section/Package/Print.jsx
+++ b/src/components/Section/Package/Print.jsx
@@ -63,95 +63,34 @@ class Print extends SectionElement {
       let sectionComponent = null
       switch (section.url) {
         case 'identification':
-          sectionComponent = (
-            <IdentificationSections
-              {...this.props.Identification}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <IdentificationSections {...this.props.Identification} />
           break
         case 'relationships':
-          sectionComponent = (
-            <RelationshipSections
-              {...this.props.Relationships}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <RelationshipSections {...this.props.Relationships} />
           break
         case 'history':
-          sectionComponent = (
-            <HistorySections
-              {...this.props.History}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <HistorySections {...this.props.History} />
           break
         case 'citizenship':
-          sectionComponent = (
-            <CitizenshipSections
-              {...this.props.Citizenship}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <CitizenshipSections {...this.props.Citizenship} />
           break
         case 'military':
-          sectionComponent = (
-            <MilitarySections
-              {...this.props.Military}
-              application={this.props.Application}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <MilitarySections {...this.props.Military} application={this.props.Application} />
           break
         case 'foreign':
-          sectionComponent = (
-            <ForeignSections
-              {...this.props.Foreign}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <ForeignSections {...this.props.Foreign} />
           break
         case 'financial':
-          sectionComponent = (
-            <FinancialSections
-              {...this.props.Financial}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <FinancialSections {...this.props.Financial} />
           break
         case 'substance':
-          sectionComponent = (
-            <SubstanceUseSections
-              {...this.props.SubstanceUse}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <SubstanceUseSections {...this.props.SubstanceUse} />
           break
         case 'legal':
-          sectionComponent = (
-            <LegalSections
-              {...this.props.Legal}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <LegalSections {...this.props.Legal} />
           break
         case 'psychological':
-          sectionComponent = (
-            <PsychologicalSections
-              {...this.props.Psychological}
-              dispatch={this.props.dispatch}
-              onError={this.handleError}
-            />
-          )
+          sectionComponent = <PsychologicalSections {...this.props.Psychological} />
           break
         default:
           return null


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2550

The `<Print/>` component was performing completion, error, and other
callbacks for every section/subsection on mount. Since this component
is intended for final submission and printing there should be no
further error and completion checks to complete and removing
them **should** be safe.