### PR TITLE
Nine digit zipcodes

### DIFF
--- a/api/geo/usps.go
+++ b/api/geo/usps.go
@@ -315,6 +315,7 @@ func (address *USPSAddress) ToResult(geoValues Values) (result Result) {
 
 	// Check if there are deviations between what was requested versus what
 	// was returned. If we find any, mark result as Partial
+	ziplength := len(geoValues.Zipcode)
 	switch {
 	case address.ReturnText != "":
 		fallthrough
@@ -326,7 +327,11 @@ func (address *USPSAddress) ToResult(geoValues Values) (result Result) {
 		fallthrough
 	case !strings.EqualFold(result.State, geoValues.State):
 		fallthrough
-	case !strings.EqualFold(result.Zipcode, geoValues.Zipcode):
+	case ziplength < 5:
+		fallthrough
+	case ziplength >= 5 && !strings.EqualFold(result.Zipcode, geoValues.Zipcode[0:5]):
+		fallthrough
+	case ziplength > 5 && !strings.EqualFold(address.Zip4, geoValues.Zipcode[ziplength-4:ziplength]):
 		result.Partial = true
 	}
 

--- a/src/components/Form/Location/AddressSuggestion.jsx
+++ b/src/components/Form/Location/AddressSuggestion.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { countryString } from '../../../validators/location'
 
 /**
  * Helper component that renders address information found
@@ -6,7 +7,7 @@ import React from 'react'
 export function AddressSuggestion (props) {
   const suggestion = props.suggestion
   const current = props.current
-  const country = (current.country || {}).value
+  const country = countryString(current.country)
 
   switch (country) {
     case 'United States':

--- a/src/components/Form/ZipCode/ZipCode.jsx
+++ b/src/components/Form/ZipCode/ZipCode.jsx
@@ -38,7 +38,7 @@ export default class ZipCode extends ValidationElement {
             label={this.props.label}
             placeholder={this.props.placeholder}
             className={this.props.className}
-            pattern="^\d{5}(?:[-\s]\d{4})?$"
+            pattern="^\d{5}(?:[-\s]{0,1}\d{4})?$"
             required={this.props.required}
             disabled={this.props.disabled}
             value={this.state.value}

--- a/src/config/locales/en/error.js
+++ b/src/config/locales/en/error.js
@@ -658,7 +658,7 @@ export const error = {
         pattern: {
           title: 'There is a problem with the ZIP Code',
           message: 'The ZIP Code should be either 5 or 9 digits.',
-          note: ''
+          note: 'Note: A 9 digit zip code should be in the following format #####-####.'
         }
       },
       country: {

--- a/src/validators/location.js
+++ b/src/validators/location.js
@@ -80,7 +80,8 @@ export default class LocationValidator {
     if (!this.zipcode) {
       return false
     }
-    return this.zipcode.length === 5
+    const withoutDashes = this.zipcode.replace('-', '').length
+    return withoutDashes === 5 || withoutDashes === 9
   }
 
   validCounty () {


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#1786

Updated logic to allow for validation of 9-digit zip codes whereas
previously it was only 5-digit zip codes. In addition to when it was
triggered also updated the backend logic to check for the 9-digit in
its validation as well.

Also added additional context to zip code error message.

![image](https://user-images.githubusercontent.com/697855/37417069-be1445a6-2785-11e8-9190-7f51b57e13d6.png)
