### PR TITLE
IE11 Button sizes and other alignment styling

### DIFF
--- a/src/components/Form/Field/Field.scss
+++ b/src/components/Form/Field/Field.scss
@@ -286,7 +286,7 @@
 
     > .table > .content > .component {
       width: 100%;
-      max-width: initial !important;
+      max-width: auto !important;
     }
 
     > .messages > .message {

--- a/src/components/Form/Name/Name.scss
+++ b/src/components/Form/Name/Name.scss
@@ -7,7 +7,7 @@
   }
 
   .suffix .block label {
-    height: initial !important;
+    height: auto !important;
     width: 7.5rem !important;
     min-width: 7.5rem !important;
   }
@@ -20,7 +20,7 @@
     margin-left: 1rem;
 
     > label {
-      width: initial;
+      width: auto;
     }
   }
 }

--- a/src/components/Form/SSN/SSN.scss
+++ b/src/components/Form/SSN/SSN.scss
@@ -1,6 +1,6 @@
 .ssn {
   display: inline-block;
-  width: initial !important;
+  width: auto !important;
 
   .first {
     width: 9rem !important;

--- a/src/components/Form/Sex/Sex.scss
+++ b/src/components/Form/Sex/Sex.scss
@@ -16,9 +16,9 @@
       span {
         display: block;
         margin-top: 1.5rem;
-        line-height: initial;
+        line-height: auto;
         font-size: smaller;
-        height: initial;
+        height: auto;
       }
     }
   }

--- a/src/components/Form/Telephone/Telephone.scss
+++ b/src/components/Form/Telephone/Telephone.scss
@@ -76,7 +76,7 @@
   }
 
   .phonetype-option.block label {
-    height: initial !important;
+    height: auto !important;
     width: 8.7rem !important;
   }
 

--- a/src/components/SavedIndicator/SavedIndicator.scss
+++ b/src/components/SavedIndicator/SavedIndicator.scss
@@ -19,7 +19,7 @@ $border-size: 5px;
 
   &:focus {
     outline: none;
-    outline-offset: initial;
+    outline-offset: auto;
   }
 
   &.active,
@@ -93,8 +93,8 @@ $border-size: 5px;
   .spinner {
     position: relative;
     top: -1rem;
-    width: initial;
-    height: initial;
+    width: auto;
+    height: auto;
 
     .spinner-icon,
     .spinner-icon:after {

--- a/src/components/Section/Citizenship/Status/Status.scss
+++ b/src/components/Section/Citizenship/Status/Status.scss
@@ -17,7 +17,7 @@
 
   .citizenship-abroad label {
     width: 14rem !important;
-    height: initial !important;
+    height: auto !important;
   }
 
   .citizenship-basis label {
@@ -33,6 +33,6 @@
 
   .citizenship-document-type label {
     width: 11rem !important;
-    height: initial !important;
+    height: auto !important;
   }
 }

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.scss
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.scss
@@ -1,6 +1,6 @@
 .petition-chapters {
   .block label {
     width: 14rem !important;
-    height: initial !important;
+    height: auto !important;
   }
 }

--- a/src/components/Section/Financial/Taxes/Taxes.scss
+++ b/src/components/Section/Financial/Taxes/Taxes.scss
@@ -1,6 +1,6 @@
 .taxes {
   .taxes-failure label {
     width: 15rem !important;
-    height: initial !important;
+    height: auto !important;
   }
 }

--- a/src/components/Section/Foreign/Contacts/Contacts.scss
+++ b/src/components/Section/Foreign/Contacts/Contacts.scss
@@ -42,6 +42,6 @@
 
   // The "has affiliations" branching has three options.
   .has-affiliations .block label {
-    height: initial !important;
+    height: auto !important;
   }
 }

--- a/src/components/Section/Legal/Police/Offense.scss
+++ b/src/components/Section/Legal/Police/Offense.scss
@@ -4,7 +4,7 @@
   .offense-chargetype {
     margin-bottom: 1.1rem;
     .block label {
-      height: initial !important;
+      height: auto !important;
     }
   }
 

--- a/src/components/Section/Military/History/MilitaryService.scss
+++ b/src/components/Section/Military/History/MilitaryService.scss
@@ -2,7 +2,7 @@
   .status .block label,
   .officer .block label {
     width: 18rem !important;
-    height: initial !important;
+    height: auto !important;
   }
 
   .service-icon,

--- a/src/components/Section/Psychological/ExistingConditions/ExistingConditions.scss
+++ b/src/components/Section/Psychological/ExistingConditions/ExistingConditions.scss
@@ -6,7 +6,7 @@
     }
 
     label {
-      height: initial !important;
+      height: auto !important;
     }
   }
 

--- a/src/components/Section/Relationships/RelationshipStatus/Divorce.scss
+++ b/src/components/Section/Relationships/RelationshipStatus/Divorce.scss
@@ -2,6 +2,6 @@
   .deceased label,
   .status label {
     width: 17rem !important;
-    height: initial !important;
+    height: auto !important;
   }
 }

--- a/src/components/Section/SubstanceUse/Alcohol/ReceivedCounselings.scss
+++ b/src/components/Section/SubstanceUse/Alcohol/ReceivedCounselings.scss
@@ -3,7 +3,7 @@
     display: inline-block;
     vertical-align: top;
     padding-top: 2.5rem;
-    width: initial !important;
+    width: auto !important;
 
     .or {
       display: inline-block;

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -107,6 +107,7 @@ a:focus {
     .usa-banner-button {
       display: inline-block;
       width: auto;
+      height: auto;
     }
   }
 

--- a/src/sass/phone.scss
+++ b/src/sass/phone.scss
@@ -15,7 +15,7 @@
   }
 
   .modal-open {
-    height: initial;
+    height: auto;
     overflow-y: auto !important;
   }
 
@@ -77,7 +77,7 @@
     .introduction-content {
       width: 100%;
       min-width: 100%;
-      height: initial;
+      height: auto;
       margin: 0 !important;
       padding-bottom: 5rem; // padding for ipad and iphone
       border: none;
@@ -91,13 +91,13 @@
 
       .introduction-legal {
         overflow-y: auto;
-        max-height: initial;
+        max-height: auto;
         border: none;
         padding: 0 1rem;
       }
 
       .introduction-acceptance {
-        max-height: initial;
+        max-height: auto;
         margin: 0;
         padding: 4rem 1rem;
 
@@ -206,8 +206,8 @@
 
     .eapp-form {
       width: 100% !important;
-      max-width: initial;
-      min-width: initial;
+      max-width: auto;
+      min-width: auto;
     }
 
     .block > label {

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -265,7 +265,7 @@ select {
 
     &.no-toggle.checked,
     &.no-toggle:hover {
-      color: initial;
+      color: inherit;
       border: none;
       background: transparent;
     }
@@ -364,7 +364,7 @@ select {
 
   &.disabled {
     label {
-      cursor: initial;
+      cursor: inherit;
       background: $eapp-grey-light;
 
       &.usa-input-focus,


### PR DESCRIPTION
Resolves issue #2523. IE11 does not support the `initial` css value. So height and width values containing  `initial` were switched to `auto`. 

Related issues:
#2462 - Full name style
#2461 - header - logout and instructions
#2459 - Save icon off screen 
#2522 - Where you went to school and other date blocks
#2463 - can't select checkboxes
#2466 - Estimated checkbox not aligned or missing

The following are screenshots of buttons that previously had issues that are now fixed:

![bankruptcy](https://user-images.githubusercontent.com/5938731/37006795-f9e46d98-208e-11e8-8ce8-09fe7de6ba7b.PNG)
![existing_conditions](https://user-images.githubusercontent.com/5938731/37006796-f9fcf2be-208e-11e8-80e8-26fc6b944b58.PNG)
![foreign_contacts](https://user-images.githubusercontent.com/5938731/37006797-fa18115c-208e-11e8-9f50-d86f9aae82d0.PNG)
![marital](https://user-images.githubusercontent.com/5938731/37006798-fa2fdd28-208e-11e8-8a44-9ae4bc42f24c.png)
![military](https://user-images.githubusercontent.com/5938731/37006799-fa460c2e-208e-11e8-9228-585d987751f0.png)
![offenses](https://user-images.githubusercontent.com/5938731/37006800-fa746826-208e-11e8-806d-8d1f582cf120.PNG)
![taxes](https://user-images.githubusercontent.com/5938731/37006801-fa9291ac-208e-11e8-8ecd-e5d2d0923427.PNG)
![image](https://user-images.githubusercontent.com/5938731/37008033-160f85ba-2095-11e8-9989-bf5e10d3f465.png)

