### PR TITLE
Update passport card placeholder text

### DIFF
--- a/src/components/Section/Foreign/Passport/Passport.jsx
+++ b/src/components/Section/Foreign/Passport/Passport.jsx
@@ -121,8 +121,9 @@ export default class Passport extends SubsectionElement {
   }
 
   render () {
+    const passportType = (this.props.Card || {}).value || 'Book'
     let re = this.props.reBook
-    if ((this.props.Card || {}).value === 'Card') {
+    if (passportType === 'Card') {
       re = this.props.reCard
     }
 
@@ -212,8 +213,8 @@ export default class Passport extends SubsectionElement {
                 </RadioGroup>
                 <Text name="number"
                       {...this.props.Number}
-                      label={i18n.t('foreign.passport.label.number')}
-                      placeholder={i18n.t('foreign.passport.placeholder.number')}
+                      label={i18n.t(`foreign.passport.label.${passportType.toLowerCase()}Number`)}
+                      placeholder={i18n.t(`foreign.passport.placeholder.${passportType.toLowerCase()}Number`)}
                       pattern={re}
                       maxlength="9"
                       className="number passport-number"

--- a/src/config/locales/en/foreign.js
+++ b/src/config/locales/en/foreign.js
@@ -50,12 +50,14 @@ export const foreign = {
       no: 'No'
     },
     label: {
-      number: 'Passport number',
+      bookNumber: 'Passport number',
+      cardNumber: 'Passport card number',
       book: 'Passport',
       card: 'Passport card'
     },
     placeholder: {
-      number: 'A########'
+      bookNumber: 'A########',
+      cardNumber: 'C########'
     },
     name: 'Provide the name in which passport was first issued',
     number: 'Provide your U.S. passport number',


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2533

Placeholder text was `A######` and now is `C######`