### PR TITLE
Accordion accessibility updates

### DIFF
--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -332,15 +332,15 @@ export default class Accordion extends ValidationElement {
     return (
       <div className="summary-container">
         <div className="summary">
-          <a href="javascript:;;;" className={`left ${openState(item, initial)}`} onClick={this.toggle.bind(this, item)}>
-            <span className="button-with-icon">
+          <a href="javascript:;;;" className={`left ${openState(item, initial)}`} title={`Click to ${this.openText(item).toLowerCase()} this item`} onClick={this.toggle.bind(this, item)}>
+            <span className="button-with-icon" aria-hidden="true">
               <i className={chevron(item)} aria-hidden="true"></i>
               <span className="toggle">{this.openText(item)}</span>
             </span>
             {svg}
             {this.props.summary(item, index, initial)}
           </a>
-          <a href="javascript:;;;" className="right remove" onClick={this.remove.bind(this, item)}>
+          <a href="javascript:;;;" className="right remove" aria-label="Remove this item" title="Remove this item" onClick={this.remove.bind(this, item)}>
             <span className="button-with-icon">
               <i className="fa fa-trash" aria-hidden="true"></i>
               <span>{this.props.removeLabel}</span>
@@ -361,9 +361,6 @@ export default class Accordion extends ValidationElement {
     return (
       <div className={`details ${openState(item, initial)}`}>
         {this.factory(item, index, this.props.children)}
-        <a href="javascript:;;;" className="close" onClick={this.toggle.bind(this, item)}>
-          <span>{this.props.closeLabel}</span>
-        </a>
       </div>
     )
   }
@@ -374,7 +371,7 @@ export default class Accordion extends ValidationElement {
   }
 
   /**
-   * Render the indivual items in the array.
+   * Render the individual items in the array.
    */
   content () {
     // Ensure we have the minimum amount of items required

--- a/src/components/Form/Accordion/Accordion.jsx
+++ b/src/components/Form/Accordion/Accordion.jsx
@@ -446,6 +446,15 @@ export default class Accordion extends ValidationElement {
     )
   }
 
+  description () {
+    const ariaOnly = this.props.items.length < 2
+    return (
+      <strong className={ariaOnly ? 'aria-description' : ''}>
+        {this.props.description}
+      </strong>
+    )
+  }
+
   /**
    * Render the accordion caption which is essentially a `table-caption`
    * for the accordion
@@ -469,14 +478,12 @@ export default class Accordion extends ValidationElement {
 
   render () {
     const klass = `accordion ${this.props.className}`.trim()
-    const description = this.props.items.length < 2 ? '' : this.props.description
 
     return (
       <div ref="accordion">
         <div className={klass}>
-          <strong>{description}</strong>
+          {this.description()}
           {this.caption()}
-
           <div className="items">
             {this.content()}
           </div>
@@ -484,7 +491,6 @@ export default class Accordion extends ValidationElement {
             {this.appendButton()}
           </div>
         </div>
-
         {this.addendum()}
       </div>
     )

--- a/src/components/Form/Accordion/Accordion.scss
+++ b/src/components/Form/Accordion/Accordion.scss
@@ -78,6 +78,12 @@ $breakpoints: (
     line-height: 5rem;
     min-height: 5rem;
     padding: 0 10%;
+
+    /* For screen readers we want the text to be "navigatable"
+       but for non-screenreaders do not display it */
+    &.aria-description {
+      opacity: 0;
+    }
   }
 
   .items {

--- a/src/components/Form/Accordion/Accordion.test.jsx
+++ b/src/components/Form/Accordion/Accordion.test.jsx
@@ -381,4 +381,21 @@ describe('The accordion component', () => {
     expect(items.length).toEqual(1)
     expect(items.every(x => { return x.open })).toBe(true)
   })
+
+  it('aria summary is present when no description is visually rendered', () => {
+    let items = [
+      { uuid: '1' },
+    ]
+
+    const expected = {
+      items: items,
+      summary: (item, index) => {
+        return (<div className="table">Item {index}</div>)
+      },
+      onUpdate: (x) => { items = x.items }
+    }
+    const component = mount(<Accordion {...expected}><div className="hello">hello</div></Accordion>)
+    expect(items.length).toEqual(1)
+    expect(component.find('.aria-description').length).toBe(1)
+  })
 })

--- a/src/components/Section/History/summaries.jsx
+++ b/src/components/Section/History/summaries.jsx
@@ -19,8 +19,8 @@ export const CustomSummary = (validation, summary, more, item, index, initial, c
     <div className="summary-container">
       <div className="summary">
         <span className={`left ${openState(item, initial)}`}>
-          <a href="javascript:;;;" onClick={toggle()}>
-            <span className="button-with-icon">
+          <a href="javascript:;;;" onClick={toggle()} title={`Click to ${openText().toLowerCase()} this item`}>
+            <span className="button-with-icon" aria-hidden="true">
               <i className={chevron(item)} aria-hidden="true"></i>
               <span className="toggle">{openText()}</span>
             </span>
@@ -28,7 +28,7 @@ export const CustomSummary = (validation, summary, more, item, index, initial, c
           </a>
           {more(target, errors)}
         </span>
-        <a href="javascript:;;;" className="right remove" onClick={remove()}>
+        <a href="javascript:;;;" className="right remove" onClick={remove()} title="Remove this item">
           <span className="button-with-icon">
             <i className="fa fa-trash" aria-hidden="true"></i>
             <span>{i18n.t('collection.remove')}</span>


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2747

For accessibility:
 - Summaries are visible to screen readers to provide more context
 - Rearranged wording on "toggle" link
 - Applied `aria-label` to remove button

Resolves truetandem/e-QIP-prototype#2752

Removed bottom "close" hyperlink