### PR TITLE
Trigger an immediate error update for checkboxes

### DIFF
--- a/src/components/Form/Checkbox/Checkbox.jsx
+++ b/src/components/Form/Checkbox/Checkbox.jsx
@@ -39,6 +39,8 @@ export default class Checkbox extends ValidationElement {
           checked: checked
         })
       }
+
+      this.handleValidation()
     })
   }
 


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2315

The validation was only being triggered on **blur** so the error message was not refreshing immediately.