### PR TITLE
Updated css for text buttons

### DIFF
--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -243,7 +243,7 @@ select {
       // All the div's (except the first) are treated as
       // subtext.
       > div:not(:first-of-type) {
-        font-size: smaller;
+        font-size: small;
         margin-top: -3rem;
       }
     }


### PR DESCRIPTION
Resolves #2455. Seems like IE handles relative sizing differently. Switched to `small` from `smaller` which appears to keep the same styling in chrome but renders fine in IE.

IE Edge
![selection_798](https://user-images.githubusercontent.com/5938731/36981002-f14aa90c-2059-11e8-9f0c-c4cd22851c80.png)
![selection_799](https://user-images.githubusercontent.com/5938731/36981006-f426bb70-2059-11e8-87e5-3800226896b6.png)

IE 11
![selection_800](https://user-images.githubusercontent.com/5938731/36981012-f9458190-2059-11e8-9dbc-58fa2c65f50e.png)
![selection_801](https://user-images.githubusercontent.com/5938731/36981030-037d52a0-205a-11e8-9c12-95b6391c1918.png)
