### PR TITLE
Handle null data from "package" section

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,5 +1,5 @@
 #! /bin/sh
 curl "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" -o ./lib/dap.min.js
-yarn install
+yarn install --production=false
 yarn build
 ./bin/permissions

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -205,6 +205,7 @@ const validWebToken = () => {
     if (env.IsTest()) {
       console.log('Skip refreshing web tokens')
       resolve(api.getToken())
+      return
     }
 
     const token = api.getToken()

--- a/src/actions/ApplicationActions.js
+++ b/src/actions/ApplicationActions.js
@@ -59,7 +59,7 @@ export function validateApplication (dispatch, application = {}) {
   navigationWalker((path, child) => {
     if (path.length && path[0].store && child.store && child.validator) {
       const sectionName = path[0].url
-      let data = application[path[0].store][child.store] || {}
+      let data = (application[path[0].store] || {})[child.store] || {}
 
       let subsectionName = child.url
       if (path.length > 1) {

--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -28,7 +28,7 @@ class Navigation extends React.Component {
     })
   }
 
-  componentDidUnmount () {
+  componentUnmount () {
     this.unlisten()
   }
 
@@ -106,6 +106,7 @@ class Navigation extends React.Component {
       if (subsection.subsections) {
         return (
           <ToggleItem title={subsection.name}
+                      key={subUrl}
                       section={false}
                       className={subClass}
                       visible={isActive(subUrl, pathname)}>
@@ -180,6 +181,7 @@ class Navigation extends React.Component {
               : this.state.selected === section.name
         return (
           <ToggleItem title={section.name}
+                      key={url}
                       section={true}
                       number={section.showNumber ? sectionNum : null}
                       className={sectionClass}

--- a/src/components/Navigation/ToggleItem.jsx
+++ b/src/components/Navigation/ToggleItem.jsx
@@ -63,7 +63,7 @@ export class ToggleItem extends React.Component {
     const validIcon = `${this.props.section ? '' : 'mini'} eapp-status-icon-valid`.trim()
     const errorIcon = `${this.props.section ? '' : 'mini'} eapp-status-icon-error`.trim()
     return (
-      <div ref="item" key={this.props.title} className={`${this.props.section ? 'section' : 'subsection'} ${this.state.visible ? 'open' : 'closed'}`}>
+      <div ref="item" className={`${this.props.section ? 'section' : 'subsection'} ${this.state.visible ? 'open' : 'closed'}`}>
         <span className="section-title">
           <a href="javascript:;;;" title={this.props.title} className={this.props.className} onClick={this.toggle}>
             <Show when={this.props.number}>

--- a/src/components/Section/Package/BasicAccordion.jsx
+++ b/src/components/Section/Package/BasicAccordion.jsx
@@ -24,6 +24,7 @@ export default class BasicAccordion extends React.Component {
       const validIcon = item.valid() ? <span className="valid-icon"></span> : null
       return (
         <BasicAccordionItem
+          key={item.title}
           onClick={toggle}
           component={item.component()}
           title={item.title}

--- a/src/components/Section/Package/InvalidForm.jsx
+++ b/src/components/Section/Package/InvalidForm.jsx
@@ -39,8 +39,8 @@ export default class InvalidForm extends React.Component {
 
 export class InvalidSection extends React.Component {
   render () {
-    const incompleteSubsections = this.props.mark.subsections.map(subsection => {
-      return (<div key={subsection.url}>{ subsection.name }</div>)
+    const incompleteSubsections = this.props.mark.subsections.map((subsection, i) => {
+      return (<div key={`${subsection.url}-${i}`}>{ subsection.name }</div>)
     })
 
     return (

--- a/src/components/Section/Package/Print.jsx
+++ b/src/components/Section/Package/Print.jsx
@@ -97,7 +97,7 @@ class Print extends SectionElement {
       }
 
       return (
-        <div className="section-print-container">
+        <div className="section-print-container" key={index}>
           <h3 className="section-print-header">{section.title}</h3>
           { sectionComponent }
         </div>

--- a/src/middleware/history.js
+++ b/src/middleware/history.js
@@ -90,7 +90,7 @@ export const clearErrorsMiddleware = store => next => action => {
 }
 
 export const saveSection = (application, section, subsection, dispatch, done) => {
-  const pending = sectionData(section, subsection, application)
+  const pending = sectionData(section, subsection, application) || []
   if (pending.length === 0) {
     if (done) {
       done()


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2673

When going to the **Package** section and then navigating to another
section the user would be logged out.

On further investigation the page was exhibiting a full refresh due to
a `null` returning from `sectionData` because there was no data in the
package storage. Accounting for this allows normal functionality with
minimal changes.