### PR TITLE
Update the focus switching when moving to a new section

### DIFF
--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -28,34 +28,7 @@ class Section extends React.Component {
 
   componentDidUpdate () {
     // Once a section updates then attempt to focus on the first form element
-    // const selectors = [
-    //   '.eapp-core input',
-    //   '.eapp-core textarea',
-    //   '.eapp-core select',
-    //   '.eapp-core a'
-    // ]
-
-    let el = null
-    // for (const selector of selectors) {
-    //   el = window.document.querySelector(selectors.join(', '))
-    //   if (el) {
-    //     // Make sure it is currently visible
-    //     const bottom = el.getBoundingClientRect().bottom
-    //     const height = window.innerHeight
-    //     if (height >= bottom) {
-    //       // Break out of this loop if an visible element was found
-    //       break
-    //     }
-    //   }
-
-    //   el = null
-    // }
-
-    // Fallback to a specific known point of reference
-    if (!el) {
-      el = window.document.querySelector('.eapp-section-focus')
-    }
-
+    const el = window.document.querySelector('.eapp-section-focus')
     if (el) {
       window.setTimeout(() => {
         el.focus()

--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -28,28 +28,28 @@ class Section extends React.Component {
 
   componentDidUpdate () {
     // Once a section updates then attempt to focus on the first form element
-    const selectors = [
-      '.eapp-core input',
-      '.eapp-core textarea',
-      '.eapp-core select',
-      '.eapp-core a'
-    ]
+    // const selectors = [
+    //   '.eapp-core input',
+    //   '.eapp-core textarea',
+    //   '.eapp-core select',
+    //   '.eapp-core a'
+    // ]
 
     let el = null
-    for (const selector of selectors) {
-      el = window.document.querySelector(selectors.join(', '))
-      if (el) {
-        // Make sure it is currently visible
-        const bottom = el.getBoundingClientRect().bottom
-        const height = window.innerHeight
-        if (height >= bottom) {
-          // Break out of this loop if an visible element was found
-          break
-        }
-      }
+    // for (const selector of selectors) {
+    //   el = window.document.querySelector(selectors.join(', '))
+    //   if (el) {
+    //     // Make sure it is currently visible
+    //     const bottom = el.getBoundingClientRect().bottom
+    //     const height = window.innerHeight
+    //     if (height >= bottom) {
+    //       // Break out of this loop if an visible element was found
+    //       break
+    //     }
+    //   }
 
-      el = null
-    }
+    //   el = null
+    // }
 
     // Fallback to a specific known point of reference
     if (!el) {


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2433

The focus switching, albeit a good attempt, did not cover all
exceptions or use cases when the form deviates from the standard
structure (your history sections) or if some content was delayed in
loading. Defaulting to setting the focus to an anchor at the top of
the main content section instead for the time being.