### PR TITLE
Alter flow of token refresh and timeouts for slower connections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,16 +68,6 @@ class App extends React.Component {
   }
 
   render () {
-    validWebToken()
-      .then(token => {
-        if (!token) {
-          this.props.dispatch(logout())
-        }
-      })
-      .catch(() => {
-        this.props.dispatch(logout())
-      })
-
     const logoutButton = this.props.authenticated || this.props.twofactor
         ? (<a href="#" onClick={this.logout} className="logout">{i18n.t('app.logout')}</a>)
         : null
@@ -198,28 +188,3 @@ function mapStateToProps (state) {
 // Wraps the the App component with connect() which adds the dispatch()
 // function to the props property for this component
 export default connect(mapStateToProps)(App)
-
-const validWebToken = () => {
-  return new Promise((resolve, reject) => {
-    if (env.IsTest()) {
-      resolve(api.getToken())
-      return
-    }
-
-    const token = api.getToken()
-    if (!token) {
-      reject()
-      return
-    }
-
-    api.refresh()
-      .then(r => {
-        api.setToken(r.data)
-        resolve(r.data)
-      })
-      .catch(() => {
-        api.setToken('')
-        reject()
-      })
-  })
-}

--- a/src/actions/AuthActions.js
+++ b/src/actions/AuthActions.js
@@ -38,12 +38,23 @@ export function login (username, password, fn) {
 /**
  * Logs out a user
  */
-export function logout () {
+export function logout (error = '') {
   return function (dispatch, getState) {
     const clear = () => {
       api.setToken('')
       dispatch({ type: AuthConstants.LOGOUT })
-      dispatch(push('/login'))
+      dispatch(push(`/login${error ? '?error=' : ''}${error ? error : ''}`))
+    }
+    return api.logout().then(clear).catch(clear)
+  }
+}
+
+export function tokenError () {
+  return function (dispatch, getState) {
+    const clear = () => {
+      api.setToken('')
+      dispatch({ type: AuthConstants.LOGOUT })
+      dispatch(push('/token'))
     }
     return api.logout().then(clear).catch(clear)
   }

--- a/src/boot.jsx
+++ b/src/boot.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
-import { Login, AccessDenied, Locked, Help, Form } from './views'
+import { Login, AccessDenied, Locked, TokenRefresh, Help, Form } from './views'
 import { Router, Switch, Route } from 'react-router'
 import { Provider } from 'react-redux'
 import { env } from './config'
@@ -118,6 +118,7 @@ ReactDOM.render(
           <Route exact path="/login" component={Login} />
           <Route exact path="/accessdenied" component={AccessDenied} />
           <Route exact path="/locked" component={Locked} />
+          <Route exact path="/token" component={TokenRefresh} />
         </Switch>
       </Main>
     </Router>

--- a/src/config/locales/en/login.js
+++ b/src/config/locales/en/login.js
@@ -53,5 +53,12 @@ export const login = {
       'If you need assistance contact the office who initiated your form.'
     ],
     button: 'Back to login'
+  },
+  token: {
+    title: 'You have been logged out',
+    para: [
+      'For security reasons you have been logged out. This may be due to a slow connection speed and/or inactivity. Please log in again to continue.'
+    ],
+    button: 'Back to login'
   }
 }

--- a/src/middleware/history.js
+++ b/src/middleware/history.js
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { env } from '../config'
 import SectionConstants from '../actions/SectionConstants'
 import { updateApplication, clearErrors } from '../actions/ApplicationActions'
+import { tokenError } from '../actions/AuthActions'
 import { sectionData } from '../components/Section/sectionData'
 import schema from '../schema'
 import { api } from '../services'
@@ -47,8 +48,43 @@ export const historyMiddleware = store => next => action => {
   next(action)
 }
 
+// refreshPending is a flag to determine if we are currently asking for a token
+let refreshPending = false
+
 // Retrieve the section's answers
 export const sectionMiddleware = store => next => action => {
+  if (action.type === SectionConstants.SECTION_UPDATE || action.type === SectionConstants.SUBSECTION_UPDATE) {
+    if (env.IsTest()) {
+      next(action)
+      return
+    }
+
+    const token = api.getToken()
+    if (!token) {
+      next(action)
+      return
+    }
+
+    // If a refresh is currently pending then wait for it
+    if (refreshPending) {
+      next(action)
+      return
+    }
+
+    refreshPending = true
+    api.refresh().then(r => {
+      refreshPending = false
+      api.setToken(r.data)
+      if (r.data === '') {
+        store.dispatch(tokenError())
+      }
+    }).catch(() => {
+      refreshPending = false
+      api.setToken('')
+      store.dispatch(tokenError())
+    })
+  }
+
   // Allow redux to continue the flow and executing the next middleware
   next(action)
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,7 +5,7 @@ class Api {
   constructor () {
     this.proxy = axios.create({
       baseURL: env ? env.ApiBaseURL() : '/api',
-      timeout: 5000
+      timeout: 10000
     })
   }
 

--- a/src/views/Login/Login.jsx
+++ b/src/views/Login/Login.jsx
@@ -78,6 +78,9 @@ export class Login extends React.Component {
     const err = this.getQueryValue('error')
     if (err) {
       switch (err) {
+      case 'token':
+        this.props.dispatch(push('/token'))
+        return
       case 'access_denied':
         this.props.dispatch(push('/accessdenied'))
         return

--- a/src/views/TokenRefresh/TokenRefresh.jsx
+++ b/src/views/TokenRefresh/TokenRefresh.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { i18n } from '../../config'
+
+class TokenRefresh extends React.Component {
+  render () {
+    return (
+      <div className="login eapp-core" id="login">
+        <div id="seal-header" className="seal-header text-center">
+          <div className="content">
+            <img src="/img/US-OfficeOfPersonnelManagement-Seal.svg" alt="U.S. Office of Personnel Management" />
+            <h2>{i18n.t('login.title')}</h2>
+          </div>
+        </div>
+        <div className="content">
+          <div className="table one">
+            <div id="tokenrefresh" className="auth denied">
+              <h2>{i18n.t('login.token.title')}</h2>
+              {i18n.m('login.token.para')}
+              <a href="/login" className="usa-button-primary">
+                {i18n.t('login.token.button')}
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+TokenRefresh.defaultProps = {}
+
+/**
+ * Maps the relevant subtree state from the applications state tree.
+ * In this case, we pull the authentication sub-state. This is mapped
+ * to the authentication reducer. When actions are dispatched, this
+ * method is executed which causes a re-render.
+ */
+function mapStateToProps (state) {
+  return {}
+}
+
+// Wraps the the App component with connect() which adds the dispatch()
+// function to the props property for this component
+export default connect(mapStateToProps)(TokenRefresh)

--- a/src/views/TokenRefresh/TokenRefresh.test.jsx
+++ b/src/views/TokenRefresh/TokenRefresh.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import MockAdapter from 'axios-mock-adapter'
+import configureMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import { MemoryRouter } from 'react-router'
+import { Provider } from 'react-redux'
+import { mount } from 'enzyme'
+import TokenRefresh from './TokenRefresh'
+import { i18n } from '../../config'
+
+describe('The token refresh error view', () => {
+  // Setup
+  const middlewares = [ thunk ]
+  const mockStore = configureMockStore(middlewares)
+
+  it('is visible with context', () => {
+    const store = mockStore({ authentication: {} })
+    const component = mount(<Provider store={store}><MemoryRouter><TokenRefresh /></MemoryRouter></Provider>)
+    expect(component.find('.auth.denied').length).toEqual(1)
+    expect(component.find('.auth.denied h2').text()).toEqual(i18n.t('login.token.title'))
+    expect(component.find('.auth.denied p').length).toEqual(1)
+    expect(component.find('.auth.denied a.usa-button-primary').text()).toEqual(i18n.t('login.token.button'))
+  })
+})

--- a/src/views/TokenRefresh/index.js
+++ b/src/views/TokenRefresh/index.js
@@ -1,0 +1,2 @@
+import TokenRefresh from './TokenRefresh'
+export { TokenRefresh }

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,7 +1,8 @@
 import { Login } from './Login'
 import { AccessDenied } from './AccessDenied'
 import { Locked } from './Locked'
+import { TokenRefresh } from './TokenRefresh'
 import { Help } from './Help'
 import { Form } from './Form'
 
-export { Login, AccessDenied, Locked, Help, Form }
+export { Login, AccessDenied, Locked, TokenRefresh, Help, Form }


### PR DESCRIPTION
Couple of issues addressed:

 1. Slow connection sessions rejected due to timeouts
 2. Calls for token refresh less frequent and error message displayed

## Slow connections

Using dev tools we were able to mock slower connection speeds. When connection speeds went to < 750 kbps client requests were more frequently dropped/cancelled/timed out which would cause the session to end due to security reasons.

## Calls for token refresh

Moved the request to refresh a security token to the pipeline (middleware) and reduced the amount of calls. The requests still happen per section update but just not on every API call or form rendering.

### The error message

![image](https://user-images.githubusercontent.com/697855/37055306-61eb637c-214f-11e8-9ed7-e5a9dc0a7dd9.png)
