### PR TITLE
Disable saving data if the form is locked

### DIFF
--- a/api/model/form/application.go
+++ b/api/model/form/application.go
@@ -554,7 +554,7 @@ var (
 		},
 		sectionInformation{
 			name:       "Submission",
-			subsection: "Submit",
+			subsection: "Releases",
 			payload:    "submission.releases",
 			hashable:   false,
 		},

--- a/src/components/SavedIndicator/SavedIndicator.jsx
+++ b/src/components/SavedIndicator/SavedIndicator.jsx
@@ -4,6 +4,7 @@ import { i18n } from '../../config'
 import AuthenticatedView from '../../views/AuthenticatedView'
 import { Show } from '../Form'
 import { saveSection } from '../../middleware/history'
+import { formIsLocked } from '../../validators'
 
 class SavedIndicator extends React.Component {
   constructor (props) {
@@ -113,7 +114,7 @@ class SavedIndicator extends React.Component {
   }
 
   allowed () {
-    return !this.isRoute('form/package/print')
+    return !formIsLocked(this.props.app) && !this.isRoute('form/package/print')
   }
 
   isRoute(route) {

--- a/src/components/Section/Package/Package.jsx
+++ b/src/components/Section/Package/Package.jsx
@@ -38,20 +38,19 @@ class Package extends SectionElement {
     const payload = schema(`package.submit`, data, false)
 
     axios
-      .all([api.save(payload), api.submit(), api.status()])
-      .then(axios.spread((save, submit,  status) => {
-        const statusData = ((status || {}).data || {})
+      .all([api.save(payload), api.submit()])
+      .then(() => {
+        return api.status()
+      })
+      .then(response => {
+        const statusData = ((response || {}).data || {})
         this.props.dispatch(updateApplication('Settings', 'locked', statusData.Locked || false))
         this.props.dispatch(updateApplication('Settings', 'hash', statusData.Hash || false))
         this.props.update({ section: 'package', subsection: 'print' })
         this.handleUpdate('Releases', releases)
-      }))
+      })
       .catch(() => {
         console.warn('Failed to form package')
-        data = {
-          ...data,
-          Locked: false
-        }
         this.handleUpdate('Releases', data)
       })
   }

--- a/src/validators/releases.js
+++ b/src/validators/releases.js
@@ -45,5 +45,5 @@ export const formIsSigned = (store = {}) => {
 
 export const formIsLocked = (store = {}) => {
   const settings = store.Settings || {}
-  return settings.Locked && formIsSigned(store)
+  return settings.locked
 }


### PR DESCRIPTION
The user should not have the ability to click on "Save" if the form is currently locked.