### PR TITLE
Switch number placeholders from zeroes to pound symbols

### DIFF
--- a/src/components/Form/Currency/Currency.jsx
+++ b/src/components/Form/Currency/Currency.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { i18n } from '../../../config'
 import Number from '../Number'
 
 /**
@@ -37,6 +38,7 @@ export default class Currency extends React.Component {
 
 Currency.defaultProps = {
   name: 'currency',
+  placeholder: i18n.t('currency.placeholder'),
   disabled: false,
   value: '',
   min: '1',

--- a/src/components/Form/DateControl/DateControl.jsx
+++ b/src/components/Form/DateControl/DateControl.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { i18n } from '../../../config'
 import ValidationElement from '../ValidationElement'
 import Number from '../Number'
 import Checkbox from '../Checkbox'
@@ -316,7 +317,7 @@ export default class DateControl extends ValidationElement {
                     name="month"
                     ref="month"
                     label="Month"
-                    placeholder="00"
+                    placeholder={i18n.t('date.placeholder.day')}
                     disabled={this.state.disabled}
                     max="12"
                     maxlength="2"
@@ -338,7 +339,7 @@ export default class DateControl extends ValidationElement {
                     name="day"
                     ref="day"
                     label="Day"
-                    placeholder="00"
+                    placeholder={i18n.t('date.placeholder.day')}
                     disabled={this.state.disabled}
                     max={daysInMonth(this.state.month, this.state.year)}
                     maxlength="2"
@@ -361,7 +362,7 @@ export default class DateControl extends ValidationElement {
                     name="year"
                     ref="year"
                     label="Year"
-                    placeholder="0000"
+                    placeholder={i18n.t('date.placeholder.year')}
                     disabled={this.state.disabled}
                     min="1000"
                     max={this.props.maxDate && this.props.maxDate.getFullYear()}

--- a/src/components/Form/SSN/SSN.jsx
+++ b/src/components/Form/SSN/SSN.jsx
@@ -87,7 +87,7 @@ export default class SSN extends ValidationElement {
             valid: true
           }])
         })
-      return
+      return []
     }
     return this.handleError('notApplicable', value, arr)
   }

--- a/src/components/Form/Telephone/Telephone.jsx
+++ b/src/components/Form/Telephone/Telephone.jsx
@@ -365,7 +365,7 @@ export default class Telephone extends ValidationElement {
         <Text name="dsn_first"
               ref="dsn_first"
               className="number three"
-              placeholder="000"
+              placeholder={i18n.t('telephone.placeholder.three')}
               pattern="\d{3}"
               prefilter={digitsOnly}
               label=""
@@ -384,7 +384,7 @@ export default class Telephone extends ValidationElement {
         <Text name="dsn_second"
               ref="dsn_second"
               className="number four"
-              placeholder="0000"
+              placeholder={i18n.t('telephone.placeholder.four')}
               pattern="\d{4}"
               prefilter={digitsOnly}
               label=""
@@ -424,7 +424,7 @@ export default class Telephone extends ValidationElement {
         <Text name="domestic_first"
               ref="domestic_first"
               className="number three"
-              placeholder="000"
+              placeholder={i18n.t('telephone.placeholder.three')}
               label=""
               ariaLabel={i18n.t('telephone.aria.domesticAreaCode')}
               disabled={this.props.noNumber}
@@ -441,7 +441,7 @@ export default class Telephone extends ValidationElement {
         <Text name="domestic_second"
               ref="domestic_second"
               className="number three"
-              placeholder="000"
+              placeholder={i18n.t('telephone.placeholder.three')}
               label=""
               ariaLabel={i18n.t('telephone.aria.domesticThree')}
               disabled={this.props.noNumber}
@@ -459,7 +459,7 @@ export default class Telephone extends ValidationElement {
         <Text name="domestic_third"
               ref="domestic_third"
               className="number four"
-              placeholder="0000"
+              placeholder={i18n.t('telephone.placeholder.four')}
               label=""
               ariaLabel={i18n.t('telephone.aria.domesticFour')}
               disabled={this.props.noNumber}
@@ -478,7 +478,7 @@ export default class Telephone extends ValidationElement {
         <Text name="domestic_extension"
               ref="domestic_extension"
               className="number six"
-              placeholder="000000"
+              placeholder={i18n.t('telephone.placeholder.six')}
               label={i18n.t('telephone.domestic.extension.label')}
               ariaLabel={i18n.t('telephone.aria.extension')}
               disabled={this.props.noNumber}
@@ -515,7 +515,7 @@ export default class Telephone extends ValidationElement {
         <Text name="int_first"
               ref="int_first"
               className="number three"
-              placeholder="000"
+              placeholder={i18n.t('telephone.placeholder.three')}
               label=""
               ariaLabel={i18n.t('telephone.aria.countryCode')}
               disabled={this.props.noNumber}
@@ -532,7 +532,7 @@ export default class Telephone extends ValidationElement {
         <Text name="int_second"
               ref="int_second"
               className="number ten"
-              placeholder="0000000000"
+              placeholder={i18n.t('telephone.placeholder.ten')}
               label=""
               ariaLabel={i18n.t('telephone.aria.phoneNumber')}
               disabled={this.props.noNumber}
@@ -550,7 +550,7 @@ export default class Telephone extends ValidationElement {
         <Text name="int_extension"
               ref="int_extension"
               className="number six"
-              placeholder="000000"
+              placeholder={i18n.t('telephone.placeholder.six')}
               label={i18n.t('telephone.international.extension.label')}
               ariaLabel={i18n.t('telephone.aria.extension')}
               disabled={this.props.noNumber}

--- a/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
+++ b/src/components/Section/Financial/Bankruptcy/Bankruptcy.jsx
@@ -215,7 +215,6 @@ export default class Bankruptcy extends ValidationElement {
                     {...this.props.TotalAmount}
                     className="amount"
                     min="1"
-                    placeholder={i18n.t('financial.bankruptcy.totalAmount.placeholder')}
                     required={this.props.required}
                     />
           <div className="flags">

--- a/src/components/Section/Financial/Card/CardItem.jsx
+++ b/src/components/Section/Financial/Card/CardItem.jsx
@@ -134,7 +134,6 @@ export default class CardItem extends ValidationElement {
             <Currency name="Amount"
                       {...this.props.Amount}
                       className="card-amount"
-                      placeholder={i18n.t('financial.card.placeholder.amount')}
                       min="1"
                       required={this.props.required}
                       onUpdate={this.updateAmount}

--- a/src/components/Section/Financial/Delinquent/DelinquentItem.jsx
+++ b/src/components/Section/Financial/Delinquent/DelinquentItem.jsx
@@ -184,7 +184,6 @@ export default class DelinquentItem extends ValidationElement {
                       onUpdate={this.updateAmount}
                       onError={this.props.onError}
                       className="delinquent-amount"
-                      placeholder={i18n.t('financial.delinquent.placeholder.amount')}
                       min="1"
                       required={this.props.required}
                       />

--- a/src/components/Section/Financial/Gambling/GamblingItem.jsx
+++ b/src/components/Section/Financial/Gambling/GamblingItem.jsx
@@ -67,7 +67,6 @@ export default class GamblingItem extends ValidationElement {
           <Currency name="Losses"
                     {...this.props.Losses}
                     className="losses"
-                    placeholder={i18n.t('financial.gambling.placeholder.losses')}
                     min="1"
                     onUpdate={this.updateLosses}
                     onError={this.props.onError}

--- a/src/components/Section/Financial/Nonpayment/NonpaymentItem.jsx
+++ b/src/components/Section/Financial/Nonpayment/NonpaymentItem.jsx
@@ -168,7 +168,6 @@ export default class NonpaymentItem extends ValidationElement {
                       onUpdate={this.updateAmount}
                       onError={this.props.onError}
                       className="nonpayment-amount"
-                      placeholder={i18n.t('financial.nonpayment.placeholder.amount')}
                       min="1"
                       required={this.props.required}
                       />

--- a/src/components/Section/Financial/Taxes/TaxesItem.jsx
+++ b/src/components/Section/Financial/Taxes/TaxesItem.jsx
@@ -127,7 +127,7 @@ export default class TaxesItem extends ValidationElement {
           <Number name="Year"
                   {...this.props.Year}
                   className="taxes-year"
-                  placeholder={i18n.t('financial.taxes.placeholder.year')}
+                  placeholder={i18n.t('date.placeholder.year')}
                   prefix="date"
                   min={minYearFiled.minDate.getFullYear()}
                   required={this.props.required}

--- a/src/config/locales/en/currency.js
+++ b/src/config/locales/en/currency.js
@@ -1,0 +1,3 @@
+export const currency = {
+  placeholder: '#'
+}

--- a/src/config/locales/en/date.js
+++ b/src/config/locales/en/date.js
@@ -1,0 +1,7 @@
+export const date = {
+  placeholder: {
+    month: '##',
+    day: '##',
+    year: '####'
+  }
+}

--- a/src/config/locales/en/financial.js
+++ b/src/config/locales/en/financial.js
@@ -81,9 +81,6 @@ export const financial = {
         message: 'If you need to provide any additional comments about this information enter them below',
         note: ''
       }
-    },
-    placeholder: {
-      losses: '0'
     }
   },
   bankruptcy: {
@@ -161,7 +158,6 @@ export const financial = {
     },
     totalAmount: {
       label: 'Amount',
-      placeholder: '0',
       help: {
         title: 'Need help with the total amount?',
         message: 'Provide the total amount (in U.S. dollars) involved in the bankruptcy',
@@ -232,8 +228,7 @@ export const financial = {
       or: 'or'
     },
     placeholder: {
-      year: '0000',
-      amount: '0'
+      year: '0000'
     },
     help: {
       branch: {
@@ -548,9 +543,6 @@ export const financial = {
     label: {
       notresolved: 'Not resolved',
       estimated: 'Estimated'
-    },
-    placeholder: {
-      amount: '0'
     },
     help: {
       branch: {

--- a/src/config/locales/en/financial.js
+++ b/src/config/locales/en/financial.js
@@ -227,9 +227,6 @@ export const financial = {
     para: {
       or: 'or'
     },
-    placeholder: {
-      year: '0000'
-    },
     help: {
       branch: {
         title: 'Need help with the type of tax failure?',
@@ -299,9 +296,6 @@ export const financial = {
     },
     label: {
       estimated: 'Estimated'
-    },
-    placeholder: {
-      amount: '0'
     },
     help: {
       branch: {
@@ -433,9 +427,6 @@ export const financial = {
     label: {
       notresolved: 'Not resolved',
       estimated: 'Estimated'
-    },
-    placeholder: {
-      amount: '0'
     },
     help: {
       branch: {

--- a/src/config/locales/en/identification.js
+++ b/src/config/locales/en/identification.js
@@ -217,9 +217,9 @@ export const identification = {
       verify: 'Please verify your social security number'
     },
     placeholder: {
-      last: '0000',
-      middle: '00',
-      first: '000'
+      last: '####',
+      middle: '##',
+      first: '###'
     }
   },
   traits: {
@@ -281,9 +281,9 @@ export const identification = {
       comments: 'Add a comment about sex'
     },
     placeholder: {
-      feet: '0',
-      inches: '0',
-      pounds: '0'
+      feet: '#',
+      inches: '##',
+      pounds: '###'
     },
     hair: {
       bald: 'Bald',

--- a/src/config/locales/en/index.js
+++ b/src/config/locales/en/index.js
@@ -8,6 +8,8 @@ import { comments } from './comments'
 import { consent } from './consent'
 import { countries } from './countries'
 import { country } from './country'
+import { currency } from './currency'
+import { date } from './date'
 import { error } from './error'
 import { financial } from './financial'
 import { foreign } from './foreign'
@@ -60,6 +62,8 @@ const en = {
   collection,
   comments,
   country,
+  currency,
+  date,
   foreignBornDocuments,
   name,
   reference,

--- a/src/config/locales/en/telephone.js
+++ b/src/config/locales/en/telephone.js
@@ -34,6 +34,12 @@ export const telephone = {
     work: 'Work',
     other: 'Other'
   },
+  placeholder: {
+    three: '###',
+    four: '####',
+    six: '######',
+    ten: '##########'
+  },
   aria: {
     domestic: 'Switch to United States number',
     dsn: 'Switch to DSN number',

--- a/src/validators/foreigntravel.js
+++ b/src/validators/foreigntravel.js
@@ -35,8 +35,8 @@ export class TravelValidator {
   constructor (data = {}) {
     this.dates = data.Dates
     this.country = data.Country
-    this.days = data.Days || []
-    this.purpose = data.Purpose || []
+    this.days = (data.Days || {}).values || []
+    this.purpose = (data.Purpose || {}).values || []
     this.questioned = (data.Questioned || {}).value
     this.questionedExplanation = data.QuestionedExplanation
     this.encounter = (data.Encounter || {}).value
@@ -63,12 +63,12 @@ export class TravelValidator {
 
   validDays () {
     const options = ['1-5', '6-10', '11-20', '21-30', 'More than 30', 'Many short trips']
-    return !!this.days && this.days.values && this.days.values.length > 0 && this.days.values.every(x => options.includes(x))
+    return !!this.days && this.days.length > 0 && this.days.every(x => options.includes(x))
   }
 
   validPurpose () {
     const options = ['Business', 'Volunteer', 'Education', 'Tourism', 'Conference', 'Family', 'Other']
-    return !!this.purpose && this.purpose.values && this.purpose.values.length > 0 && this.purpose.values.every(x => options.includes(x))
+    return !!this.purpose && this.purpose.length > 0 && this.purpose.every(x => options.includes(x))
   }
 
   validQuestioned () {

--- a/src/validators/foreigntravel.test.js
+++ b/src/validators/foreigntravel.test.js
@@ -60,19 +60,19 @@ describe('Foreign travel component validation', function () {
     const tests = [
       {
         state: {
-          Days: []
+          Days: { values: [] }
         },
         expected: false
       },
       {
         state: {
-          Days: ['00000']
+          Days: { values: ['00000'] }
         },
         expected: false
       },
       {
         state: {
-          Days: ['1-5', '21-30']
+          Days: { values: ['1-5', '21-30'] }
         },
         expected: true
       }
@@ -85,19 +85,19 @@ describe('Foreign travel component validation', function () {
     const tests = [
       {
         state: {
-          Purpose: []
+          Purpose: { values: [] }
         },
         expected: false
       },
       {
         state: {
-          Purpose: ['Nothing']
+          Purpose: { values: ['Nothing'] }
         },
         expected: false
       },
       {
         state: {
-          Purpose: ['Business', 'Family']
+          Purpose: { values: ['Business', 'Family'] }
         },
         expected: true
       }
@@ -427,8 +427,8 @@ describe('Foreign travel component validation', function () {
                     },
                     present: false
                   },
-                  Days: ['1-5', '21-30'],
-                  Purpose: ['Business', 'Family'],
+                  Days: { values: ['1-5', '21-30'] },
+                  Purpose: { values: ['Business', 'Family'] },
                   Questioned: { value: 'No' },
                   Encounter: { value: 'No' },
                   Contacted: { value: 'No' },


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2829

This came from accessibility testing. With the placeholders being
zeroes originally this led to confusion when using a screen reader
where it could be assumed this was pre-filled content.

## Telephone
![image](https://user-images.githubusercontent.com/697855/38378457-c383ad68-38cb-11e8-84ef-695ec30d8024.png)

## SSN

![image](https://user-images.githubusercontent.com/697855/38378435-b048fb22-38cb-11e8-8bb5-0efff99780d8.png)

## Dates

![image](https://user-images.githubusercontent.com/697855/38378443-b70c8f82-38cb-11e8-9cdb-589a1c7b3569.png)

## Currency

![image](https://user-images.githubusercontent.com/697855/38378427-a8934c66-38cb-11e8-9395-7841aad52d90.png)
