### PR TITLE
Navigation updates for tablet and phone form factors

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,9 +72,12 @@ class App extends React.Component {
         ? (<a href="#" onClick={this.logout} className="logout">{i18n.t('app.logout')}</a>)
         : null
     const klassApp = `${this.designClass()} ${this.props.settings.modalOpen ? 'modal-open' : ''}`.trim()
-    const klassTitle = `eapp-structure-right eapp-title ${this.props.settings.mobileNavigation ? 'mobile-hidden' : 'visible'}`.trim()
-    const klassNavigation = `eapp-structure-left eapp-navigation ${this.props.settings.mobileNavigation ? 'mobile-visible' : 'mobile-hidden'}`.trim()
-    const klassCore = `eapp-structure-right eapp-core ${this.props.settings.mobileNavigation ? 'mobile-hidden' : 'visible'}`.trim()
+    const mobileNavigation = this.props.settings.mobileNavigation || false
+    const klassTitle = 'eapp-structure-right eapp-title'
+    const klassHeading = `eapp-structure-wrap eapp-header ${mobileNavigation ? 'mobile-navigation' : ''}`.trim()
+    const klassMain = `eapp-structure-wrap eapp-main ${mobileNavigation ? 'mobile-navigation' : ''}`.trim()
+    const klassNavigation = `eapp-structure-left eapp-navigation ${mobileNavigation ? 'mobile-visible tablet-visible desktop-visible' : 'mobile-hidden'}`
+    const klassCore = `eapp-structure-right eapp-core ${mobileNavigation ? 'mobile-hidden' : 'visible'}`
 
     return (
       <div className={klassApp}>
@@ -89,7 +92,7 @@ class App extends React.Component {
               <header className="usa-header usa-header-basic" role="banner">
                 <div className="usa-banner mobile-hidden">
                   <div className="usa-accordion">
-                    <header className="usa-banner-header">
+                    <div className="usa-banner-header">
                       <div className="usa-grid usa-banner-inner">
                         <img src="/img/favicons/favicon-57.png" alt="U.S. flag" />
                         <p>{i18n.t('app.banner.title')}</p>
@@ -97,7 +100,7 @@ class App extends React.Component {
                           <span className="usa-banner-button-text">{i18n.t('app.banner.button')}</span>
                         </button>
                       </div>
-                    </header>
+                    </div>
                     <div className="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
                       <div className="usa-banner-guidance-gov usa-width-one-half">
                         <img className="usa-banner-icon usa-media_block-img" src="/img/icon-dot-gov.svg" alt="Dot gov" />
@@ -118,19 +121,21 @@ class App extends React.Component {
                     </div>
                   </div>
                 </div>
-                <div className="eapp-structure-wrap eapp-header">
+                <div className={klassHeading}>
                   <div className="eapp-structure-row">
                     <div className="eapp-structure-left eapp-logo" id="logo">
-                      <img className="eapp-logo-icon" src="/img/US-OfficeOfPersonnelManagement-Seal.svg" alt="Office of Personnet Management" />
-                      <span className="eapp-logo-text">SF86</span>
                       <NavigationToggle />
+                      <div className="text-center">
+                        <img className="eapp-logo-icon" src="/img/US-OfficeOfPersonnelManagement-Seal.svg" alt="Office of Personnet Management" />
+                        <span className="eapp-logo-text">SF86</span>
+                      </div>
                     </div>
                     <div className={klassTitle}>
-                      <div className="eapp-logout mobile-hidden">
-                        <button onClick={this.showInstructions} className="instructions">{i18n.t('app.instructions')}</button>
+                      <div className="eapp-logout">
+                        <button onClick={this.showInstructions} className="instructions mobile-hidden">{i18n.t('app.instructions')}</button>
                         {logoutButton}
                       </div>
-                      <SectionTitle />
+                      <SectionTitle hidden={mobileNavigation} />
                     </div>
                   </div>
                 </div>
@@ -141,12 +146,13 @@ class App extends React.Component {
             </div>
           </div>
         </StickyHeader>
-        <main className="eapp-structure-wrap">
+        <main className={klassMain}>
           <div className="eapp-structure-row">
             <div className={klassNavigation}>
               <Sticky options={{tolerance: 400, ignoreWindowComparison: true}}>
                 <ScoreCard />
                 <Navigation />
+                <button onClick={this.showInstructions} className="instructions mobile-visible"><span>{i18n.t('app.instructions')}</span></button>
               </Sticky>
               &nbsp;
             </div>

--- a/src/components/Navigation/NavigationToggle.jsx
+++ b/src/components/Navigation/NavigationToggle.jsx
@@ -8,39 +8,29 @@ import AuthenticatedView from '../../views/AuthenticatedView'
 export class NavigationToggle extends React.Component {
   constructor (props) {
     super(props)
-    this.logout = this.logout.bind(this)
     this.toggle = this.toggle.bind(this)
   }
 
-  logout () {
-    this.props.dispatch(logout())
-    window.location = window.location.pathname
+  toggle () {
+    this.props.dispatch(updateApplication('Settings', 'mobileNavigation', !this.isOpen()))
   }
 
-  toggle () {
-    const open = this.props.settings.mobileNavigation || false
-    this.props.dispatch(updateApplication('Settings', 'mobileNavigation', !open))
+  isOpen () {
+    return this.props.settings.mobileNavigation || false
   }
 
   render () {
-    if (this.props.settings.mobileNavigation) {
-      return (
-        <div className="navigation-override mobile-visible">
-          <a href="javascript:;;" className="logout" onClick={this.logout}>
-            <span>{i18n.t('app.logout')}</span>
-          </a>
-          <a href="javascript:;;" className="navigation-toggle" onClick={this.toggle}>
-            <i className="fa fa-times" aria-hidden="true"></i>
-            <span>Close navigation</span>
-          </a>
-        </div>
-      )
-    }
-
+    const open = this.isOpen()
+    const title = open ? 'Close navigation' : 'Open navigation'
+    const icon = `fa ${open ? 'fa-times' : 'fa-bars'}`
     return (
-      <a href="javascript:;;" className="navigation-toggle desktop-hidden tablet-hidden mobile-visible" onClick={this.toggle}>
-        <i className="fa fa-bars" aria-hidden="true"></i>
-        <span>Navigation</span>
+      <a href="javascript:;;"
+         className="navigation-toggle mobile-visible"
+         title={title}
+         aria-label={title}
+         onClick={this.toggle}>
+        <i className={icon}
+           aria-hidden="true"></i>
       </a>
     )
   }

--- a/src/components/Navigation/NavigationToggle.scss
+++ b/src/components/Navigation/NavigationToggle.scss
@@ -1,22 +1,14 @@
 .navigation-toggle {
   position: absolute;
   top: 0;
-  right: 0;
+  left: 0;
   padding-top: 1.7rem;
+  padding-left: 1.7rem;
+  padding-right: 1.7rem;
   height: 5.5rem;
-  width: 50%;
-  text-align: center;
-  background-color: #194b88;
 
-  @media only screen and (max-width: 350px) {
-    text-align: right;
-    width: 2rem;
-    padding-right: 4rem;
-
-    > span {
-      display: none !important;
-      visibility: hidden;
-    }
+  .fa.fa-times {
+    font-size: 1.9rem;
   }
 
   &:hover,

--- a/src/components/Navigation/NavigationToggle.test.jsx
+++ b/src/components/Navigation/NavigationToggle.test.jsx
@@ -9,19 +9,6 @@ import AuthenticatedNavigationToggle, { NavigationToggle } from './NavigationTog
 describe('The navigation toggle component', () => {
   window.token = 'fake-token'
 
-  it('can logout', () => {
-    let dispatched = 0
-    const props = {
-      dispatch: () => { dispatched++ },
-      settings: {
-        mobileNavigation: true
-      }
-    }
-    const component = mount(<NavigationToggle {...props} />)
-    component.find('.logout').simulate('click')
-    expect(dispatched).toEqual(1)
-  })
-
   it('can toggle', () => {
     let dispatched = 0
     const props = {
@@ -45,7 +32,7 @@ describe('The navigation toggle component', () => {
     expect(component.find('.navigation-override').length).toBe(0)
   })
 
-  it('visible when authenticated and mobile', () => {
+  it('visible when authenticated', () => {
     const middlewares = [ thunk ]
     const mockStore = configureMockStore(middlewares)
     const store = mockStore({
@@ -60,10 +47,10 @@ describe('The navigation toggle component', () => {
       }
     })
     const component = mount(<Provider store={store}><AuthenticatedNavigationToggle /></Provider>)
-    expect(component.find('.navigation-override').length).toBe(1)
+    expect(component.find('.navigation-toggle').length).toBe(1)
   })
 
-  it('hidden when not authenticated and mobile', () => {
+  it('hidden when not authenticated', () => {
     window.token = ''
     const middlewares = [ thunk ]
     const mockStore = configureMockStore(middlewares)
@@ -76,7 +63,7 @@ describe('The navigation toggle component', () => {
       }
     })
     const component = mount(<Provider store={store}><AuthenticatedNavigationToggle /></Provider>)
-    expect(component.find('.navigation-override').length).toBe(0)
+    expect(component.find('.navigation-toggle').length).toBe(0)
     window.token = 'fake-token'
   })
 })

--- a/src/components/ScoreCard/ScoreCard.jsx
+++ b/src/components/ScoreCard/ScoreCard.jsx
@@ -21,9 +21,9 @@ class ScoreCard extends React.Component {
 }
 
 function mapStateToProps (state) {
-  let section = state.section || {}
-  let app = state.application || {}
-  let completed = app.Completed || {}
+  const section = state.section || {}
+  const app = state.application || {}
+  const completed = app.Completed || {}
   return {
     application: app,
     section: section,

--- a/src/components/SectionTitle/SectionTitle.jsx
+++ b/src/components/SectionTitle/SectionTitle.jsx
@@ -16,6 +16,10 @@ import { navigation } from '../../config'
  */
 class SectionTitle extends React.Component {
   render () {
+    if (this.props.hidden) {
+      return null
+    }
+
     const splitSubsections = (this.props.section.subsection || '').split('/')
 
     let title = null
@@ -66,6 +70,10 @@ function mapStateToProps (state) {
   return {
     section: section
   }
+}
+
+SectionTitle.defaultProps = {
+  hidden: false
 }
 
 // Wraps the the component with connect() which adds the dispatch()

--- a/src/sass/desktop.scss
+++ b/src/sass/desktop.scss
@@ -1,4 +1,16 @@
-.desktop-hidden {
-  display: none !important;
+.desktop-visible {
+  display: none;
   visibility: hidden;
+}
+
+@media only screen and (min-width: 1413px) {
+  .desktop-visible {
+    display: block !important;
+    visibility: visible !important;
+  }
+
+  .desktop-hidden {
+    display: none !important;
+    visibility: hidden;
+  }
 }

--- a/src/sass/eqip.scss
+++ b/src/sass/eqip.scss
@@ -127,12 +127,9 @@ a:focus {
         vertical-align: middle;
       }
 
-      span {
+      .eapp-logo-text {
         display: inline-block;
         margin-left: 2rem;
-      }
-
-      .eapp-logo-text {
         font-size: 3rem;
         font-weight: $eapp-bold;
         margin-top: 4.7rem;
@@ -182,7 +179,7 @@ a:focus {
   }
 }
 
-@media screen and (min-width: 850px) {
+@media screen and (min-width: 1001px) {
   .sticky-header {
     .header-container {
       height: 16.7rem;

--- a/src/sass/phone.scss
+++ b/src/sass/phone.scss
@@ -147,23 +147,25 @@
         display: block;
 
         > .eapp-logo {
+          display: block;
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
           width: 100%;
           height: 5.5rem;
-          display: inline-block;
+          z-index: 100;
 
-          > .eapp-logo-icon {
-            width: 3.5rem;
+          .eapp-logo-icon {
+            width: 3.2rem;
             height: auto;
-            margin-left: 1rem;
+            margin-left: 0;
             vertical-align: text-bottom;
           }
 
-          span {
-            margin-left: 1rem;
-          }
-
-          > .eapp-logo-text {
+          .eapp-logo-text {
             margin-top: 1rem;
+            margin-left: 1rem;
           }
         }
 
@@ -171,9 +173,29 @@
           padding: 1rem;
           display: block;
           height: auto;
+          margin-top: 5.5rem;
+
+          > .eapp-logout {
+            position: fixed;
+            top: 0;
+            right: 0;
+
+            > a {
+              padding: 1.7rem;
+            }
+          }
 
           > .title {
             margin: 0;
+          }
+        }
+      }
+
+      &.mobile-navigation {
+        > .eapp-structure-row {
+          > .eapp-title {
+            padding: 0;
+            margin-top: 0.5rem;
           }
         }
       }
@@ -189,8 +211,71 @@
     }
 
     .form-navigation {
+      transform: translateX(-100%);
+      -webkit-transform: translateX(-100%);
+
       .section-name {
         max-width: 88%;
+      }
+    }
+
+    &.mobile-visible {
+      padding-left: 1.6rem;
+      padding-right: 1.6rem;
+
+      .score-card {
+        font-size: 2.8rem;
+        padding-bottom: 1rem;
+        padding-left: 2.1rem;
+        text-align: left;
+
+        > .score-card-done,
+        > .score-card-total,
+        > .score-card-text {
+          display: inline-block;
+          line-height: normal;
+        }
+
+        > .score-card-done,
+        > .score-card-total {
+          font-size: 2.6rem;
+        }
+
+        > .score-card-text {
+          font-size: 1.9rem;
+          margin-left: 1rem;
+        }
+      }
+
+      .form-navigation {
+        animation: slide-out 0.5s forwards;
+        -webkit-animation: slide-out 0.5s forwards;
+
+        @keyframes slide-out {
+          0% { transform: translateX(-100%); }
+          100% { transform: translateX(0%); }
+        }
+
+        @-webkit-keyframes slide-out {
+          0% { transform: translateX(-100%); }
+          100% { transform: translateX(0%); }
+        }
+      }
+
+      .instructions {
+        margin-top: 3rem;
+        margin-bottom: 4rem;
+        margin-left: 2rem;
+        width: auto;
+        text-align: left;
+        background: none;
+        font-weight: initial;
+        font-size: 1.6rem;
+
+        > span {
+          color: #0071bc;
+          border-bottom: 1px dashed #0071bc;
+        }
       }
     }
   }

--- a/src/sass/tablet.scss
+++ b/src/sass/tablet.scss
@@ -40,6 +40,11 @@
 }
 
 @media only screen and (max-width: 1250px) {
+  .tablet-hidden {
+    display: block !important;
+    visibility: visible;
+  }
+
   .accordion {
     margin: 0;
   }


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2099

 - [x] Fixes navigation button being present
 - [x] Updates styles to most recent design comps
 - [x] Added instructions link to bottom of navigation
 - [x] "Slide-out" animation
 - [x] Main navigation is **fixed** to top
 - [x] Fixes bugs transitioning form factors while nav is open

## Navigation opened
![image](https://user-images.githubusercontent.com/697855/37164691-070e0894-22c9-11e8-8325-bdab9054cd9f.png)

## Navigation closed
![image](https://user-images.githubusercontent.com/697855/37164679-00724bbc-22c9-11e8-9b9c-e30a1fbbb99c.png)

## Added instructions link to bottom of navigation
![image](https://user-images.githubusercontent.com/697855/37164670-f8354c42-22c8-11e8-96cd-1e06a063320a.png)
