### PR TITLE
If a date is NA for direct/indirect control then no explanation req

### DIFF
--- a/src/components/Section/Foreign/Activities/DirectActivity/DirectInterest.jsx
+++ b/src/components/Section/Foreign/Activities/DirectActivity/DirectInterest.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { i18n } from '../../../../../config'
-import { ValidationElement, Currency, Field, Text, DateControl, Textarea, NotApplicable, Checkbox, CheckboxGroup } from '../../../../Form'
+import { ValidationElement, Currency, Field, Text, DateControl, Textarea,
+         NotApplicable, Checkbox, CheckboxGroup, Show} from '../../../../Form'
 import CoOwners from '../CoOwners'
 
 export default class DirectInterest extends ValidationElement {
@@ -104,7 +105,8 @@ export default class DirectInterest extends ValidationElement {
 
   updateRelinquishedNotApplicable (values) {
     this.update({
-      RelinquishedNotApplicable: values
+      RelinquishedNotApplicable: values,
+      Explanation: values.applicable ? this.props.Explanation : {}
     })
   }
 
@@ -267,16 +269,18 @@ export default class DirectInterest extends ValidationElement {
           </NotApplicable>
         </Field>
 
-        <Field title={i18n.t('foreign.activities.direct.interest.heading.explanation')}
-               scrollIntoView={this.props.scrollIntoView}>
-          <Textarea name="Explanation"
-                    className="explanation"
-                    {...this.props.Explanation}
-                    onUpdate={this.updateExplanation}
-                    onError={this.props.onError}
-                    required={this.props.required}
-                    />
-        </Field>
+        <Show when={(this.props.RelinquishedNotApplicable || {}).applicable}>
+          <Field title={i18n.t('foreign.activities.direct.interest.heading.explanation')}
+                 scrollIntoView={this.props.scrollIntoView}>
+            <Textarea name="Explanation"
+                      className="explanation"
+                      {...this.props.Explanation}
+                      onUpdate={this.updateExplanation}
+                      onError={this.props.onError}
+                      required={this.props.required}
+                      />
+          </Field>
+        </Show>
 
         <CoOwners prefix={prefix}
                   {...this.props.CoOwners}

--- a/src/components/Section/Foreign/Activities/IndirectActivity/IndirectInterest.jsx
+++ b/src/components/Section/Foreign/Activities/IndirectActivity/IndirectInterest.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { i18n } from '../../../../../config'
-import { ValidationElement, Currency, Field, Text, DateControl, Textarea, NotApplicable, Checkbox, CheckboxGroup } from '../../../../Form'
+import { ValidationElement, Currency, Field, Text, DateControl, Textarea,
+         NotApplicable, Checkbox, CheckboxGroup, Show } from '../../../../Form'
 import CoOwners from '../CoOwners'
 
 export default class IndirectInterest extends ValidationElement {
@@ -128,7 +129,8 @@ export default class IndirectInterest extends ValidationElement {
 
   updateSoldNotApplicable (values) {
     this.update({
-      SoldNotApplicable: values
+      SoldNotApplicable: values,
+      Explanation: values.applicable ? this.props.Explanation : {}
     })
   }
 
@@ -320,16 +322,18 @@ export default class IndirectInterest extends ValidationElement {
           </NotApplicable>
         </Field>
 
-        <Field title={i18n.t(`foreign.activities.indirect.interest.heading.explanation`)}
-               scrollIntoView={this.props.scrollIntoView}>
-          <Textarea name="Explanation"
-                    className="explanation"
-                    {...this.props.Explanation}
-                    onUpdate={this.updateExplanation}
-                    onError={this.props.onError}
-                    required={this.props.required}
-                    />
-        </Field>
+        <Show when={(this.props.SoldNotApplicable || {}).applicable}>
+          <Field title={i18n.t(`foreign.activities.indirect.interest.heading.explanation`)}
+                 scrollIntoView={this.props.scrollIntoView}>
+            <Textarea name="Explanation"
+                      className="explanation"
+                      {...this.props.Explanation}
+                      onUpdate={this.updateExplanation}
+                      onError={this.props.onError}
+                      required={this.props.required}
+                      />
+          </Field>
+        </Show>
 
         <CoOwners prefix={prefix}
                   {...this.props.CoOwners}

--- a/src/validators/foreigndirectinterest.js
+++ b/src/validators/foreigndirectinterest.js
@@ -50,7 +50,9 @@ export default class ForeignDirectInterestValidator {
   }
 
   validExplanation () {
-    return validGenericTextfield(this.explanation)
+    return validNotApplicable(this.relinquishedNotApplicable, () => {
+      return validGenericTextfield(this.explanation)
+    })
   }
 
   isValid () {

--- a/src/validators/foreignindirectinterest.js
+++ b/src/validators/foreignindirectinterest.js
@@ -65,7 +65,9 @@ export default class ForeignIndirectInterestValidator {
   }
 
   validExplanation () {
-    return validGenericTextfield(this.explanation)
+    return validNotApplicable(this.soldNotApplicable, () => {
+      return validGenericTextfield(this.explanation)
+    })
   }
 
   isValid () {


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#1718

Toggle the display/requirement of the explanation block based on
whether the item had been sold or relenquished.