### PR TITLE
Current address usage in marital section

### DIFF
--- a/api/db/migrations/20180315110413_use_current_address.sql
+++ b/api/db/migrations/20180315110413_use_current_address.sql
@@ -1,0 +1,12 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- +goose StatementBegin
+ALTER TABLE civil_unions ADD COLUMN use_current_address_id bigint REFERENCES not_applicables(id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+-- +goose StatementBegin
+ALTER TABLE civil_unions DROP COLUMN IF EXISTS use_current_address_id;
+-- +goose StatementEnd

--- a/api/model/form/civilunion.go
+++ b/api/model/form/civilunion.go
@@ -24,6 +24,7 @@ type CivilUnion struct {
 	PayloadSSN                           Payload `json:"SSN" sql:"-"`
 	PayloadSeparated                     Payload `json:"Separated" sql:"-"`
 	PayloadTelephone                     Payload `json:"Telephone" sql:"-"`
+	PayloadUseCurrentAddress             Payload `json:"UseCurrentAddress" sql:"-"`
 
 	// Validator specific fields
 	Address                       *Location            `json:"-"`
@@ -42,6 +43,7 @@ type CivilUnion struct {
 	SSN                           *SSN                 `json:"-" sql:"-"`
 	Separated                     *Branch              `json:"-"`
 	Telephone                     *Telephone           `json:"-"`
+	UseCurrentAddress             *NotApplicable       `json:"-"`
 
 	// Persister specific fields
 	ID                              int `json:"-" sql:",pk"`
@@ -62,6 +64,7 @@ type CivilUnion struct {
 	SSNID                           int `json:"-"`
 	SeparatedID                     int `json:"-"`
 	TelephoneID                     int `json:"-"`
+	UseCurrentAddressID             int `json:"-"`
 }
 
 // Unmarshal bytes in to the entity properties.
@@ -167,6 +170,12 @@ func (entity *CivilUnion) Unmarshal(raw []byte) error {
 	}
 	entity.Telephone = telephone.(*Telephone)
 
+	useCurrentAddress, err := entity.PayloadUseCurrentAddress.Entity()
+	if err != nil {
+		return err
+	}
+	entity.UseCurrentAddress = useCurrentAddress.(*NotApplicable)
+
 	return err
 }
 
@@ -219,6 +228,9 @@ func (entity *CivilUnion) Marshal() Payload {
 	}
 	if entity.Telephone != nil {
 		entity.PayloadTelephone = entity.Telephone.Marshal()
+	}
+	if entity.UseCurrentAddress != nil {
+		entity.PayloadUseCurrentAddress = entity.UseCurrentAddress.Marshal()
 	}
 	return MarshalPayloadEntity("civilunion", entity)
 }
@@ -302,6 +314,11 @@ func (entity *CivilUnion) Valid() (bool, error) {
 	}
 	if entity.Telephone != nil {
 		if ok, err := entity.Telephone.Valid(); !ok {
+			return false, err
+		}
+	}
+	if entity.UseCurrentAddress != nil {
+		if ok, err := entity.UseCurrentAddress.Valid(); !ok {
 			return false, err
 		}
 	}
@@ -398,6 +415,11 @@ func (entity *CivilUnion) Save(context *db.DatabaseContext, account int) (int, e
 		}
 		entity.Telephone.ID = previous.TelephoneID
 		entity.TelephoneID = previous.TelephoneID
+		if entity.UseCurrentAddress == nil {
+			entity.UseCurrentAddress = &NotApplicable{}
+		}
+		entity.UseCurrentAddress.ID = previous.UseCurrentAddressID
+		entity.UseCurrentAddressID = previous.UseCurrentAddressID
 	})
 
 	addressID, err := entity.Address.Save(context, account)
@@ -496,6 +518,12 @@ func (entity *CivilUnion) Save(context *db.DatabaseContext, account int) (int, e
 	}
 	entity.TelephoneID = telephoneID
 
+	useCurrentAddressID, err := entity.UseCurrentAddress.Save(context, account)
+	if err != nil {
+		return useCurrentAddressID, err
+	}
+	entity.UseCurrentAddressID = useCurrentAddressID
+
 	if err := context.Save(entity); err != nil {
 		return entity.ID, err
 	}
@@ -593,6 +621,11 @@ func (entity *CivilUnion) Delete(context *db.DatabaseContext, account int) (int,
 		}
 		entity.Telephone.ID = previous.TelephoneID
 		entity.TelephoneID = previous.TelephoneID
+		if entity.UseCurrentAddress == nil {
+			entity.UseCurrentAddress = &NotApplicable{}
+		}
+		entity.UseCurrentAddress.ID = previous.UseCurrentAddressID
+		entity.UseCurrentAddressID = previous.UseCurrentAddressID
 	})
 
 	if entity.ID != 0 {
@@ -647,6 +680,9 @@ func (entity *CivilUnion) Delete(context *db.DatabaseContext, account int) (int,
 		return entity.ID, err
 	}
 	if _, err := entity.Telephone.Delete(context, account); err != nil {
+		return entity.ID, err
+	}
+	if _, err := entity.UseCurrentAddress.Delete(context, account); err != nil {
 		return entity.ID, err
 	}
 
@@ -743,6 +779,11 @@ func (entity *CivilUnion) Get(context *db.DatabaseContext, account int) (int, er
 		}
 		entity.Telephone.ID = previous.TelephoneID
 		entity.TelephoneID = previous.TelephoneID
+		if entity.UseCurrentAddress == nil {
+			entity.UseCurrentAddress = &NotApplicable{}
+		}
+		entity.UseCurrentAddress.ID = previous.UseCurrentAddressID
+		entity.UseCurrentAddressID = previous.UseCurrentAddressID
 	})
 
 	if entity.ID != 0 {
@@ -828,6 +869,11 @@ func (entity *CivilUnion) Get(context *db.DatabaseContext, account int) (int, er
 	}
 	if entity.TelephoneID != 0 {
 		if _, err := entity.Telephone.Get(context, account); err != nil {
+			return entity.ID, err
+		}
+	}
+	if entity.UseCurrentAddressID != 0 {
+		if _, err := entity.UseCurrentAddress.Get(context, account); err != nil {
 			return entity.ID, err
 		}
 	}

--- a/api/model/form/templates/spouse-present-marriage.xml
+++ b/api/model/form/templates/spouse-present-marriage.xml
@@ -14,7 +14,7 @@
       </PhysicalLocation>
     </APOFPO>
     {{else}}
-    <Address UseMyCurrentAddress="{{checkboxTrueFalse $Item.UseCurrentAddress}}">
+    <Address UseMyCurrentAddress="{{notApplicable $Item.UseCurrentAddress}}">
       {{location $Item.Address}}
     </Address>
     {{end}}

--- a/api/model/form/testdata/civilunion.json
+++ b/api/model/form/testdata/civilunion.json
@@ -249,9 +249,9 @@
       }
     },
     "UseCurrentAddress": {
-      "type": "checkbox",
+      "type": "notapplicable",
       "props": {
-        "checked": false
+        "applicable": true
       }
     }
   }

--- a/api/model/form/testdata/relationships-status-marital.json
+++ b/api/model/form/testdata/relationships-status-marital.json
@@ -259,9 +259,9 @@
           }
         },
         "UseCurrentAddress": {
-          "type": "checkbox",
+          "type": "notapplicable",
           "props": {
-            "checked": false
+            "applicable": true
           }
         }
       }

--- a/api/model/form/testdata/spouse-present-marriage.json
+++ b/api/model/form/testdata/spouse-present-marriage.json
@@ -247,9 +247,9 @@
     }
   },
   "UseCurrentAddress": {
-    "type": "checkbox",
+    "type": "notapplicable",
     "props": {
-      "checked": false
+      "applicable": true
     }
   }
 }

--- a/src/components/Form/Dropdown/Dropdown.jsx
+++ b/src/components/Form/Dropdown/Dropdown.jsx
@@ -95,14 +95,24 @@ export default class Dropdown extends ValidationElement {
 
   componentWillReceiveProps (next) {
     if (next.receiveProps) {
-      if (next.value !== undefined && next.value !== this.state.value) {
-        const errors = this.errors(next.value)
-        this.setState({
-          value: next.value,
-          error: errors.some(x => x.valid === false),
-          valid: errors.every(x => x.valid === true)
-        })
+      let updates = {}
+
+      if (next.value !== this.state.value) {
+        updates = { ...updates, value: next.value }
       }
+
+      // If disabled, we clear the value and clear state
+      if (next.disabled) {
+        updates = { value: '', valid: null, error: null }
+      }
+
+      if (updates.value !== undefined && updates.value !== this.state.value) {
+        const errors = this.errors(updates.value)
+        updates.error = errors.some(x => x.valid === false)
+        updates.valid = errors.every(x => x.valid === true)
+      }
+
+      this.setState(updates)
     }
   }
 

--- a/src/components/Section/Citizenship/Citizenship.jsx
+++ b/src/components/Section/Citizenship/Citizenship.jsx
@@ -16,8 +16,8 @@ class Citizenship extends SectionElement {
       <div>
         <SectionViews current={this.props.subsection} dispatch={this.props.dispatch} update={this.props.update}>
           <SectionView name="intro"
-                       back="history/review"
-                       backLabel={i18n.t('history.destination.review')}
+                       back="relationships/review"
+                       backLabel={i18n.t('relationships.destination.review')}
                        next="citizenship/status"
                        nextLabel={i18n.t('citizenship.destination.status')}>
             <div>

--- a/src/components/Section/History/History.jsx
+++ b/src/components/Section/History/History.jsx
@@ -326,8 +326,8 @@ class History extends SectionElement {
       <div className="history">
         <SectionViews current={this.props.subsection} dispatch={this.props.dispatch} update={this.props.update}>
           <SectionView name="intro"
-                       back="relationships/review"
-                       backLabel={i18n.t('relationships.destination.review')}
+                       back="identification/review"
+                       backLabel={i18n.t('identification.destination.review')}
                        next="history/residence"
                        nextLabel={i18n.t('history.destination.residence')}>
             <Field title={i18n.t('history.intro.title')}
@@ -344,8 +344,8 @@ class History extends SectionElement {
                        showTop={true}
                        back="history/federal"
                        backLabel={i18n.t('history.destination.federal')}
-                       next="citizenship/intro"
-                       nextLabel={i18n.t('citizenship.destination.intro')}>
+                       next="relationships/intro"
+                       nextLabel={i18n.t('relationships.destination.intro')}>
             { this.residenceSummaryProgress() }
             { this.employmentSummaryProgress() }
             <Show when={(this.props.Education.HasAttended || {}).value === 'Yes' || (this.props.Education.HasDegree10 || {}).value === 'Yes'}>

--- a/src/components/Section/Identification/Identification.jsx
+++ b/src/components/Section/Identification/Identification.jsx
@@ -34,10 +34,10 @@ class Identification extends SectionElement {
                        title={i18n.t('review.title')}
                        para={i18n.m('review.para')}
                        showTop={true}
-                       next="relationships/intro"
-                       nextLabel={i18n.t('relationships.destination.intro')}
                        back="identification/physical"
-                       backLabel={i18n.t('identification.destination.physical')}>
+                       backLabel={i18n.t('identification.destination.physical')}
+                       next="history/intro"
+                       nextLabel={i18n.t('history.destination.intro')}>
             <ApplicantName name="name"
                            {...this.props.ApplicantName}
                            section="identification"

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.jsx
@@ -107,7 +107,6 @@ export default class CivilUnion extends ValidationElement {
 
   updateAddress (values) {
     this.update({
-      UseCurrentAddress: false,
       Address: values
     })
   }
@@ -161,14 +160,9 @@ export default class CivilUnion extends ValidationElement {
   }
 
   updateUseCurrentAddress (values) {
-    if (values.checked) {
-      this.updateAddress(this.props.currentAddress)
-    } else {
-      this.updateAddress({})
-    }
-
     this.update({
-      UseCurrentAddress: values
+      UseCurrentAddress: values,
+      Address: !values.applicable ? {...this.props.currentAddress} : {}
     })
   }
 
@@ -334,31 +328,45 @@ export default class CivilUnion extends ValidationElement {
                       />
           </Field>
 
-          <Field title={i18n.t('relationships.civilUnion.heading.address')}
+          <Field title={i18n.t(`relationships.civilUnion.heading.address${this.props.currentAddress ? '' : 'WithoutCurrent'}`)}
                  optional={true}
                  help="relationships.civilUnion.help.address"
                  scrollIntoView={this.props.scrollIntoView}
                  adjustFor="address">
             <Show when={this.props.currentAddress}>
-              <Checkbox name="current_address"
-                        className="current-address"
-                        label="Use current address"
-                        {...this.props.UseCurrentAddress}
-                        onUpdate={this.updateUseCurrentAddress}
+              <NotApplicable name="UseCurrentAddress"
+                             {...this.props.UseCurrentAddress}
+                             className="current-address"
+                             label={i18n.t('relationships.civilUnion.useCurrentAddress.label')}
+                             or={i18n.m('relationships.civilUnion.useCurrentAddress.or')}
+                             onUpdate={this.updateUseCurrentAddress}
+                             onError={this.props.onError}>
+                <Location name="Address"
+                          {...this.props.Address}
+                          layout={Location.ADDRESS}
+                          geocode={true}
+                          addressBooks={this.props.addressBooks}
+                          addressBook="Relative"
+                          dispatch={this.props.dispatch}
+                          onUpdate={this.updateAddress}
+                          onError={this.props.onError}
+                          required={this.props.required}
+                          />
+              </NotApplicable>
+            </Show>
+            <Show when={!this.props.currentAddress}>
+              <Location name="Address"
+                        {...this.props.Address}
+                        layout={Location.ADDRESS}
+                        geocode={true}
+                        addressBooks={this.props.addressBooks}
+                        addressBook="Relative"
+                        dispatch={this.props.dispatch}
+                        onUpdate={this.updateAddress}
                         onError={this.props.onError}
+                        required={this.props.required}
                         />
             </Show>
-            <Location name="Address"
-                      {...this.props.Address}
-                      layout={Location.ADDRESS}
-                      geocode={true}
-                      addressBooks={this.props.addressBooks}
-                      addressBook="Relative"
-                      dispatch={this.props.dispatch}
-                      onUpdate={this.updateAddress}
-                      onError={this.props.onError}
-                      required={this.props.required}
-                      />
           </Field>
 
           <Field title={i18n.t('relationships.civilUnion.heading.telephone')}
@@ -467,7 +475,7 @@ CivilUnion.defaultProps = {
     applicable: true
   },
   Divorced: {},
-  UseCurrentAddress: false,
+  UseCurrentAddress: {},
   addressBooks: {},
   dispatch: (action) => {},
   onUpdate: (queue) => {},

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.scss
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.scss
@@ -1,9 +1,0 @@
-.civil-union {
-  .current-address {
-    label {
-      width: 20rem;
-      margin-bottom: 2.1rem;
-      margin-top: 2.1rem;
-    }
-  }
-}

--- a/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
+++ b/src/components/Section/Relationships/RelationshipStatus/CivilUnion.test.jsx
@@ -64,10 +64,10 @@ describe('The civil union component', () => {
     }
 
     const component = mount(<CivilUnion {...expected} />)
-    expect(component.find('.current-address').length).toEqual(1)
-    component.find('.current-address input').simulate('change')
-    expect(updates).toBe(2)
-    component.find('.current-address input').simulate('change')
-    expect(component.find('.current-address label.checked').length).toEqual(0)
+    expect(component.find('.current-address.button').length).toEqual(1)
+    component.find('.current-address.button input').simulate('change')
+    expect(updates).toBe(1)
+    component.find('.current-address.button input').simulate('change')
+    expect(component.find('.current-address.button label.checked').length).toEqual(0)
   })
 })

--- a/src/components/Section/Relationships/Relationships.jsx
+++ b/src/components/Section/Relationships/Relationships.jsx
@@ -52,8 +52,8 @@ class Relationships extends SectionElement {
       <div>
         <SectionViews current={this.props.subsection} dispatch={this.props.dispatch} update={this.props.update}>
           <SectionView name="intro"
-                       back="identification/review"
-                       backLabel={i18n.t('identification.destination.review')}
+                       back="history/review"
+                       backLabel={i18n.t('history.destination.review')}
                        next="relationships/status/marital"
                        nextLabel={i18n.t('relationships.destination.marital')}>
             <Field title={i18n.t('relationships.intro.title')}
@@ -132,8 +132,8 @@ class Relationships extends SectionElement {
                        showTop={true}
                        back="relationships/relatives"
                        backLabel={i18n.t('relationships.destination.relatives')}
-                       next="history/intro"
-                       nextLabel={i18n.t('history.destination.intro')}>
+                       next="citizenship/intro"
+                       nextLabel={i18n.t('citizenship.destination.intro')}>
             <Marital name="marital"
                      {...this.props.Marital}
                      section="relationships"

--- a/src/config/locales/en/relationships.js
+++ b/src/config/locales/en/relationships.js
@@ -357,6 +357,7 @@ export const relationships = {
       citizenship: 'Provide this person\'s country(ies) of citizenship',
       location: 'Provide the location',
       address: 'Provide this person\'s current address, if different than your current address',
+      addressWithoutCurrent: 'Provide this person\'s current address',
       telephone: 'Provide this person\'s telephone number',
       email: 'Provide this person\'s email address',
       separated: 'Are you separated?',
@@ -369,6 +370,10 @@ export const relationships = {
     notApplicable: {
       or: 'or',
       label: 'Not applicable'
+    },
+    useCurrentAddress: {
+      or: 'or',
+      label: 'Use my current address'
     },
     deceasedAddressNotApplicable: {
       or: 'or',

--- a/src/config/navigation.js
+++ b/src/config/navigation.js
@@ -21,6 +21,22 @@ const navigation = [
     ]
   },
   {
+    name: 'Your history',
+    title: 'Your history',
+    url: 'history',
+    store: 'History',
+    showNumber: true,
+    locked: validators.formIsLocked,
+    subsections: [
+      { exclude: true, name: 'Introduction', url: 'intro' },
+      { name: 'Where you have lived', url: 'residence', store: 'Residence', validator: validators.HistoryResidenceValidator },
+      { name: 'Employment activities', url: 'employment', store: 'Employment', validator: validators.HistoryEmploymentValidator },
+      { name: 'Where you went to school', url: 'education', store: 'Education', validator: validators.HistoryEducationValidator },
+      { name: 'Former federal service', url: 'federal', store: 'Federal', validator: validators.FederalServiceValidator },
+      { exclude: true, name: 'Review', url: 'review' }
+    ]
+  },
+  {
     name: 'Relationships',
     title: 'Relationships',
     url: 'relationships',
@@ -39,22 +55,6 @@ const navigation = [
       },
       { name: 'People who know you well', url: 'people', store: 'People', validator: validators.PeopleValidator },
       { name: 'Relatives', url: 'relatives', store: 'Relatives', validator: validators.RelativesValidator },
-      { exclude: true, name: 'Review', url: 'review' }
-    ]
-  },
-  {
-    name: 'Your history',
-    title: 'Your history',
-    url: 'history',
-    store: 'History',
-    showNumber: true,
-    locked: validators.formIsLocked,
-    subsections: [
-      { exclude: true, name: 'Introduction', url: 'intro' },
-      { name: 'Where you have lived', url: 'residence', store: 'Residence', validator: validators.HistoryResidenceValidator },
-      { name: 'Employment activities', url: 'employment', store: 'Employment', validator: validators.HistoryEmploymentValidator },
-      { name: 'Where you went to school', url: 'education', store: 'Education', validator: validators.HistoryEducationValidator },
-      { name: 'Former federal service', url: 'federal', store: 'Federal', validator: validators.FederalServiceValidator },
       { exclude: true, name: 'Review', url: 'review' }
     ]
   },

--- a/src/reducers/history.js
+++ b/src/reducers/history.js
@@ -18,12 +18,13 @@ const history = function (state = {}, action) {
 }
 
 export const populateCurrentAddress = (history) => {
-  if (!history.Residence || !history.Residence.length) {
+  const items = (((history || {}).Residence || {}).List || {}).items || []
+  if (items.length === 0) {
     return history
   }
 
   let found = false
-  for (let r of history.Residence) {
+  for (let r of items) {
     if (!r.Item) {
       continue
     }

--- a/src/reducers/history.test.js
+++ b/src/reducers/history.test.js
@@ -74,7 +74,6 @@ describe('History Reducer', function () {
           ]
         },
         expected: {
-          CurrentAddress: null,
           Residence: [
             {
               Item: null
@@ -99,7 +98,6 @@ describe('History Reducer', function () {
           ]
         },
         expected: {
-          CurrentAddress: null,
           Residence: [
             {
               Item: {
@@ -126,7 +124,6 @@ describe('History Reducer', function () {
           ]
         },
         expected: {
-          CurrentAddress: null,
           Residence: [
             {
               Item: {
@@ -156,7 +153,6 @@ describe('History Reducer', function () {
           ]
         },
         expected: {
-          CurrentAddress: {},
           Residence: [
             {
               Item: {

--- a/src/schema/form/civilunion.js
+++ b/src/schema/form/civilunion.js
@@ -39,6 +39,7 @@ export const civilunion = (data = {}) => {
     })),
     SSN: ssn(data.SSN),
     Separated: branch(data.Separated),
-    Telephone: telephone(data.Telephone)
+    Telephone: telephone(data.Telephone),
+    UseCurrentAddress: notapplicable(data.UseCurrentAddress)
   })
 }

--- a/src/schema/section/relationships-marital.test.js
+++ b/src/schema/section/relationships-marital.test.js
@@ -47,7 +47,8 @@ describe('Schema for financial taxes', () => {
         },
         SSN: {},
         Separated: {},
-        Telephone: {}
+        Telephone: {},
+        UseCurrentAddress: {}
       },
       DivorcedList: {
         branch: { value: 'No' },

--- a/src/views/Form/Form.scss
+++ b/src/views/Form/Form.scss
@@ -370,6 +370,7 @@ select {
       &.usa-input-focus,
       &.checked,
       &:hover {
+        color: $eapp-grey-dark;
         background: $eapp-grey-light;
       }
     }


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2262

Updated the history reducer to capture the first `present` address as
the current address. In addition to this we changed the location and
behavior of the "Use my current address" button to follow a similar
pattern and style used throughout the rest of the application.

## With no current address found
![image](https://user-images.githubusercontent.com/697855/37474535-eeb6701e-2846-11e8-9a99-91bb6f1ec0c3.png)

## With current address found
![image](https://user-images.githubusercontent.com/697855/37474550-f5dc005c-2846-11e8-9012-8e7d50997a1a.png)

## Current address selected
![image](https://user-images.githubusercontent.com/697855/37474559-fbfb9af6-2846-11e8-871b-48ff758a037f.png)
