### PR TITLE
Adding JWT init to manifest of cloudgov

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -234,7 +234,7 @@ United States Postal Service (USPS) API key for address validation.
 
 ## `JWT_SECRET`
 
-The HS512 algorithm is used to sign each JavaScript Web Token using a secret random key of at least 512-bits. For example, `openssl rand 64 | base64 --wrap=0` generates an appropriate key. If this value is not specified, one will be automatically generated unique to the instance.
+The HS256 algorithm is used to sign each JavaScript Web Token using a secret random key of at least 256-bits. For example, `openssl rand -base64 32` generates an appropriate key. If this value is not specified, one will be automatically generated unique to the instance.
 
 **Target** - Back-end (api)<br>
 **Default** - *none*<br>

--- a/bin/deploy-cloudgov
+++ b/bin/deploy-cloudgov
@@ -35,6 +35,9 @@ else
 		exit
 fi
 
+# Add the JWT_SECRET to the manifest
+echo "    JWT_SECRET: $(openssl rand -base64 32)" >> $API_MANIFEST
+
 # This directory is used to persist the CF credentials
 mkdir -p $HOME/.cf
 


### PR DESCRIPTION
Resolves truetandem/e-QIP-prototype#2861

Trying to see if adding the `JWT_SECRET` to the manifest prior deploying helps w/ cloud.gov deployments.