### PR TITLE
Updated aria-labels for section navigation buttons

### DIFF
--- a/src/components/Section/SectionView.jsx
+++ b/src/components/Section/SectionView.jsx
@@ -16,7 +16,7 @@ export class SectionViews extends React.Component {
       if (currentSection === child.props.name) {
         let previousButton = <div className="btn-cell"></div>
         if (child.props.back) {
-          const backtalk = `Back to ${child.props.backLabel}`
+          const backtalk = `Go to previous section ${child.props.backLabel}`
           previousButton = (
             <button className="btn-cell back" title={backtalk} aria-label={backtalk} onClick={this.handleTransition.bind(this, child.props.back)}>
               <div className="actions back">
@@ -34,7 +34,7 @@ export class SectionViews extends React.Component {
 
         let nextButton = <div className="btn-cell"></div>
         if (child.props.next) {
-          const nexttalk = `Next to ${child.props.nextLabel}`
+          const nexttalk = `Go to next section ${child.props.nextLabel}`
           nextButton = (
             <button className="btn-cell next" title={nexttalk} aria-label={nexttalk} onClick={this.handleTransition.bind(this, child.props.next)}>
               <div className="actions next">


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2749

This updates the text to read

> Go to {next or previous} section {section name}